### PR TITLE
Expose native GTA radio playback state to Lua

### DIFF
--- a/Client/game_sa/CAERadioTrackManagerSA.cpp
+++ b/Client/game_sa/CAERadioTrackManagerSA.cpp
@@ -14,6 +14,9 @@
 
 namespace
 {
+    constexpr int         INVALID_TRACK_ID = -1;
+    constexpr signed char TRACK_TYPE_NONE = 6;
+
     int GetHardwareInt(DWORD function)
     {
         int value = -1;
@@ -34,6 +37,59 @@ namespace
             mov ecx, CLASS_CAEAudioHardware
             call function
         }
+    }
+
+    void ClearQueueEntry(SRadioPlaybackState& state, unsigned int index)
+    {
+        state.trackQueue[index] = INVALID_TRACK_ID;
+        state.trackTypes[index] = TRACK_TYPE_NONE;
+        state.trackIndexes[index] = -1;
+    }
+
+    void CanonicalisePlaybackQueue(SRadioPlaybackState& state, bool forcePrepend = false)
+    {
+        if (state.currentTrackId < 0)
+            return;
+
+        int currentIndex = -1;
+        if (!forcePrepend)
+        {
+            for (unsigned int i = 0; i < SRadioPlaybackState::QUEUE_SIZE; ++i)
+            {
+                if (state.trackQueue[i] == state.currentTrackId)
+                {
+                    currentIndex = static_cast<int>(i);
+                    break;
+                }
+            }
+        }
+
+        if (currentIndex > 0)
+        {
+            const unsigned int shift = static_cast<unsigned int>(currentIndex);
+            const unsigned int remaining = SRadioPlaybackState::QUEUE_SIZE - shift;
+            for (unsigned int i = 0; i < remaining; ++i)
+            {
+                state.trackQueue[i] = state.trackQueue[i + shift];
+                state.trackTypes[i] = state.trackTypes[i + shift];
+                state.trackIndexes[i] = state.trackIndexes[i + shift];
+            }
+            for (unsigned int i = remaining; i < SRadioPlaybackState::QUEUE_SIZE; ++i)
+                ClearQueueEntry(state, i);
+        }
+        else if (currentIndex < 0)
+        {
+            for (unsigned int i = SRadioPlaybackState::QUEUE_SIZE - 1; i > 0; --i)
+            {
+                state.trackQueue[i] = state.trackQueue[i - 1];
+                state.trackTypes[i] = state.trackTypes[i - 1];
+                state.trackIndexes[i] = state.trackIndexes[i - 1];
+            }
+        }
+
+        state.trackQueue[0] = state.currentTrackId;
+        state.trackTypes[0] = static_cast<signed char>(state.currentTrackType);
+        state.trackIndexes[0] = static_cast<signed char>(state.currentTrackIndex);
     }
 }
 
@@ -164,9 +220,10 @@ bool CAERadioTrackManagerSA::GetPlaybackState(SRadioPlaybackState& state) const
                     trackInterface->stationsListDown;
     state.stationId = settings.currentRadioStation;
     state.mode = static_cast<int>(trackInterface->trackMode);
-    state.currentTrackId = GetHardwareInt(FUNC_CAEAudioHardware_GetPlayingTrackID);
-    state.currentTrackType = settings.currentTrackType;
-    state.currentTrackIndex = settings.currentTrackIndex;
+
+    const int playingTrackId = GetHardwareInt(FUNC_CAEAudioHardware_GetPlayingTrackID);
+    const int activeTrackId = GetHardwareInt(FUNC_CAEAudioHardware_GetActiveTrackID);
+    state.currentTrackId = playingTrackId >= 0 ? playingTrackId : activeTrackId;
     state.playTimeMs = GetHardwareInt(FUNC_CAEAudioHardware_GetTrackPlayTime);
     state.trackLengthMs = GetHardwareInt(FUNC_CAEAudioHardware_GetTrackLengthMs);
     state.trackFlags = settings.trackFlags;
@@ -176,6 +233,39 @@ bool CAERadioTrackManagerSA::GetPlaybackState(SRadioPlaybackState& state) const
         state.trackQueue[i] = settings.trackQueue[i];
         state.trackTypes[i] = static_cast<signed char>(settings.trackTypes[i]);
         state.trackIndexes[i] = settings.trackIndexes[i];
+    }
+
+    state.currentTrackType = settings.currentTrackType;
+    state.currentTrackIndex = settings.currentTrackIndex;
+
+    bool currentIsPrevious = false;
+    if (state.currentTrackId >= 0)
+    {
+        int matchingQueueIndex = -1;
+        for (unsigned int i = 0; i < SRadioPlaybackState::QUEUE_SIZE; ++i)
+        {
+            if (state.trackQueue[i] == state.currentTrackId)
+            {
+                matchingQueueIndex = static_cast<int>(i);
+                break;
+            }
+        }
+
+        if (matchingQueueIndex >= 0)
+        {
+            state.currentTrackType = state.trackTypes[matchingQueueIndex];
+            state.currentTrackIndex = state.trackIndexes[matchingQueueIndex];
+        }
+        else if (settings.prevTrackId == state.currentTrackId)
+        {
+            state.currentTrackType = settings.prevTrackType;
+            state.currentTrackIndex = settings.prevTrackIndex;
+            currentIsPrevious = true;
+        }
+
+        // The audio thread can switch to queue[1] before the radio manager rotates its queue.
+        // Return a coherent snapshot where queue[0] is always the hardware-current track.
+        CanonicalisePlaybackQueue(state, currentIsPrevious);
     }
 
     return true;
@@ -190,31 +280,27 @@ bool CAERadioTrackManagerSA::SetPlaybackState(const SRadioPlaybackState& state)
     if (!trackInterface)
         return false;
 
+    SRadioPlaybackState normalisedState = state;
+    CanonicalisePlaybackQueue(normalisedState);
+
     auto settings = trackInterface->activeSettings;
-    settings.currentRadioStation = state.stationId;
-    settings.currentTrackId = state.currentTrackId;
+    settings.currentRadioStation = normalisedState.stationId;
+    settings.currentTrackId = normalisedState.currentTrackId;
     settings.prevTrackId = -1;
-    settings.trackPlayTime = state.playTimeMs;
-    settings.trackLengthInMS = state.trackLengthMs;
-    settings.trackFlags = state.trackFlags;
-    settings.currentTrackType = static_cast<std::uint8_t>(state.currentTrackType);
-    settings.currentTrackIndex = static_cast<std::int8_t>(state.currentTrackIndex);
-    settings.prevTrackType = 6;
+    settings.trackPlayTime = normalisedState.playTimeMs;
+    settings.trackLengthInMS = normalisedState.trackLengthMs;
+    settings.trackFlags = normalisedState.trackFlags;
+    settings.currentTrackType = static_cast<std::uint8_t>(normalisedState.currentTrackType);
+    settings.currentTrackIndex = static_cast<std::int8_t>(normalisedState.currentTrackIndex);
+    settings.prevTrackType = TRACK_TYPE_NONE;
     settings.prevTrackIndex = -1;
 
     for (unsigned int i = 0; i < SRadioPlaybackState::QUEUE_SIZE; ++i)
     {
-        settings.trackQueue[i] = state.trackQueue[i];
-        settings.trackTypes[i] = static_cast<std::uint8_t>(state.trackTypes[i]);
-        settings.trackIndexes[i] = state.trackIndexes[i];
+        settings.trackQueue[i] = normalisedState.trackQueue[i];
+        settings.trackTypes[i] = static_cast<std::uint8_t>(normalisedState.trackTypes[i]);
+        settings.trackIndexes[i] = normalisedState.trackIndexes[i];
     }
-
-    // The first queued stream is what RADIO_STARTING passes to CAEAudioHardware::PlayTrack.
-    // Canonicalise it to the supplied current clip so applying a snapshot cannot accidentally
-    // resume the previous queue head during a transition.
-    settings.trackQueue[0] = state.currentTrackId;
-    settings.trackTypes[0] = static_cast<std::uint8_t>(state.currentTrackType);
-    settings.trackIndexes[0] = static_cast<std::int8_t>(state.currentTrackIndex);
 
     // CAEStreamThread keeps the existing decoder when the track id is unchanged. Queueing a
     // stop first makes its next service pass rebuild the decoder and honour the requested seek.

--- a/Client/game_sa/CAERadioTrackManagerSA.cpp
+++ b/Client/game_sa/CAERadioTrackManagerSA.cpp
@@ -302,14 +302,17 @@ bool CAERadioTrackManagerSA::SetPlaybackState(const SRadioPlaybackState& state)
         settings.trackIndexes[i] = normalisedState.trackIndexes[i];
     }
 
-    // CAEStreamThread keeps the existing decoder when the track id is unchanged. Queueing a
-    // stop first makes its next service pass rebuild the decoder and honour the requested seek.
+    // Keep the desired seek in RequestedSettings until GTA enters RADIO_STARTING. Service()
+    // refreshes ActiveSettings.PlayTime from the hardware before processing the radio mode, so
+    // forcing RADIO_STARTING here would overwrite the transported position before PlayTrack().
+    // RADIO_STOPPED + isInitialised follows StartRadio's native hand-off: Service copies
+    // RequestedSettings to ActiveSettings after that refresh, then starts the requested stream.
     StopHardwareTrack();
-
     trackInterface->requestedSettings = settings;
-    trackInterface->activeSettings = settings;
-    trackInterface->trackMode = eRadioTrackMode::RADIO_STARTING;
-    trackInterface->isInitialised = false;
+    trackInterface->trackMode = eRadioTrackMode::RADIO_STOPPED;
+    trackInterface->isInitialised = true;
+    trackInterface->stationsListed = 0;
+    trackInterface->stationsListDown = 0;
     trackInterface->radioStationMenuRequest = -1;
     trackInterface->radioStationScriptRequest = -1;
     return true;

--- a/Client/game_sa/CAERadioTrackManagerSA.cpp
+++ b/Client/game_sa/CAERadioTrackManagerSA.cpp
@@ -12,6 +12,31 @@
 #include "StdInc.h"
 #include "CAERadioTrackManagerSA.h"
 
+namespace
+{
+    int GetHardwareInt(DWORD function)
+    {
+        int value = -1;
+        __asm
+        {
+            mov ecx, CLASS_CAEAudioHardware
+            call function
+            mov value, eax
+        }
+        return value;
+    }
+
+    void StopHardwareTrack()
+    {
+        DWORD function = FUNC_CAEAudioHardware_StopTrack;
+        __asm
+        {
+            mov ecx, CLASS_CAEAudioHardware
+            call function
+        }
+    }
+}
+
 BYTE CAERadioTrackManagerSA::GetCurrentRadioStationID()
 {
     DWORD dwFunc = FUNC_GetCurrentRadioStationID;
@@ -126,4 +151,80 @@ bool CAERadioTrackManagerSA::IsStationLoading() const
 {
     CAERadioTrackManagerSAInterface* trackInterface = GetInterface();
     return (trackInterface->stationsListed || trackInterface->stationsListDown);
+}
+
+bool CAERadioTrackManagerSA::GetPlaybackState(SRadioPlaybackState& state) const
+{
+    const auto* trackInterface = GetInterface();
+    if (!trackInterface)
+        return false;
+
+    const auto& settings = trackInterface->activeSettings;
+    state.radioOn = trackInterface->trackMode != eRadioTrackMode::RADIO_STOPPED || trackInterface->isInitialised || trackInterface->stationsListed ||
+                    trackInterface->stationsListDown;
+    state.stationId = settings.currentRadioStation;
+    state.mode = static_cast<int>(trackInterface->trackMode);
+    state.currentTrackId = GetHardwareInt(FUNC_CAEAudioHardware_GetPlayingTrackID);
+    state.currentTrackType = settings.currentTrackType;
+    state.currentTrackIndex = settings.currentTrackIndex;
+    state.playTimeMs = GetHardwareInt(FUNC_CAEAudioHardware_GetTrackPlayTime);
+    state.trackLengthMs = GetHardwareInt(FUNC_CAEAudioHardware_GetTrackLengthMs);
+    state.trackFlags = settings.trackFlags;
+
+    for (unsigned int i = 0; i < SRadioPlaybackState::QUEUE_SIZE; ++i)
+    {
+        state.trackQueue[i] = settings.trackQueue[i];
+        state.trackTypes[i] = static_cast<signed char>(settings.trackTypes[i]);
+        state.trackIndexes[i] = settings.trackIndexes[i];
+    }
+
+    return true;
+}
+
+bool CAERadioTrackManagerSA::SetPlaybackState(const SRadioPlaybackState& state)
+{
+    if (!state.radioOn || state.stationId >= 13 || state.currentTrackId < 0 || state.playTimeMs < 0)
+        return false;
+
+    auto* trackInterface = GetInterface();
+    if (!trackInterface)
+        return false;
+
+    auto settings = trackInterface->activeSettings;
+    settings.currentRadioStation = state.stationId;
+    settings.currentTrackId = state.currentTrackId;
+    settings.prevTrackId = -1;
+    settings.trackPlayTime = state.playTimeMs;
+    settings.trackLengthInMS = state.trackLengthMs;
+    settings.trackFlags = state.trackFlags;
+    settings.currentTrackType = static_cast<std::uint8_t>(state.currentTrackType);
+    settings.currentTrackIndex = static_cast<std::int8_t>(state.currentTrackIndex);
+    settings.prevTrackType = 6;
+    settings.prevTrackIndex = -1;
+
+    for (unsigned int i = 0; i < SRadioPlaybackState::QUEUE_SIZE; ++i)
+    {
+        settings.trackQueue[i] = state.trackQueue[i];
+        settings.trackTypes[i] = static_cast<std::uint8_t>(state.trackTypes[i]);
+        settings.trackIndexes[i] = state.trackIndexes[i];
+    }
+
+    // The first queued stream is what RADIO_STARTING passes to CAEAudioHardware::PlayTrack.
+    // Canonicalise it to the supplied current clip so applying a snapshot cannot accidentally
+    // resume the previous queue head during a transition.
+    settings.trackQueue[0] = state.currentTrackId;
+    settings.trackTypes[0] = static_cast<std::uint8_t>(state.currentTrackType);
+    settings.trackIndexes[0] = static_cast<std::int8_t>(state.currentTrackIndex);
+
+    // CAEStreamThread keeps the existing decoder when the track id is unchanged. Queueing a
+    // stop first makes its next service pass rebuild the decoder and honour the requested seek.
+    StopHardwareTrack();
+
+    trackInterface->requestedSettings = settings;
+    trackInterface->activeSettings = settings;
+    trackInterface->trackMode = eRadioTrackMode::RADIO_STARTING;
+    trackInterface->isInitialised = false;
+    trackInterface->radioStationMenuRequest = -1;
+    trackInterface->radioStationScriptRequest = -1;
+    return true;
 }

--- a/Client/game_sa/CAERadioTrackManagerSA.h
+++ b/Client/game_sa/CAERadioTrackManagerSA.h
@@ -21,7 +21,15 @@
 #define FUNC_Reset                    0x4E7F80
 #define FUNC_StartRadio               0x4EB3C0
 
+#define FUNC_CAEAudioHardware_PlayTrack          0x4D8F10
+#define FUNC_CAEAudioHardware_StartTrackPlayback 0x4D8F30
+#define FUNC_CAEAudioHardware_StopTrack          0x4D8F50
+#define FUNC_CAEAudioHardware_GetTrackPlayTime   0x4D8F60
+#define FUNC_CAEAudioHardware_GetTrackLengthMs   0x4D8F70
+#define FUNC_CAEAudioHardware_GetPlayingTrackID  0x4D8F90
+
 #define CLASS_CAERadioTrackManager 0x8CB6F8
+#define CLASS_CAEAudioHardware     0xB5F8B8
 
 enum class eRadioTrackMode
 {
@@ -120,4 +128,6 @@ public:
     void  Reset();
     void  StartRadio(BYTE bStationID, BYTE bUnknown);
     bool  IsStationLoading() const;
+    bool  GetPlaybackState(SRadioPlaybackState& state) const override;
+    bool  SetPlaybackState(const SRadioPlaybackState& state) override;
 };

--- a/Client/game_sa/CAERadioTrackManagerSA.h
+++ b/Client/game_sa/CAERadioTrackManagerSA.h
@@ -29,6 +29,8 @@
 #define CLASS_CAERadioTrackManager 0x8CB6F8
 #define CLASS_CAEAudioHardware     0xB5F8B8
 
+constexpr std::size_t RADIO_STATION_COUNT = 14;
+
 enum class eRadioTrackMode
 {
     RADIO_STARTING,
@@ -59,7 +61,6 @@ struct tRadioSettings
     std::int8_t  trackIndexes[5];
     std::int8_t  currentTrackIndex;
     std::int8_t  prevTrackIndex;
-    std::uint8_t field_3A[2];
 };
 static_assert(sizeof(tRadioSettings) == 0x3C, "Invalid size of tRadioSettings struct!");
 static_assert(offsetof(tRadioSettings, currentTrackId) == 0x14, "Invalid current track offset!");
@@ -91,15 +92,15 @@ public:
     bool            pauseMode;
     bool            retuneJustStarted;
     bool            autoSelect;
-    std::uint8_t    tracksInARow[14];
+    std::uint8_t    tracksInARow[RADIO_STATION_COUNT];
     std::uint8_t    gameMonthDay;
     std::uint8_t    gameClockHours;
-    std::int32_t    listenItems[14];
+    std::int32_t    listenItems[RADIO_STATION_COUNT];
     std::uint32_t   timeRadioStationReturned;
     std::uint32_t   timeToDisplayRadioName;
     std::uint32_t   savedTimeInMS;
     std::uint32_t   retuneStartedTime;
-    std::uint8_t    field_60[4];
+    std::uint32_t   field_60;
     std::int32_t    hwClientHandle;
     eRadioTrackMode trackMode;
     std::int32_t    stationsListed;
@@ -111,14 +112,16 @@ public:
     float           volume2;
     tRadioSettings  requestedSettings;
     tRadioSettings  activeSettings;
-    tRadioState     radioState[13];
-    std::uint8_t    field_33C[12];
-    std::uint8_t    field_348[32];
+    tRadioState     radioState[RADIO_STATION_COUNT];
     std::uint32_t   field_368;
     std::uint8_t    userTrackPlayMode;
     std::uint8_t    field_36D[3];
 };
 static_assert(sizeof(CAERadioTrackManagerSAInterface) == 0x370, "Invalid size of CAERadioTrackManagerSAInterface class!");
+static_assert(offsetof(CAERadioTrackManagerSAInterface, requestedSettings) == 0x88, "Invalid requested settings offset!");
+static_assert(offsetof(CAERadioTrackManagerSAInterface, activeSettings) == 0xC4, "Invalid active settings offset!");
+static_assert(offsetof(CAERadioTrackManagerSAInterface, radioState) == 0x100, "Invalid radio state offset!");
+static_assert(offsetof(CAERadioTrackManagerSAInterface, field_368) == 0x368, "Invalid tail offset!");
 
 class CAERadioTrackManagerSA : public CAERadioTrackManager
 {

--- a/Client/game_sa/CAERadioTrackManagerSA.h
+++ b/Client/game_sa/CAERadioTrackManagerSA.h
@@ -21,12 +21,10 @@
 #define FUNC_Reset                    0x4E7F80
 #define FUNC_StartRadio               0x4EB3C0
 
-#define FUNC_CAEAudioHardware_PlayTrack          0x4D8F10
-#define FUNC_CAEAudioHardware_StartTrackPlayback 0x4D8F30
-#define FUNC_CAEAudioHardware_StopTrack          0x4D8F50
-#define FUNC_CAEAudioHardware_GetTrackPlayTime   0x4D8F60
-#define FUNC_CAEAudioHardware_GetTrackLengthMs   0x4D8F70
-#define FUNC_CAEAudioHardware_GetPlayingTrackID  0x4D8F90
+#define FUNC_CAEAudioHardware_StopTrack         0x4D8F50
+#define FUNC_CAEAudioHardware_GetTrackPlayTime  0x4D8F60
+#define FUNC_CAEAudioHardware_GetTrackLengthMs  0x4D8F70
+#define FUNC_CAEAudioHardware_GetPlayingTrackID 0x4D8F90
 
 #define CLASS_CAERadioTrackManager 0x8CB6F8
 #define CLASS_CAEAudioHardware     0xB5F8B8
@@ -45,22 +43,29 @@ enum class eRadioTrackMode
 
 struct tRadioSettings
 {
-    std::int32_t djIndex[4];
+    std::int32_t trackQueue[5];
     std::int32_t currentTrackId;
     std::int32_t prevTrackId;
     std::int32_t trackPlayTime;
     std::int32_t trackLengthInMS;
-    std::uint8_t trackFlags[2];
+    std::uint8_t trackFlags;
     std::uint8_t currentRadioStation;
-    std::uint8_t field_27;
     std::uint8_t bassSet;
+    std::uint8_t field_27;
     float        bassGain;
-    std::uint8_t trackTypes[4];
+    std::uint8_t trackTypes[5];
     std::uint8_t currentTrackType;
     std::uint8_t prevTrackType;
-    std::int8_t  trackIndexes[10];
+    std::int8_t  trackIndexes[5];
+    std::int8_t  currentTrackIndex;
+    std::int8_t  prevTrackIndex;
+    std::uint8_t field_3A[2];
 };
 static_assert(sizeof(tRadioSettings) == 0x3C, "Invalid size of tRadioSettings struct!");
+static_assert(offsetof(tRadioSettings, currentTrackId) == 0x14, "Invalid current track offset!");
+static_assert(offsetof(tRadioSettings, trackPlayTime) == 0x1C, "Invalid play time offset!");
+static_assert(offsetof(tRadioSettings, currentRadioStation) == 0x25, "Invalid station offset!");
+static_assert(offsetof(tRadioSettings, trackTypes) == 0x2C, "Invalid track type offset!");
 
 struct tRadioState
 {

--- a/Client/game_sa/CAERadioTrackManagerSA.h
+++ b/Client/game_sa/CAERadioTrackManagerSA.h
@@ -24,6 +24,7 @@
 #define FUNC_CAEAudioHardware_StopTrack         0x4D8F50
 #define FUNC_CAEAudioHardware_GetTrackPlayTime  0x4D8F60
 #define FUNC_CAEAudioHardware_GetTrackLengthMs  0x4D8F70
+#define FUNC_CAEAudioHardware_GetActiveTrackID  0x4D8F80
 #define FUNC_CAEAudioHardware_GetPlayingTrackID 0x4D8F90
 
 #define CLASS_CAERadioTrackManager 0x8CB6F8

--- a/Client/mods/deathmatch/logic/lua/CLuaCFunctions.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaCFunctions.cpp
@@ -10,6 +10,8 @@
 
 #include <StdInc.h>
 
+void RegisterRadioPlaybackFunctions();
+
 static std::vector<CLuaCFunction*>             m_sFunctions;
 static std::map<lua_CFunction, CLuaCFunction*> ms_Functions;
 static void*                                   ms_pFunctionPtrLow = (void*)0xffffffff;
@@ -41,7 +43,7 @@ CLuaCFunction* CLuaCFunctions::AddFunction(const char* szName, lua_CFunction f, 
 
 CLuaCFunction* CLuaCFunctions::GetFunction(const char* szName, lua_CFunction f)
 {
-    // Grab a function of the given name and type
+    // Grab the function we've got passed
     std::vector<CLuaCFunction*>::const_iterator iter = m_sFunctions.begin();
     for (; iter != m_sFunctions.end(); iter++)
     {
@@ -56,7 +58,7 @@ CLuaCFunction* CLuaCFunctions::GetFunction(const char* szName, lua_CFunction f)
 
 CLuaCFunction* CLuaCFunctions::GetFunction(const char* szName)
 {
-    // Grab a function of the given name and type
+    // Grab the function we've got passed
     std::vector<CLuaCFunction*>::const_iterator iter = m_sFunctions.begin();
     for (; iter != m_sFunctions.end(); iter++)
     {
@@ -80,7 +82,6 @@ CLuaCFunction* CLuaCFunctions::GetFunction(lua_CFunction f)
 
 const char* CLuaCFunctions::GetFunctionName(lua_CFunction f, bool& bRestricted)
 {
-    // Return the function name of the given C address
     std::vector<CLuaCFunction*>::const_iterator iter = m_sFunctions.begin();
     for (; iter != m_sFunctions.end(); iter++)
     {
@@ -107,7 +108,6 @@ bool CLuaCFunctions::IsNotFunction(lua_CFunction f)
 
 bool CLuaCFunctions::IsRestricted(const char* szName)
 {
-    // Grab a function of the given name and type
     std::vector<CLuaCFunction*>::const_iterator iter = m_sFunctions.begin();
     for (; iter != m_sFunctions.end(); iter++)
     {
@@ -123,6 +123,9 @@ bool CLuaCFunctions::IsRestricted(const char* szName)
 
 void CLuaCFunctions::RegisterFunctionsWithVM(lua_State* luaVM)
 {
+    // Register these lazily after the function registry's own globals are fully constructed.
+    RegisterRadioPlaybackFunctions();
+
     // Register all our functions to a lua VM
     std::vector<CLuaCFunction*>::const_iterator iter = m_sFunctions.begin();
     for (; iter != m_sFunctions.end(); iter++)

--- a/Client/mods/deathmatch/logic/lua/CLuaCFunctions.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaCFunctions.cpp
@@ -43,7 +43,7 @@ CLuaCFunction* CLuaCFunctions::AddFunction(const char* szName, lua_CFunction f, 
 
 CLuaCFunction* CLuaCFunctions::GetFunction(const char* szName, lua_CFunction f)
 {
-    // Grab the function we've got passed
+    // Grab a function of the given name and type
     std::vector<CLuaCFunction*>::const_iterator iter = m_sFunctions.begin();
     for (; iter != m_sFunctions.end(); iter++)
     {
@@ -58,7 +58,7 @@ CLuaCFunction* CLuaCFunctions::GetFunction(const char* szName, lua_CFunction f)
 
 CLuaCFunction* CLuaCFunctions::GetFunction(const char* szName)
 {
-    // Grab the function we've got passed
+    // Grab a function of the given name and type
     std::vector<CLuaCFunction*>::const_iterator iter = m_sFunctions.begin();
     for (; iter != m_sFunctions.end(); iter++)
     {
@@ -82,6 +82,7 @@ CLuaCFunction* CLuaCFunctions::GetFunction(lua_CFunction f)
 
 const char* CLuaCFunctions::GetFunctionName(lua_CFunction f, bool& bRestricted)
 {
+    // Return the function name of the given C address
     std::vector<CLuaCFunction*>::const_iterator iter = m_sFunctions.begin();
     for (; iter != m_sFunctions.end(); iter++)
     {
@@ -108,6 +109,7 @@ bool CLuaCFunctions::IsNotFunction(lua_CFunction f)
 
 bool CLuaCFunctions::IsRestricted(const char* szName)
 {
+    // Grab a function of the given name and type
     std::vector<CLuaCFunction*>::const_iterator iter = m_sFunctions.begin();
     for (; iter != m_sFunctions.end(); iter++)
     {
@@ -123,7 +125,6 @@ bool CLuaCFunctions::IsRestricted(const char* szName)
 
 void CLuaCFunctions::RegisterFunctionsWithVM(lua_State* luaVM)
 {
-    // Register these lazily after the function registry's own globals are fully constructed.
     RegisterRadioPlaybackFunctions();
 
     // Register all our functions to a lua VM

--- a/Client/mods/deathmatch/logic/luadefs/CLuaRadioPlaybackDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaRadioPlaybackDefs.cpp
@@ -1,0 +1,153 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  PURPOSE:     Native GTA radio playback state Lua bindings
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+#include <game/CAERadioTrackManager.h>
+
+namespace
+{
+    void PushIntegerField(lua_State* luaVM, const char* name, int value)
+    {
+        lua_pushinteger(luaVM, value);
+        lua_setfield(luaVM, -2, name);
+    }
+
+    bool ReadIntegerField(lua_State* luaVM, int tableIndex, const char* name, int& value)
+    {
+        lua_getfield(luaVM, tableIndex, name);
+        if (!lua_isnumber(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            return false;
+        }
+
+        value = static_cast<int>(lua_tointeger(luaVM, -1));
+        lua_pop(luaVM, 1);
+        return true;
+    }
+
+    int GetRadioPlaybackState(lua_State* luaVM)
+    {
+        CAERadioTrackManager* radio = g_pGame ? g_pGame->GetAERadioTrackManager() : nullptr;
+        SRadioPlaybackState   state;
+        if (!radio || !radio->GetPlaybackState(state))
+        {
+            lua_pushboolean(luaVM, false);
+            return 1;
+        }
+
+        lua_newtable(luaVM);
+        lua_pushboolean(luaVM, state.radioOn);
+        lua_setfield(luaVM, -2, "radioOn");
+        PushIntegerField(luaVM, "station", state.stationId);
+        PushIntegerField(luaVM, "mode", state.mode);
+        PushIntegerField(luaVM, "trackId", state.currentTrackId);
+        PushIntegerField(luaVM, "trackType", state.currentTrackType);
+        PushIntegerField(luaVM, "trackIndex", state.currentTrackIndex);
+        PushIntegerField(luaVM, "position", state.playTimeMs);
+        PushIntegerField(luaVM, "length", state.trackLengthMs);
+        PushIntegerField(luaVM, "flags", state.trackFlags);
+
+        lua_newtable(luaVM);
+        for (unsigned int i = 0; i < SRadioPlaybackState::QUEUE_SIZE; ++i)
+        {
+            lua_newtable(luaVM);
+            PushIntegerField(luaVM, "id", state.trackQueue[i]);
+            PushIntegerField(luaVM, "type", state.trackTypes[i]);
+            PushIntegerField(luaVM, "index", state.trackIndexes[i]);
+            lua_rawseti(luaVM, -2, i + 1);
+        }
+        lua_setfield(luaVM, -2, "queue");
+        return 1;
+    }
+
+    int SetRadioPlaybackState(lua_State* luaVM)
+    {
+        if (!lua_istable(luaVM, 1))
+        {
+            lua_pushboolean(luaVM, false);
+            return 1;
+        }
+
+        SRadioPlaybackState state;
+        lua_getfield(luaVM, 1, "radioOn");
+        state.radioOn = lua_isboolean(luaVM, -1) ? lua_toboolean(luaVM, -1) != 0 : true;
+        lua_pop(luaVM, 1);
+
+        int station{}, mode{}, trackId{}, trackType{}, trackIndex{}, position{}, length{}, flags{};
+        if (!ReadIntegerField(luaVM, 1, "station", station) || !ReadIntegerField(luaVM, 1, "trackId", trackId) ||
+            !ReadIntegerField(luaVM, 1, "trackType", trackType) || !ReadIntegerField(luaVM, 1, "trackIndex", trackIndex) ||
+            !ReadIntegerField(luaVM, 1, "position", position) || !ReadIntegerField(luaVM, 1, "length", length) ||
+            !ReadIntegerField(luaVM, 1, "flags", flags))
+        {
+            lua_pushboolean(luaVM, false);
+            return 1;
+        }
+        ReadIntegerField(luaVM, 1, "mode", mode);
+
+        if (station < 0 || station >= 13 || trackId < 0 || trackType < 0 || trackType > 7 || trackIndex < -1 || trackIndex > 127 || position < 0 ||
+            length < -1 || flags < 0 || flags > 255)
+        {
+            lua_pushboolean(luaVM, false);
+            return 1;
+        }
+
+        state.stationId = static_cast<unsigned char>(station);
+        state.mode = mode;
+        state.currentTrackId = trackId;
+        state.currentTrackType = trackType;
+        state.currentTrackIndex = trackIndex;
+        state.playTimeMs = position;
+        state.trackLengthMs = length;
+        state.trackFlags = static_cast<unsigned char>(flags);
+
+        lua_getfield(luaVM, 1, "queue");
+        if (!lua_istable(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            lua_pushboolean(luaVM, false);
+            return 1;
+        }
+
+        for (unsigned int i = 0; i < SRadioPlaybackState::QUEUE_SIZE; ++i)
+        {
+            lua_rawgeti(luaVM, -1, i + 1);
+            if (!lua_istable(luaVM, -1))
+            {
+                lua_pop(luaVM, 2);
+                lua_pushboolean(luaVM, false);
+                return 1;
+            }
+
+            int id{}, type{}, index{};
+            if (!ReadIntegerField(luaVM, -1, "id", id) || !ReadIntegerField(luaVM, -1, "type", type) || !ReadIntegerField(luaVM, -1, "index", index) ||
+                id < -1 || type < 0 || type > 7 || index < -1 || index > 127)
+            {
+                lua_pop(luaVM, 2);
+                lua_pushboolean(luaVM, false);
+                return 1;
+            }
+
+            state.trackQueue[i] = id;
+            state.trackTypes[i] = static_cast<signed char>(type);
+            state.trackIndexes[i] = static_cast<signed char>(index);
+            lua_pop(luaVM, 1);
+        }
+        lua_pop(luaVM, 1);
+
+        CAERadioTrackManager* radio = g_pGame ? g_pGame->GetAERadioTrackManager() : nullptr;
+        lua_pushboolean(luaVM, radio && radio->SetPlaybackState(state));
+        return 1;
+    }
+}
+
+void RegisterRadioPlaybackFunctions()
+{
+    CLuaCFunctions::AddFunction("getRadioPlaybackState", GetRadioPlaybackState);
+    CLuaCFunctions::AddFunction("setRadioPlaybackState", SetRadioPlaybackState);
+}

--- a/Client/mods/deathmatch/logic/luadefs/CLuaRadioPlaybackDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaRadioPlaybackDefs.cpp
@@ -11,6 +11,9 @@
 
 namespace
 {
+    constexpr int MIN_NATIVE_TRACK_INDEX = -128;
+    constexpr int MAX_NATIVE_TRACK_INDEX = 127;
+
     void PushIntegerField(lua_State* luaVM, const char* name, int value)
     {
         lua_pushinteger(luaVM, value);
@@ -90,8 +93,8 @@ namespace
         }
         ReadIntegerField(luaVM, 1, "mode", mode);
 
-        if (station < 0 || station >= 13 || trackId < 0 || trackType < 0 || trackType > 7 || trackIndex < -1 || trackIndex > 127 || position < 0 ||
-            length < -1 || flags < 0 || flags > 255)
+        if (station < 0 || station >= 13 || trackId < 0 || trackType < 0 || trackType > 7 || trackIndex < MIN_NATIVE_TRACK_INDEX ||
+            trackIndex > MAX_NATIVE_TRACK_INDEX || position < 0 || length < -1 || flags < 0 || flags > 255)
         {
             lua_pushboolean(luaVM, false);
             return 1;
@@ -126,7 +129,7 @@ namespace
 
             int id{}, type{}, index{};
             if (!ReadIntegerField(luaVM, -1, "id", id) || !ReadIntegerField(luaVM, -1, "type", type) || !ReadIntegerField(luaVM, -1, "index", index) ||
-                id < -1 || type < 0 || type > 7 || index < -1 || index > 127)
+                id < -1 || type < 0 || type > 7 || index < MIN_NATIVE_TRACK_INDEX || index > MAX_NATIVE_TRACK_INDEX)
             {
                 lua_pop(luaVM, 2);
                 lua_pushboolean(luaVM, false);

--- a/Client/sdk/game/CAERadioTrackManager.h
+++ b/Client/sdk/game/CAERadioTrackManager.h
@@ -11,6 +11,24 @@
 
 #pragma once
 
+struct SRadioPlaybackState
+{
+    static constexpr unsigned int QUEUE_SIZE = 5;
+
+    bool          radioOn{};
+    unsigned char stationId{};
+    int           mode{};
+    int           currentTrackId{-1};
+    int           currentTrackType{6};
+    int           currentTrackIndex{-1};
+    int           playTimeMs{-1};
+    int           trackLengthMs{-1};
+    unsigned char trackFlags{};
+    int           trackQueue[QUEUE_SIZE]{-1, -1, -1, -1, -1};
+    signed char   trackTypes[QUEUE_SIZE]{6, 6, 6, 6, 6};
+    signed char   trackIndexes[QUEUE_SIZE]{-1, -1, -1, -1, -1};
+};
+
 class CAERadioTrackManager
 {
 public:
@@ -22,4 +40,6 @@ public:
     virtual void  Reset() = 0;
     virtual void  StartRadio(BYTE bStationID, BYTE bUnknown) = 0;
     virtual bool  IsStationLoading() const = 0;
+    virtual bool  GetPlaybackState(SRadioPlaybackState& state) const = 0;
+    virtual bool  SetPlaybackState(const SRadioPlaybackState& state) = 0;
 };


### PR DESCRIPTION
Implements #20.

### What changed
- exposes `getRadioPlaybackState()` and `setRadioPlaybackState(state)` client-side Lua functions
- snapshots native station/mode, current streamed clip, live playback position, track length, track flags, type/index, and the five-entry native queue
- applies a snapshot through GTA's native `RequestedSettings -> ActiveSettings -> RADIO_STARTING` hand-off so the requested seek survives the hardware refresh at the beginning of `CAERadioTrackManager::Service`
- stops the current native stream before the hand-off so restoring the same track ID rebuilds the decoder and honours the new seek position
- corrects the existing `tRadioSettings` wrapper layout to GTA's five-entry queue
- corrects the radio-state array to 14 entries (`RADIO_COUNT`), replacing padding that previously hid the mismatch
- adds compile-time size/offset assertions for the native structures
- normalises snapshots around the hardware-current track so an audio-thread queue transition cannot produce a duplicated/stale queue when transported to another client
- falls back from `GetPlayingTrackID()` to `GetActiveTrackID()` while the native stream is prepared but not yet playing
- preserves the full signed `int8` domain of native track indices when round-tripping through Lua

### Binary validation
Validated directly against the GTA SA 1.0 US compact executable used by `gta-reversed-dryxio`:

- SHA-256: `72ae59e44c761389e354a50dc6215e964fe771121e2f4b1877273a493ceecc9b`
- PE32/i386 image base: `0x400000`
- `CAEAudioHardware` radio wrappers verified at `0x4D8F10` through `0x4D8F90`
- `CAEStreamThread::PlayTrack @ 0x4F1230` stores `StartOffsetMs` at stream-thread offset `+0x1C`
- `CAEStreamThread::Service @ 0x4F1290` rebuilds a decoder and calls `SetCursor(StartOffsetMs % GetStreamLengthMs())`
- the same-track fast path does not rebuild/seek an existing decoder; native `StopTrack` sets the stop request, which the stream thread handles before its queued play request
- `GetTrackPlayTime @ 0x4D8F60` reaches the live `CAEStreamingChannel::GetPlayTime` path unless the stream thread is preparing a decoder (then GTA returns `-8`)
- `CAERadioTrackManager::Service @ 0x4EB9A0` refreshes `ActiveSettings.PlayTime` from the hardware before processing the radio mode; the setter therefore keeps the transported position in `RequestedSettings`, enters `RADIO_STOPPED` with `isInitialised=true`, and lets GTA copy Requested -> Active before `RADIO_STARTING`
- `RADIO_STARTING` starts `TrackQueue[0]` with `TrackQueue[1]` preloaded using the restored playback offset
- `CheckForTrackConcatenation @ 0x4EA930` can rotate the radio queue after the audio thread has already switched streams; the getter therefore canonicalises the returned queue around the hardware-current track
- `CAETrackLoader::GetDataStream @ 0x4E0D20` rejects `trackId >= m_nTrackCount`, and `CAEUserRadioTrackManager::LoadUserTrack @ 0x4F35F0` rejects negative/out-of-range local user-track IDs

The binary audit also identified inaccuracies in the reference `gta-reversed-dryxio` streaming reverse: `CAEStreamingChannel::FillBuffer` stores `GetStreamPlayTimeMs()` rather than `GetStreamLengthMs()`, and `UpdatePlayTime` selects its buffer-half branch from `currentPlayCursor / 0x60000` rather than from the frequency factor. Those reference-source issues do not affect this MTA implementation, which calls the original GTA binary entrypoints.

### Lua shape
`getRadioPlaybackState()` returns a table containing `radioOn`, `station`, `mode`, `trackId`, `trackType`, `trackIndex`, `position`, `length`, `flags`, and `queue`. `queue` contains five `{ id, type, index }` entries.

The returned snapshot is canonicalised so `queue[1]` (Lua index 1) is the native clip represented by `trackId`, followed by the remaining native queue. It can be transported to another client and passed to `setRadioPlaybackState`.

Native track indices are signed bytes and are round-tripped as `-128..127`; the 32-bit `id` field is the actual stream/user-track ID used by GTA's loader.

User-track radio (`trackType == 7`) still refers to each client's local user-track library; identical native user-track IDs do not imply identical audio files across different machines.

### Native transition caveat
GTA prebuffers streamed audio. During a seamless concatenation, `FillBuffer` may replace `m_pStreamingDecoder` with the next decoder after filling the tail of the previous clip into the DirectSound buffer. For a short native transition window, the reported track ID can therefore already be the next clip while buffered samples from the previous clip are still audible; the new clip's reported play time may remain clamped at zero until playback catches up.

Queue canonicalisation prevents this window from corrupting the transported scheduler state, but a single snapshot captured exactly there cannot be guaranteed sample-perfect. Vehicle-radio sync code should re-snapshot on/after native track changes (and periodically for long-lived sessions) rather than assume one snapshot keeps independently-running schedulers locked forever. The five queued native segments substantially reduce scheduler divergence, but later GTA RNG/history choices can still diverge between clients.

### Validation status
- direct opcode-level validation against the matching GTA SA compact executable
- native structure sizes/offsets cross-checked against the executable and reference source
- transition, same-track restore, requested/active settings hand-off, and loader bounds paths checked against native control flow
- the new Lua translation unit is automatically included by the Client Deathmatch `**.cpp` premake rule
- PR remains draft pending an MTA client build/runtime test in the normal Windows toolchain