### PR TITLE
fix(menu): initialize V-Sync checkbox from cvar

### DIFF
--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -2496,6 +2496,11 @@ void CSettings::UpdateVideoTab()
     GetVideoModeManager()->GetNextVideoMode(iNextVidMode, bNextWindowed, bNextFSMinimize, iNextFullscreenStyle);
 
     m_pCheckBoxMipMapping->SetSelected(gameSettings->IsMipMappingEnabled());
+
+    bool bVSync = true;
+    CVARS_GET("vsync", bVSync);
+    m_pCheckBoxVSync->SetSelected(bVSync);
+
     m_pCheckBoxWindowed->SetSelected(bNextWindowed);
     m_pCheckBoxMinimize->SetSelected(bNextFSMinimize);
     m_pDrawDistance->SetScrollPosition((gameSettings->GetDrawDistance() - 0.925f) / 0.8749f);


### PR DESCRIPTION
#### Summary
<!-- What change are you making? -->
<!-- When changing Lua APIs, consider including code samples and documentation. -->
Porting from https://github.com/multitheftauto/mtasa-blue/commit/c983fbbbb8a2c828dfbea7df3c02bba8969f9922. In CSettings::UpdateVideoTab (Client/core/CSettings.cpp) read the 'vsync' cvar (defaulting to true) and set m_pCheckBoxVSync accordingly. Ensures the V-Sync checkbox reflects the current runtime setting when the video tab is updated.

#### Motivation
<!-- Why are you making this change? Which GitHub issue does this resolve, if any? Any additional context? -->
Fixes the settings menu showing V-Sync as ticked instead of unticked even though I disabled it (I double-checked \MTA\config\coreconfig.xml).

#### Test plan
<!-- How have you tested this change? This should give confidence to the reviewer that your change is safe. -->
<!-- If someone makes changes to this code in the future, what steps can they follow to check that it's still working correctly? -->
1. Use a current Nightly, make sure vsync is set to 0 for false, open the game, see V-Sync is checked instead of unchecked.
2. Build with this edit, see V-Sync is now unchecked when set to 0 for false and checked when set to 1 for true.

#### Checklist
* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.