### PR TITLE
docs: link the hosted Neon wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # MTA:SA Neon Engine
 
 [![Join the MTA:SA Neon Discord](https://img.shields.io/badge/Discord-Join%20MTA%3ASA%20Neon-5865F2?logo=discord&logoColor=white)](https://discord.com/invite/mgFRd2AzF8)
+[![Read the MTA:SA Neon Wiki](https://img.shields.io/badge/Documentation-Read%20the%20Neon%20Wiki-F28C18?logo=readthedocs&logoColor=white)](https://mtasa-neon-wiki.vercel.app)
 
 MTA:SA Neon is an experimental fork of [Multi Theft Auto: San Andreas](https://github.com/multitheftauto/mtasa-blue), focused on prototyping advanced engine features and exploring changes that may be too early or too specialized for the upstream project.
 


### PR DESCRIPTION
## What changed

- adds a warm-orange Documentation badge beside the Discord badge at the top of the README
- links directly to the verified Vercel production deployment

## Why this placement

The top badge row is the natural entry point for new visitors looking for project documentation or community links. It keeps the main introduction focused while making the full Neon reference immediately discoverable.

## Verification

- `https://mtasa-neon-wiki.vercel.app` returns HTTP 200
- the shields.io badge returns HTTP 200
- Markdown diff and whitespace checks pass

The change was prepared in an isolated worktree so the unrelated local Native World and gang-tag work in the canonical checkout remains untouched.
