### PR TITLE
feat(world-objects): script native physics objects

### DIFF
--- a/Client/mods/deathmatch/CClient.cpp
+++ b/Client/mods/deathmatch/CClient.cpp
@@ -13,6 +13,7 @@
 #define ALLOC_STATS_MODULE_NAME "client"
 #include "SharedUtil.hpp"
 #include <core/CClientCommands.h>
+#include "logic/CClientWorldObjectManager.h"
 
 CCoreInterface*         g_pCore = NULL;
 CLocalizationInterface* g_pLocalization = NULL;
@@ -192,6 +193,8 @@ void CClient::ClientShutdown()
     g_pCore->GetKeyBinds()->RemoveControlFunction("radio_next", CClientGame::HandleRadioNext);
     g_pCore->GetKeyBinds()->RemoveControlFunction("radio_previous", CClientGame::HandleRadioPrevious);
 
+    CClientWorldObjectManager::Shutdown();
+
     // If the client modification is loaded, delete it
     if (g_pClientGame)
     {
@@ -205,6 +208,7 @@ void CClient::PreFrameExecutionHandler()
     // If the client modification is loaded, pulse it
     if (g_pClientGame)
     {
+        CClientWorldObjectManager::Pulse();
         g_pClientGame->DoPulsePreFrame();
     }
 }

--- a/Client/mods/deathmatch/logic/CClientDummy.h
+++ b/Client/mods/deathmatch/logic/CClientDummy.h
@@ -12,7 +12,7 @@
 
 #include "CClientEntity.h"
 
-class CClientDummy final : public CClientEntity
+class CClientDummy : public CClientEntity
 {
     DECLARE_CLASS(CClientDummy, CClientEntity)
 public:

--- a/Client/mods/deathmatch/logic/CClientWorldObject.cpp
+++ b/Client/mods/deathmatch/logic/CClientWorldObject.cpp
@@ -1,0 +1,202 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        mods/deathmatch/logic/CClientWorldObject.cpp
+ *  PURPOSE:     Client-only proxy for GTA-owned dynamic world objects
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+#include "CClientWorldObject.h"
+#include "../../../game_sa/CEntitySA.h"
+#include "../../../game_sa/CObjectSA.h"
+
+#include <cmath>
+
+namespace
+{
+    constexpr float MIN_AXIS_LENGTH = 0.0001f;
+
+    float AxisLength(const CVector& axis)
+    {
+        return std::sqrt(axis.fX * axis.fX + axis.fY * axis.fY + axis.fZ * axis.fZ);
+    }
+
+    CVector NormalizedAxis(const CVector& axis)
+    {
+        const float length = AxisLength(axis);
+        return length > MIN_AXIS_LENGTH ? axis / length : axis;
+    }
+}
+
+CClientWorldObject::CClientWorldObject(CClientManager* pManager, CEntitySAInterface* pDummy, CObjectSAInterface* pObject)
+    : CClientDummy(pManager, INVALID_ELEMENT_ID, "worldobject"), m_pDummy(pDummy), m_pObject(pObject)
+{
+    // GTA owns both interfaces. The MTA element only observes and edits their
+    // transform, so scripts must never be able to destroy the native object.
+    MakeSystemEntity();
+    if (m_pObject)
+        m_usModel = m_pObject->m_nModelIndex;
+    else if (m_pDummy)
+        m_usModel = m_pDummy->m_nModelIndex;
+    RefreshFromGame();
+}
+
+void CClientWorldObject::Attach(CObjectSAInterface* pObject)
+{
+    if (!pObject)
+        return;
+
+    if (m_pObject == pObject)
+    {
+        RefreshFromGame();
+        return;
+    }
+
+    const bool wasStreamedIn = m_pObject != nullptr;
+    m_pObject = pObject;
+    m_usModel = pObject->m_nModelIndex;
+    RefreshFromGame();
+
+    if (!wasStreamedIn)
+        FireStreamEvent("onClientElementStreamIn");
+}
+
+void CClientWorldObject::Detach()
+{
+    if (!m_pObject)
+        return;
+
+    // ConvertToDummyObject copies the final object matrix back to the persistent
+    // dummy before deleting the CObject. Read the dummy after detaching instead
+    // of ever touching the now-stale object pointer.
+    m_pObject = nullptr;
+    RefreshFromGame();
+    FireStreamEvent("onClientElementStreamOut");
+}
+
+void CClientWorldObject::RefreshFromGame()
+{
+    CEntitySAInterface* pInterface = GetTransformInterface();
+    if (!pInterface)
+        return;
+
+    ReadTransform(pInterface, m_vecPosition, m_vecRotation);
+    m_usModel = pInterface->m_nModelIndex;
+}
+
+bool CClientWorldObject::GetMatrix(CMatrix& matrix) const
+{
+    CEntitySAInterface* pInterface = GetTransformInterface();
+    if (pInterface && pInterface->matrix)
+    {
+        pInterface->matrix->ConvertToMatrix(matrix);
+        return true;
+    }
+
+    return CClientEntity::GetMatrix(matrix);
+}
+
+bool CClientWorldObject::SetMatrix(const CMatrix& matrix)
+{
+    CEntitySAInterface* pInterface = GetTransformInterface();
+    if (pInterface && pInterface->matrix)
+    {
+        pInterface->matrix->SetFromMatrixSkipPadding(matrix);
+        pInterface->UpdateRW();
+        RefreshFromGame();
+        return true;
+    }
+
+    return CClientEntity::SetMatrix(matrix);
+}
+
+void CClientWorldObject::GetPosition(CVector& vecPosition) const
+{
+    CEntitySAInterface* pInterface = GetTransformInterface();
+    if (pInterface)
+    {
+        CVector rotation;
+        ReadTransform(pInterface, vecPosition, rotation);
+        return;
+    }
+
+    vecPosition = m_vecPosition;
+}
+
+void CClientWorldObject::SetPosition(const CVector& vecPosition)
+{
+    m_vecPosition = vecPosition;
+
+    CEntitySAInterface* pInterface = GetTransformInterface();
+    if (!pInterface)
+        return;
+
+    if (pInterface->matrix)
+        pInterface->matrix->vPos = vecPosition;
+    else
+        pInterface->m_transform.m_translate = vecPosition;
+
+    pInterface->UpdateRW();
+}
+
+void CClientWorldObject::GetRotationRadians(CVector& vecOutRadians) const
+{
+    CEntitySAInterface* pInterface = GetTransformInterface();
+    if (pInterface)
+    {
+        CVector position;
+        ReadTransform(pInterface, position, vecOutRadians);
+        return;
+    }
+
+    vecOutRadians = m_vecRotation;
+}
+
+void CClientWorldObject::SetRotationRadians(const CVector& vecRadians)
+{
+    m_vecRotation = vecRadians;
+
+    CEntitySAInterface* pInterface = GetTransformInterface();
+    if (!pInterface)
+        return;
+
+    pInterface->SetOrientation(vecRadians.fX, vecRadians.fY, vecRadians.fZ);
+    pInterface->UpdateRW();
+}
+
+CEntitySAInterface* CClientWorldObject::GetTransformInterface() const
+{
+    return m_pObject ? static_cast<CEntitySAInterface*>(m_pObject) : m_pDummy;
+}
+
+void CClientWorldObject::ReadTransform(CEntitySAInterface* pInterface, CVector& vecPosition, CVector& vecRotation) const
+{
+    if (!pInterface)
+        return;
+
+    if (!pInterface->matrix)
+    {
+        vecPosition = pInterface->m_transform.m_translate;
+        vecRotation = CVector(0.0f, 0.0f, pInterface->m_transform.m_heading);
+        return;
+    }
+
+    vecPosition = pInterface->matrix->vPos;
+
+    // Match CClientObject's ZXY decomposition so matrix reads expose the same
+    // orientation convention for native and MTA-created objects.
+    const CVector right = NormalizedAxis(pInterface->matrix->vRight);
+    const CVector front = NormalizedAxis(pInterface->matrix->vFront);
+    const CVector up = NormalizedAxis(pInterface->matrix->vUp);
+    vecRotation.fX = std::asin(std::clamp(front.fZ, -1.0f, 1.0f));
+    vecRotation.fY = std::atan2(-right.fZ, up.fZ);
+    vecRotation.fZ = std::atan2(-front.fX, front.fY);
+}
+
+void CClientWorldObject::FireStreamEvent(const char* szEvent)
+{
+    CLuaArguments arguments;
+    CallEvent(szEvent, arguments, true);
+}

--- a/Client/mods/deathmatch/logic/CClientWorldObject.h
+++ b/Client/mods/deathmatch/logic/CClientWorldObject.h
@@ -1,0 +1,50 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        mods/deathmatch/logic/CClientWorldObject.h
+ *  PURPOSE:     Client-only proxy for GTA-owned dynamic world objects
+ *
+ *****************************************************************************/
+
+#pragma once
+
+#include "CClientDummy.h"
+
+class CEntitySAInterface;
+class CObjectSAInterface;
+
+class CClientWorldObject final : public CClientDummy
+{
+public:
+    CClientWorldObject(CClientManager* pManager, CEntitySAInterface* pDummy, CObjectSAInterface* pObject);
+    ~CClientWorldObject() override = default;
+
+    void Attach(CObjectSAInterface* pObject);
+    void Detach();
+    void RefreshFromGame();
+
+    CObjectSAInterface* GetGameObject() const { return m_pObject; }
+    CEntitySAInterface* GetDummyInterface() const { return m_pDummy; }
+    unsigned short      GetWorldModel() const { return m_usModel; }
+    bool                IsWorldObjectStreamedIn() const { return m_pObject != nullptr; }
+
+    bool GetMatrix(CMatrix& matrix) const override;
+    bool SetMatrix(const CMatrix& matrix) override;
+    void GetPosition(CVector& vecPosition) const override;
+    void SetPosition(const CVector& vecPosition) override;
+    void GetRotationRadians(CVector& vecOutRadians) const override;
+    void SetRotationRadians(const CVector& vecRadians) override;
+
+private:
+    CEntitySAInterface* GetTransformInterface() const;
+    void                ReadTransform(CEntitySAInterface* pInterface, CVector& vecPosition, CVector& vecRotation) const;
+    void                FireStreamEvent(const char* szEvent);
+
+private:
+    CEntitySAInterface* m_pDummy = nullptr;
+    CObjectSAInterface* m_pObject = nullptr;
+    unsigned short      m_usModel = 0;
+    CVector             m_vecPosition;
+    CVector             m_vecRotation;
+};

--- a/Client/mods/deathmatch/logic/CClientWorldObjectManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientWorldObjectManager.cpp
@@ -1,0 +1,239 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        mods/deathmatch/logic/CClientWorldObjectManager.cpp
+ *  PURPOSE:     Discovery and event bridge for GTA-owned dynamic world objects
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+#include "CClientWorldObjectManager.h"
+#include "CClientWorldObject.h"
+#include "../../../game_sa/CPoolSAInterface.h"
+#include "../../../game_sa/CPoolsSA.h"
+
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace
+{
+    using WorldObjectMap = std::unordered_map<CEntitySAInterface*, std::unique_ptr<CClientWorldObject>>;
+    using LiveObjectMap = std::unordered_map<CObjectSAInterface*, CClientWorldObject*>;
+
+    WorldObjectMap                                  g_worldObjects;
+    LiveObjectMap                                   g_liveObjects;
+    std::unordered_set<CEntitySAInterface*>         g_streamedDummies;
+    CClientGame*                                    g_pRegisteredGame = nullptr;
+    bool                                            g_bHandlersInstalled = false;
+
+    CPoolSAInterface<CObjectSAInterface>* GetNativeObjectPool()
+    {
+        auto** ppPool = reinterpret_cast<CPoolSAInterface<CObjectSAInterface>**>(CLASS_CObjectPool);
+        return ppPool ? *ppPool : nullptr;
+    }
+
+    CPoolSAInterface<CEntitySAInterface>* GetNativeDummyPool()
+    {
+        auto** ppPool = reinterpret_cast<CPoolSAInterface<CEntitySAInterface>**>(CLASS_CDummyPool);
+        return ppPool ? *ppPool : nullptr;
+    }
+
+    bool IsDummyAlive(CPoolSAInterface<CEntitySAInterface>* pPool, CEntitySAInterface* pDummy)
+    {
+        if (!pPool || !pDummy || !pPool->m_pObjects || !pPool->m_byteMap)
+            return false;
+
+        const std::int32_t index = pPool->GetObjectIndexSafe(pDummy);
+        return index >= 0 && !pPool->IsEmpty(index) && pPool->GetObject(index) == pDummy;
+    }
+
+    bool IsNativeWorldObject(CObjectSAInterface* pObject)
+    {
+        if (!pObject || pObject->nType != ENTITY_TYPE_OBJECT || !pObject->pLinkedObjectDummy)
+            return false;
+
+        // CObject::Init writes OBJECT_GAME (1) at offset 316. MTA-created
+        // CObjectSA instances overwrite the same byte with OBJECT_MISSION2 (6),
+        // so this excludes MTA objects and temporary/flying components.
+        return pObject->pad1 == 1;
+    }
+
+    CClientWorldObject* AdoptObject(CObjectSAInterface* pObject)
+    {
+        if (!IsNativeWorldObject(pObject) || !g_pClientGame)
+            return nullptr;
+
+        CEntitySAInterface* pDummy = pObject->pLinkedObjectDummy;
+        auto                iter = g_worldObjects.find(pDummy);
+        if (iter == g_worldObjects.end())
+        {
+            auto proxy = std::make_unique<CClientWorldObject>(g_pClientGame->GetManager(), pDummy, pObject);
+            proxy->SetParent(g_pClientGame->GetRootEntity());
+            CClientWorldObject* pProxy = proxy.get();
+            g_worldObjects.emplace(pDummy, std::move(proxy));
+            g_liveObjects[pObject] = pProxy;
+            return pProxy;
+        }
+
+        iter->second->Attach(pObject);
+        g_liveObjects[pObject] = iter->second.get();
+        return iter->second.get();
+    }
+
+    CClientWorldObject* FindOrAdoptObject(CObjectSAInterface* pObject)
+    {
+        const auto iter = g_liveObjects.find(pObject);
+        if (iter != g_liveObjects.end())
+        {
+            // GTA may recycle an object-pool address between scans. Only reuse
+            // the cached proxy when the persistent dummy identity still matches.
+            if (iter->second && iter->second->GetDummyInterface() == pObject->pLinkedObjectDummy)
+                return iter->second;
+            g_liveObjects.erase(iter);
+        }
+        return AdoptObject(pObject);
+    }
+
+    void RegisterForGame(CClientGame* pGame)
+    {
+        if (!pGame || !g_pMultiplayer)
+            return;
+
+        if (g_pRegisteredGame == pGame && g_bHandlersInstalled)
+            return;
+
+        g_pRegisteredGame = pGame;
+        pGame->GetEvents()->AddEvent("onClientWorldObjectDamage", "loss, attacker, model, x, y, z", nullptr, false);
+        pGame->GetEvents()->AddEvent("onClientWorldObjectBreak", "attacker, model, x, y, z", nullptr, false);
+        g_pMultiplayer->SetObjectDamageHandler(CClientWorldObjectManager::ObjectDamageHandler);
+        g_pMultiplayer->SetObjectBreakHandler(CClientWorldObjectManager::ObjectBreakHandler);
+        g_bHandlersInstalled = true;
+    }
+
+    void ClearProxies()
+    {
+        g_liveObjects.clear();
+        g_streamedDummies.clear();
+        g_worldObjects.clear();
+    }
+}
+
+void CClientWorldObjectManager::Pulse()
+{
+    if (!g_pClientGame || !g_pGame || !g_pMultiplayer)
+        return;
+
+    RegisterForGame(g_pClientGame);
+
+    if (g_pGame->GetSystemState() != SystemState::GS_PLAYING_GAME)
+    {
+        ClearProxies();
+        return;
+    }
+
+    auto* pObjectPool = GetNativeObjectPool();
+    auto* pDummyPool = GetNativeDummyPool();
+    if (!pObjectPool || !pDummyPool || !pObjectPool->m_pObjects || !pObjectPool->m_byteMap || !pDummyPool->m_pObjects || !pDummyPool->m_byteMap)
+        return;
+
+    g_liveObjects.clear();
+    g_streamedDummies.clear();
+    if (g_streamedDummies.bucket_count() < 256)
+        g_streamedDummies.reserve(256);
+
+    for (int i = 0; i < pObjectPool->m_nSize; ++i)
+    {
+        if (pObjectPool->IsEmpty(i))
+            continue;
+
+        CObjectSAInterface* pObject = pObjectPool->GetObject(i);
+        if (!IsNativeWorldObject(pObject) || !IsDummyAlive(pDummyPool, pObject->pLinkedObjectDummy))
+            continue;
+
+        CClientWorldObject* pProxy = AdoptObject(pObject);
+        if (!pProxy)
+            continue;
+
+        pProxy->RefreshFromGame();
+        g_streamedDummies.insert(pObject->pLinkedObjectDummy);
+    }
+
+    for (auto iter = g_worldObjects.begin(); iter != g_worldObjects.end();)
+    {
+        if (!IsDummyAlive(pDummyPool, iter->first))
+        {
+            iter = g_worldObjects.erase(iter);
+            continue;
+        }
+
+        if (!g_streamedDummies.contains(iter->first))
+            iter->second->Detach();
+        ++iter;
+    }
+}
+
+void CClientWorldObjectManager::Shutdown()
+{
+    ClearProxies();
+
+    if (g_bHandlersInstalled && g_pMultiplayer)
+    {
+        g_pMultiplayer->SetObjectDamageHandler(CClientGame::StaticObjectDamageHandler);
+        g_pMultiplayer->SetObjectBreakHandler(CClientGame::StaticObjectBreakHandler);
+    }
+
+    g_bHandlersInstalled = false;
+    g_pRegisteredGame = nullptr;
+}
+
+bool CClientWorldObjectManager::ObjectDamageHandler(CObjectSAInterface* pObjectInterface, float fLoss, CEntitySAInterface* pAttackerInterface)
+{
+    CClientWorldObject* pProxy = FindOrAdoptObject(pObjectInterface);
+    if (!pProxy)
+        return CClientGame::StaticObjectDamageHandler(pObjectInterface, fLoss, pAttackerInterface);
+
+    pProxy->RefreshFromGame();
+    CVector position;
+    pProxy->GetPosition(position);
+
+    CLuaArguments arguments;
+    arguments.PushNumber(fLoss);
+
+    CClientEntity* pAttacker = g_pGame->GetPools()->GetClientEntity(reinterpret_cast<DWORD*>(pAttackerInterface));
+    if (pAttacker)
+        arguments.PushElement(pAttacker);
+    else
+        arguments.PushNil();
+
+    arguments.PushNumber(pProxy->GetWorldModel());
+    arguments.PushNumber(position.fX);
+    arguments.PushNumber(position.fY);
+    arguments.PushNumber(position.fZ);
+    return pProxy->CallEvent("onClientWorldObjectDamage", arguments, true);
+}
+
+bool CClientWorldObjectManager::ObjectBreakHandler(CObjectSAInterface* pObjectInterface, CEntitySAInterface* pAttackerInterface)
+{
+    CClientWorldObject* pProxy = FindOrAdoptObject(pObjectInterface);
+    if (!pProxy)
+        return CClientGame::StaticObjectBreakHandler(pObjectInterface, pAttackerInterface);
+
+    pProxy->RefreshFromGame();
+    CVector position;
+    pProxy->GetPosition(position);
+
+    CLuaArguments arguments;
+    CClientEntity* pAttacker = g_pGame->GetPools()->GetClientEntity(reinterpret_cast<DWORD*>(pAttackerInterface));
+    if (pAttacker)
+        arguments.PushElement(pAttacker);
+    else
+        arguments.PushNil();
+
+    arguments.PushNumber(pProxy->GetWorldModel());
+    arguments.PushNumber(position.fX);
+    arguments.PushNumber(position.fY);
+    arguments.PushNumber(position.fZ);
+    return pProxy->CallEvent("onClientWorldObjectBreak", arguments, true);
+}

--- a/Client/mods/deathmatch/logic/CClientWorldObjectManager.h
+++ b/Client/mods/deathmatch/logic/CClientWorldObjectManager.h
@@ -1,0 +1,25 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        mods/deathmatch/logic/CClientWorldObjectManager.h
+ *  PURPOSE:     Discovery and event bridge for GTA-owned dynamic world objects
+ *
+ *****************************************************************************/
+
+#pragma once
+
+class CEntitySAInterface;
+class CObjectSAInterface;
+
+class CClientWorldObjectManager
+{
+public:
+    static void Pulse();
+    static void Shutdown();
+
+    // Installed into CMultiplayer's existing global CObject hooks. Non-world
+    // objects are forwarded unchanged to CClientGame's normal handlers.
+    static bool ObjectDamageHandler(CObjectSAInterface* pObjectInterface, float fLoss, CEntitySAInterface* pAttackerInterface);
+    static bool ObjectBreakHandler(CObjectSAInterface* pObjectInterface, CEntitySAInterface* pAttackerInterface);
+};

--- a/test-resources/world-object-scripting-harness/README.md
+++ b/test-resources/world-object-scripting-harness/README.md
@@ -1,0 +1,40 @@
+# World object scripting harness
+
+Client-side validation and showcase resource for native GTA dynamic world objects exposed as `worldobject` elements.
+
+## Showcase flow
+
+### Live physics object
+
+1. Aim at a native physics object such as a Grove Street box and use `/wotarget`.
+2. A blue halo, 3D `PHYSICS OBJECT` label, live coordinates, and a top banner follow the object.
+3. Push it normally with the player or a vehicle. The visuals track the GTA-owned object in real time.
+4. Shoot or break it. Damage flashes red with the loss value; destruction displays `OBJECT BROKEN`.
+
+This makes the scripting bridge visible without moving the object from Lua: GTA still owns the physics, while Lua observes and reacts to it.
+
+### Physics objective
+
+1. Select a movable object with `/wotarget`.
+2. Use `/woobjective`.
+3. A green destination zone is placed roughly five metres beyond the object in the direction you are facing it.
+4. Physically push the object into the zone.
+5. The zone and HUD switch to `OBJECT DELIVERED!` when the live `worldobject` position enters the goal.
+
+This is a tiny gameplay example driven entirely by the native object's GTA physics and its Lua-visible transform.
+
+## Commands
+
+- `/wotarget` — aim the camera at a native physics object and bind the closest `worldobject` proxy; also enables the showcase visuals.
+- `/woobjective` — create the green push objective for the selected object.
+- `/woshowcase` — toggle the halo, 3D labels, damage/break feedback, and showcase HUD.
+- `/wolist` — list currently known proxies.
+- `/wopull` — move the selected proxy two metres in front of the local player.
+- `/worotate` — rotate the selected proxy 30 degrees through `getElementMatrix` / `setElementMatrix`.
+- `/womatrix` — dump the selected proxy matrix.
+- `/wodestroy` — verify scripts cannot destroy the GTA-owned native object/proxy.
+- `/woclear` — clear the selected object and local showcase state.
+
+Damage, break, stream-in and stream-out events are also logged to chat/debug output. For the lifetime test, select an object, move far enough away to stream it out, then return; the same Lua element should report `STREAM OUT ... [TARGET PRESERVED]` followed by `STREAM IN ... [SAME TARGET]`.
+
+This resource is not auto-deployed. Copy it to the VM server resources directory before starting it.

--- a/test-resources/world-object-scripting-harness/client.lua
+++ b/test-resources/world-object-scripting-harness/client.lua
@@ -1,0 +1,409 @@
+local target
+local lastWorldModel
+local targetStreamedIn = false
+
+local showcaseEnabled = true
+local targetMarker
+local damagePulseUntil = 0
+local damagePulseText
+local breakPulseUntil = 0
+local breakPulsePosition
+local breakFlashMarker
+local breakFlashUntil = 0
+
+local objective
+local objectiveMarker
+
+local function log(message, r, g, b)
+    outputChatBox("[world-object] " .. message, r or 220, g or 220, b or 220)
+    outputDebugString("[world-object] " .. message)
+end
+
+local function getWorldObjects()
+    return getElementsByType("worldobject", root, true)
+end
+
+local function distanceSquared(x1, y1, z1, x2, y2, z2)
+    local dx, dy, dz = x1 - x2, y1 - y2, z1 - z2
+    return dx * dx + dy * dy + dz * dz
+end
+
+local function destroyLocalElement(element)
+    if isElement(element) then
+        destroyElement(element)
+    end
+end
+
+local function clearTargetMarker()
+    destroyLocalElement(targetMarker)
+    targetMarker = nil
+end
+
+local function clearBreakFlash()
+    destroyLocalElement(breakFlashMarker)
+    breakFlashMarker = nil
+    breakFlashUntil = 0
+end
+
+local function clearObjective()
+    destroyLocalElement(objectiveMarker)
+    objectiveMarker = nil
+    objective = nil
+end
+
+local function ensureTargetMarker()
+    if not showcaseEnabled or not isElement(target) or not targetStreamedIn then
+        clearTargetMarker()
+        return
+    end
+
+    local x, y, z = getElementPosition(target)
+    if not x then
+        clearTargetMarker()
+        return
+    end
+
+    if not isElement(targetMarker) then
+        targetMarker = createMarker(x, y, z + 0.15, "corona", 1.15, 70, 190, 255, 145)
+    else
+        setElementPosition(targetMarker, x, y, z + 0.15)
+    end
+
+    local now = getTickCount()
+    if now < breakPulseUntil or now < damagePulseUntil then
+        setMarkerColor(targetMarker, 255, 70, 55, 190)
+    else
+        setMarkerColor(targetMarker, 70, 190, 255, 145)
+    end
+end
+
+local function draw3DLabel(text, x, y, z, color, scale)
+    local sx, sy = getScreenFromWorldPosition(x, y, z, 0.08)
+    if not sx then
+        return
+    end
+
+    local width = 360
+    local height = 50
+    scale = scale or 1.0
+
+    dxDrawText(text, sx - width / 2 + 2, sy - height / 2 + 2, sx + width / 2 + 2, sy + height / 2 + 2,
+        tocolor(0, 0, 0, 210), scale, "default-bold", "center", "center", false, false, false, true)
+    dxDrawText(text, sx - width / 2, sy - height / 2, sx + width / 2, sy + height / 2,
+        color, scale, "default-bold", "center", "center", false, false, false, true)
+end
+
+local function findClosestWorldObject(x, y, z, maxDistance)
+    local best, bestDistance = nil, (maxDistance or 5) ^ 2
+    for _, element in ipairs(getWorldObjects()) do
+        local ex, ey, ez = getElementPosition(element)
+        if ex then
+            local distance = distanceSquared(x, y, z, ex, ey, ez)
+            if distance < bestDistance then
+                best, bestDistance = element, distance
+            end
+        end
+    end
+    return best, math.sqrt(bestDistance)
+end
+
+local function targetFromCamera()
+    local cx, cy, cz, lx, ly, lz = getCameraMatrix()
+    local dx, dy, dz = lx - cx, ly - cy, lz - cz
+    local length = math.sqrt(dx * dx + dy * dy + dz * dz)
+    if length == 0 then
+        return false
+    end
+
+    local range = 100
+    local ex, ey, ez = cx + dx / length * range, cy + dy / length * range, cz + dz / length * range
+    local result = {processLineOfSight(cx, cy, cz, ex, ey, ez, true, true, true, true, true, false, false, false, localPlayer, true)}
+    if not result[1] then
+        log("LOS: no hit", 255, 180, 120)
+        return false
+    end
+
+    local hitX, hitY, hitZ = result[2], result[3], result[4]
+    lastWorldModel = result[12]
+    local candidate, distance = findClosestWorldObject(hitX, hitY, hitZ, 8)
+    if not candidate then
+        log(("LOS hit %.2f %.2f %.2f, model=%s, but no worldobject proxy nearby"):format(hitX, hitY, hitZ, tostring(lastWorldModel)), 255, 180, 120)
+        return false
+    end
+
+    clearObjective()
+    target = candidate
+    targetStreamedIn = true
+    damagePulseUntil = 0
+    breakPulseUntil = 0
+    clearBreakFlash()
+    ensureTargetMarker()
+
+    local x, y, z = getElementPosition(target)
+    log(("target=%s model(LOS)=%s distance=%.2f pos=%.3f %.3f %.3f"):format(tostring(target), tostring(lastWorldModel), distance, x, y, z), 120, 255, 160)
+    return true
+end
+
+addCommandHandler("wotarget", targetFromCamera)
+
+addCommandHandler("wolist", function()
+    local elements = getWorldObjects()
+    log(("%d worldobject proxies"):format(#elements), 120, 200, 255)
+    for index, element in ipairs(elements) do
+        if index > 12 then
+            log(("... %d more"):format(#elements - 12))
+            break
+        end
+        local x, y, z = getElementPosition(element)
+        log(("#%d %s @ %.2f %.2f %.2f%s"):format(index, tostring(element), x or 0, y or 0, z or 0, element == target and " [TARGET]" or ""))
+    end
+end)
+
+addCommandHandler("woshowcase", function()
+    showcaseEnabled = not showcaseEnabled
+    if not showcaseEnabled then
+        clearTargetMarker()
+    else
+        ensureTargetMarker()
+    end
+    log("showcase visuals => " .. tostring(showcaseEnabled), 120, 220, 255)
+end)
+
+addCommandHandler("woobjective", function()
+    if not isElement(target) then
+        log("No target. Aim at a native physics object and use /wotarget first.", 255, 180, 120)
+        return
+    end
+
+    local px, py = getElementPosition(localPlayer)
+    local tx, ty, tz = getElementPosition(target)
+    if not tx then
+        log("Target transform unavailable.", 255, 120, 120)
+        return
+    end
+
+    local dx, dy = tx - px, ty - py
+    local length = math.sqrt(dx * dx + dy * dy)
+    if length < 0.1 then
+        local _, _, heading = getElementRotation(localPlayer)
+        local radians = math.rad(heading)
+        dx, dy = -math.sin(radians), math.cos(radians)
+        length = 1
+    end
+
+    local pushDistance = 5.0
+    local goalX = tx + dx / length * pushDistance
+    local goalY = ty + dy / length * pushDistance
+    local goalZ = tz - 0.65
+
+    clearObjective()
+    objectiveMarker = createMarker(goalX, goalY, goalZ, "cylinder", 2.6, 70, 255, 120, 105)
+    objective = {
+        target = target,
+        x = goalX,
+        y = goalY,
+        z = goalZ,
+        radius = 1.55,
+        complete = false,
+        completedAt = 0,
+    }
+
+    log("PHYSICS OBJECTIVE: push the target into the green zone.", 80, 255, 130)
+end)
+
+addCommandHandler("wopull", function()
+    if not isElement(target) then
+        log("No target. Aim at a native physics object and use /wotarget first.", 255, 180, 120)
+        return
+    end
+
+    local x, y, z = getElementPosition(localPlayer)
+    local _, _, heading = getElementRotation(localPlayer)
+    local radians = math.rad(heading)
+    local ok = setElementPosition(target, x - math.sin(radians) * 2.0, y + math.cos(radians) * 2.0, z + 0.4)
+    log("setElementPosition(target) => " .. tostring(ok), ok and 120 or 255, ok and 255 or 120, 160)
+end)
+
+addCommandHandler("worotate", function()
+    if not isElement(target) then
+        log("No target. Use /wotarget first.", 255, 180, 120)
+        return
+    end
+
+    local matrix = getElementMatrix(target)
+    if not matrix then
+        log("getElementMatrix(target) failed", 255, 120, 120)
+        return
+    end
+
+    local radians = math.rad(30)
+    local c, s = math.cos(radians), math.sin(radians)
+    local right = {matrix[1][1], matrix[1][2], matrix[1][3]}
+    local front = {matrix[2][1], matrix[2][2], matrix[2][3]}
+    for axis = 1, 3 do
+        matrix[1][axis] = right[axis] * c + front[axis] * s
+        matrix[2][axis] = front[axis] * c - right[axis] * s
+    end
+
+    local ok = setElementMatrix(target, matrix)
+    log("setElementMatrix(target, +30deg local Z) => " .. tostring(ok), ok and 120 or 255, ok and 255 or 120, 160)
+end)
+
+addCommandHandler("womatrix", function()
+    if not isElement(target) then
+        log("No target. Use /wotarget first.", 255, 180, 120)
+        return
+    end
+
+    local matrix = getElementMatrix(target)
+    if not matrix then
+        log("getElementMatrix(target) failed", 255, 120, 120)
+        return
+    end
+
+    for row = 1, 4 do
+        log(("M%d %.4f %.4f %.4f %.4f"):format(row, matrix[row][1], matrix[row][2], matrix[row][3], matrix[row][4]))
+    end
+end)
+
+addCommandHandler("wodestroy", function()
+    if not isElement(target) then
+        log("No target. Use /wotarget first.", 255, 180, 120)
+        return
+    end
+
+    local before = target
+    local ok = destroyElement(target)
+    log(("destroyElement(%s) => %s; still valid=%s (expected: false / true)"):format(tostring(before), tostring(ok), tostring(isElement(before))), ok and 255 or 120, ok and 120 or 255, 120)
+end)
+
+addCommandHandler("woclear", function()
+    clearTargetMarker()
+    clearObjective()
+    clearBreakFlash()
+    target = nil
+    lastWorldModel = nil
+    targetStreamedIn = false
+    log("target/showcase cleared")
+end)
+
+addEventHandler("onClientWorldObjectDamage", root, function(loss, attacker, model, x, y, z)
+    log(("DAMAGE source=%s model=%s loss=%.3f attacker=%s @ %.2f %.2f %.2f"):format(tostring(source), tostring(model), tonumber(loss) or 0, tostring(attacker), x, y, z), 255, 220, 120)
+
+    if source == target then
+        damagePulseUntil = getTickCount() + 700
+        damagePulseText = ("DAMAGE %.1f"):format(tonumber(loss) or 0)
+    end
+end)
+
+addEventHandler("onClientWorldObjectBreak", root, function(attacker, model, x, y, z)
+    log(("BREAK source=%s model=%s attacker=%s @ %.2f %.2f %.2f"):format(tostring(source), tostring(model), tostring(attacker), x, y, z), 255, 140, 120)
+
+    if source == target then
+        local now = getTickCount()
+        breakPulseUntil = now + 1800
+        breakPulsePosition = {x, y, z}
+        clearBreakFlash()
+        breakFlashMarker = createMarker(x, y, z + 0.25, "corona", 2.2, 255, 70, 45, 190)
+        breakFlashUntil = now + 500
+
+        if objective and objective.target == source and not objective.complete then
+            clearObjective()
+        end
+    end
+end)
+
+addEventHandler("onClientElementStreamIn", root, function()
+    if getElementType(source) ~= "worldobject" then
+        return
+    end
+
+    if source == target then
+        targetStreamedIn = true
+        ensureTargetMarker()
+    end
+
+    log(("STREAM IN %s%s"):format(tostring(source), source == target and " [SAME TARGET]" or ""), 120, 255, 160)
+end)
+
+addEventHandler("onClientElementStreamOut", root, function()
+    if getElementType(source) ~= "worldobject" then
+        return
+    end
+
+    if source == target then
+        targetStreamedIn = false
+        clearTargetMarker()
+    end
+
+    log(("STREAM OUT %s%s"):format(tostring(source), source == target and " [TARGET PRESERVED]" or ""), 160, 200, 255)
+end)
+
+addEventHandler("onClientRender", root, function()
+    local now = getTickCount()
+
+    if isElement(breakFlashMarker) and now >= breakFlashUntil then
+        clearBreakFlash()
+    end
+
+    if objective then
+        if not isElement(objective.target) then
+            clearObjective()
+        elseif not objective.complete then
+            local x, y, z = getElementPosition(objective.target)
+            if x then
+                local dx, dy = x - objective.x, y - objective.y
+                local horizontalDistance = math.sqrt(dx * dx + dy * dy)
+                if horizontalDistance <= objective.radius and math.abs(z - objective.z) <= 2.0 then
+                    objective.complete = true
+                    objective.completedAt = now
+                    setMarkerColor(objectiveMarker, 100, 255, 140, 190)
+                    log("OBJECT DELIVERED! Native GTA physics drove a Lua gameplay objective.", 100, 255, 140)
+                end
+            end
+        elseif now - objective.completedAt >= 2500 then
+            clearObjective()
+        end
+    end
+
+    ensureTargetMarker()
+
+    if showcaseEnabled and isElement(target) then
+        local x, y, z = getElementPosition(target)
+        if x then
+            if targetStreamedIn then
+                dxDrawLine3D(x, y, z + 0.15, x, y, z + 1.25, tocolor(70, 190, 255, 210), 2.0)
+            end
+
+            local labelColor = tocolor(90, 210, 255, 245)
+            local label = ("PHYSICS OBJECT\npos %.2f  %.2f  %.2f"):format(x, y, z)
+            draw3DLabel(label, x, y, z + 1.55, labelColor, 1.0)
+
+            if now < damagePulseUntil then
+                draw3DLabel(damagePulseText or "DAMAGE", x, y, z + 2.2, tocolor(255, 85, 65, 255), 1.2)
+            end
+        end
+
+        if now < breakPulseUntil and breakPulsePosition then
+            draw3DLabel("OBJECT BROKEN", breakPulsePosition[1], breakPulsePosition[2], breakPulsePosition[3] + 1.8,
+                tocolor(255, 80, 55, 255), 1.25)
+        end
+    end
+
+    if objective then
+        local objectiveColor = objective.complete and tocolor(100, 255, 140, 255) or tocolor(80, 255, 130, 245)
+        local objectiveText = objective.complete and "OBJECT DELIVERED!" or "PUSH INTO THE ZONE"
+        draw3DLabel(objectiveText, objective.x, objective.y, objective.z + 1.1, objectiveColor, 1.15)
+    end
+end)
+
+addEventHandler("onClientResourceStop", resourceRoot, function()
+    clearTargetMarker()
+    clearObjective()
+    clearBreakFlash()
+end)
+
+addEventHandler("onClientResourceStart", resourceRoot, function()
+    log("showcase ready: /wotarget -> push/shoot | /woobjective -> push into green zone", 120, 255, 160)
+    log("tools: /wolist /woshowcase /wopull /worotate /womatrix /wodestroy /woclear", 160, 210, 255)
+end)

--- a/test-resources/world-object-scripting-harness/meta.xml
+++ b/test-resources/world-object-scripting-harness/meta.xml
@@ -1,0 +1,4 @@
+<meta>
+    <info author="Neon" name="World object scripting test harness" version="0.1.0" type="script" />
+    <script src="client.lua" type="client" cache="false" />
+</meta>


### PR DESCRIPTION
## Summary

Adds client-side scripting support for GTA-owned dynamic world objects as one checkpoint: native damage/break events, client-only proxies, and an in-game validation/showcase resource.

### Native events
- bridges the existing global native `CObject` damage/break hooks for GTA-owned world objects
- adds `onClientWorldObjectDamage(loss, attacker, model, x, y, z)`
- adds `onClientWorldObjectBreak(attacker, model, x, y, z)`
- keeps existing MTA-created object handlers unchanged via fallback forwarding

### Client-only proxies
- exposes eligible GTA-owned dynamic objects as local `worldobject` elements
- identifies them by `OBJECT_GAME` + persistent linked dummy
- keeps proxy identity keyed to the dummy across `ConvertToDummyObject` / `ConvertToRealObject` churn
- never inserts adopted objects into `CPoolsSA::m_objectPool`
- never owns/deletes the native `CObject` and marks proxies as system elements
- supports live `getElementPosition` / `setElementPosition`
- supports full transform access through `getElementMatrix` / `setElementMatrix`
- emits normal `onClientElementStreamOut` / `onClientElementStreamIn` on native object detach/reattach
- validates dummy lifetime against GTA's dummy pool and guards object-slot address reuse

The manager scans the native object pool from the normal client `PreFrame` path instead of adding another naked conversion hook. Damage/break callbacks also adopt lazily so an object cannot miss an event just because it appeared between scans.

## Harness / showcase

Added `test-resources/world-object-scripting-harness` with:
- `/wotarget` — select a native physics object and enable live showcase visuals
- `/woobjective` — create a small `PUSH INTO THE ZONE` physics objective
- `/woshowcase` — toggle the in-world showcase visuals
- `/wolist`
- `/wopull`
- `/worotate`
- `/womatrix`
- `/wodestroy`
- `/woclear`

The showcase follows the GTA-owned object with an in-world halo, 3D live position, damage feedback and break feedback. The objective demonstrates a gameplay use-case by completing when the physically pushed native object enters a Lua-tracked destination zone.

It also logs damage/break and stream transitions and checks that the same Lua element survives native stream-out/in.

## Validation

The base feature has been built and exercised in-game against movable/breakable native objects. The showcase additions still need a quick in-game pass after syncing the updated resource.

Suggested validation:
1. deploy/restart `test-resources/world-object-scripting-harness`
2. select a Grove Street box with `/wotarget`, push it and confirm the halo/position follows it
3. shoot/break the selected object and confirm the red damage/break feedback
4. select another movable object, run `/woobjective`, physically push it into the green zone and confirm `OBJECT DELIVERED!`
5. leave streaming range and return, verifying the same target reports STREAM OUT then STREAM IN
6. run `/wodestroy` and verify the native object/proxy remains valid