### PR TITLE
Disable CEF for secondary client

### DIFF
--- a/Client/cefweb/CefWeb.cpp
+++ b/Client/cefweb/CefWeb.cpp
@@ -59,6 +59,11 @@ extern "C" _declspec(dllexport) CWebCoreInterface* InitWebCoreInterface(CCoreInt
     if (!InitializeGlobalInterfaces(pCore)) [[unlikely]]
         return nullptr;
 
+    // The secondary development client does not need browser features. Stop
+    // before constructing CWebCore so CefInitialize and CEFLauncher never run.
+    if (pCore->IsSecondaryClient())
+        return nullptr;
+
     // Perform runtime initialization
     PerformRuntimeInitialization();
 


### PR DESCRIPTION
## What changed
- skip CEF web-core creation when the client is running as `-cl2`
- return before runtime CEF initialization, so `CefInitialize()` and `CEFLauncher.exe` are never reached for the secondary client

## Why
The dual-client development mode does not require browser features on CL2, and starting a second Chromium/CEF instance can produce an unwanted Chromium window during two-client testing.

## Impact
The primary client keeps normal CEF/browser behavior. The secondary client falls back to the existing native/CEGUI paths and has no CEF browser support by design.

## Validation
- branch is one commit ahead of `master`
- diff is limited to `Client/cefweb/CefWeb.cpp` (+5 lines)
- uses the existing `CCoreInterface::IsSecondaryClient()` capability before constructing `CWebCore`