### PR TITLE
Add runtime collision data generation

### DIFF
--- a/Client/mods/deathmatch/logic/CClientColModel.cpp
+++ b/Client/mods/deathmatch/logic/CClientColModel.cpp
@@ -51,6 +51,37 @@ bool CClientColModel::Load(bool isRaw, SString input)
     }
 }
 
+bool CClientColModel::LoadGenerated(SString buffer)
+{
+    if (m_pColModel)
+        return false;
+
+    m_pColModel = g_pGame->GetRenderWare()->ReadCOL(std::move(buffer));
+    return m_pColModel != nullptr;
+}
+
+bool CClientColModel::SetGenerated(SString buffer)
+{
+    if (!m_pColModel)
+        return false;
+
+    CColModel* pNewColModel = g_pGame->GetRenderWare()->ReadCOL(std::move(buffer));
+    if (!pNewColModel)
+        return false;
+
+    for (unsigned short usModel : m_Replaced)
+    {
+        CModelInfo* pModelInfo = g_pGame->GetModelInfo(usModel);
+        if (pModelInfo)
+            pModelInfo->SetColModel(pNewColModel);
+    }
+
+    CColModel* pOldColModel = m_pColModel;
+    m_pColModel = pNewColModel;
+    pOldColModel->Destroy();
+    return true;
+}
+
 bool CClientColModel::LoadFromFile(SString filePath)
 {
     SString buffer;

--- a/Client/mods/deathmatch/logic/CClientColModel.h
+++ b/Client/mods/deathmatch/logic/CClientColModel.h
@@ -25,6 +25,8 @@ public:
     eClientEntityType GetType() const { return CCLIENTCOL; }
 
     bool Load(bool isRaw, SString input);
+    bool LoadGenerated(SString buffer);
+    bool SetGenerated(SString buffer);
 
     bool IsLoaded() { return m_pColModel != NULL; };
 

--- a/Client/mods/deathmatch/logic/CRuntimeColModel.cpp
+++ b/Client/mods/deathmatch/logic/CRuntimeColModel.cpp
@@ -1,0 +1,389 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  PURPOSE:     Runtime collision model serialization
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+#include "CRuntimeColModel.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <limits>
+
+namespace RuntimeCollision
+{
+    namespace
+    {
+#pragma pack(push, 1)
+        struct ColFileHeader
+        {
+            char          version[4];
+            std::uint32_t size;
+            char          name[24];
+        };
+
+        struct SurfaceRecord
+        {
+            std::uint8_t material;
+            std::uint8_t piece;
+            std::uint8_t brightness;
+            std::uint8_t lighting;
+        };
+
+        struct BoundsRecord
+        {
+            float radius;
+            float centerX;
+            float centerY;
+            float centerZ;
+            float minX;
+            float minY;
+            float minZ;
+            float maxX;
+            float maxY;
+            float maxZ;
+        };
+
+        struct SphereRecord
+        {
+            float         radius;
+            float         x;
+            float         y;
+            float         z;
+            SurfaceRecord surface;
+        };
+
+        struct BoxRecord
+        {
+            float         minX;
+            float         minY;
+            float         minZ;
+            float         maxX;
+            float         maxY;
+            float         maxZ;
+            SurfaceRecord surface;
+        };
+
+        struct VertexRecord
+        {
+            float x;
+            float y;
+            float z;
+        };
+
+        struct FaceRecord
+        {
+            std::uint32_t a;
+            std::uint32_t b;
+            std::uint32_t c;
+            SurfaceRecord surface;
+        };
+#pragma pack(pop)
+
+        static_assert(sizeof(ColFileHeader) == 0x20);
+        static_assert(sizeof(SurfaceRecord) == 0x4);
+        static_assert(sizeof(BoundsRecord) == 0x28);
+        static_assert(sizeof(SphereRecord) == 0x14);
+        static_assert(sizeof(BoxRecord) == 0x1C);
+        static_assert(sizeof(VertexRecord) == 0x0C);
+        static_assert(sizeof(FaceRecord) == 0x10);
+
+        constexpr std::size_t kMaxNativeCount = std::numeric_limits<std::uint16_t>::max();
+        constexpr std::size_t kMaxNativeVertices = kMaxNativeCount + 1;
+        constexpr std::uint8_t kMaxSurfaceMaterial = 178;
+        constexpr float kMinCompressedVertex = -256.0f;
+        constexpr float kMaxCompressedVertex = 32767.0f / 128.0f;
+
+        bool IsFinite(float value)
+        {
+            return std::isfinite(value);
+        }
+
+        bool IsFinite(const CVector& value)
+        {
+            return IsFinite(value.fX) && IsFinite(value.fY) && IsFinite(value.fZ);
+        }
+
+        bool ValidateMaterial(std::uint8_t material, std::string& outError)
+        {
+            if (material <= kMaxSurfaceMaterial)
+                return true;
+
+            outError = "material must be in range 0-178";
+            return false;
+        }
+
+        SurfaceRecord MakeSurface(std::uint8_t material)
+        {
+            return SurfaceRecord{material, 0, 0, 0xFF};
+        }
+
+        template <class T>
+        void Append(std::string& buffer, const T& value)
+        {
+            buffer.append(reinterpret_cast<const char*>(&value), sizeof(value));
+        }
+
+        void ExtendBounds(const CVector& point, CVector& minimum, CVector& maximum, bool& initialized)
+        {
+            if (!initialized)
+            {
+                minimum = point;
+                maximum = point;
+                initialized = true;
+                return;
+            }
+
+            minimum.fX = std::min(minimum.fX, point.fX);
+            minimum.fY = std::min(minimum.fY, point.fY);
+            minimum.fZ = std::min(minimum.fZ, point.fZ);
+            maximum.fX = std::max(maximum.fX, point.fX);
+            maximum.fY = std::max(maximum.fY, point.fY);
+            maximum.fZ = std::max(maximum.fZ, point.fZ);
+        }
+
+        bool IsCompressedVertexInRange(const CVector& vertex)
+        {
+            return vertex.fX >= kMinCompressedVertex && vertex.fX <= kMaxCompressedVertex && vertex.fY >= kMinCompressedVertex &&
+                   vertex.fY <= kMaxCompressedVertex && vertex.fZ >= kMinCompressedVertex && vertex.fZ <= kMaxCompressedVertex;
+        }
+    }  // namespace
+
+    bool BuildCOLBuffer(const Model& model, std::string& outBuffer, std::string& outError)
+    {
+        outBuffer.clear();
+        outError.clear();
+
+        if (model.spheres.empty() && model.boxes.empty() && model.meshes.empty())
+        {
+            outError = "collision must contain at least one sphere, box, or mesh";
+            return false;
+        }
+
+        if (model.spheres.size() > kMaxNativeCount)
+        {
+            outError = "too many spheres";
+            return false;
+        }
+
+        if (model.boxes.size() > kMaxNativeCount)
+        {
+            outError = "too many boxes";
+            return false;
+        }
+
+        std::size_t totalVertices = 0;
+        std::size_t totalTriangles = 0;
+
+        for (const Mesh& mesh : model.meshes)
+        {
+            if (!ValidateMaterial(mesh.material, outError))
+                return false;
+
+            if (mesh.vertices.empty())
+            {
+                outError = "mesh must contain vertices";
+                return false;
+            }
+
+            if (mesh.indices.empty() || mesh.indices.size() % 3 != 0)
+            {
+                outError = "mesh indices must contain complete triangles";
+                return false;
+            }
+
+            if (mesh.vertices.size() > kMaxNativeVertices - totalVertices)
+            {
+                outError = "combined mesh vertex count exceeds 65536";
+                return false;
+            }
+
+            totalVertices += mesh.vertices.size();
+
+            const std::size_t meshTriangles = mesh.indices.size() / 3;
+            if (meshTriangles > kMaxNativeCount - totalTriangles)
+            {
+                outError = "combined triangle count exceeds 65535";
+                return false;
+            }
+
+            totalTriangles += meshTriangles;
+        }
+
+        std::vector<VertexRecord> vertices;
+        std::vector<FaceRecord>   faces;
+        vertices.reserve(totalVertices);
+        faces.reserve(totalTriangles);
+
+        CVector boundsMin;
+        CVector boundsMax;
+        bool    boundsInitialized = false;
+
+        for (const Sphere& sphere : model.spheres)
+        {
+            if (!IsFinite(sphere.position) || !IsFinite(sphere.radius) || sphere.radius <= 0.0f)
+            {
+                outError = "sphere position and radius must be finite, with radius > 0";
+                return false;
+            }
+
+            if (!ValidateMaterial(sphere.material, outError))
+                return false;
+
+            CVector minimum{sphere.position.fX - sphere.radius, sphere.position.fY - sphere.radius, sphere.position.fZ - sphere.radius};
+            CVector maximum{sphere.position.fX + sphere.radius, sphere.position.fY + sphere.radius, sphere.position.fZ + sphere.radius};
+            if (!IsFinite(minimum) || !IsFinite(maximum))
+            {
+                outError = "sphere bounds overflowed";
+                return false;
+            }
+
+            ExtendBounds(minimum, boundsMin, boundsMax, boundsInitialized);
+            ExtendBounds(maximum, boundsMin, boundsMax, boundsInitialized);
+        }
+
+        for (const Box& box : model.boxes)
+        {
+            if (!IsFinite(box.position) || !IsFinite(box.size) || box.size.fX <= 0.0f || box.size.fY <= 0.0f || box.size.fZ <= 0.0f)
+            {
+                outError = "box position and size must be finite, with all size components > 0";
+                return false;
+            }
+
+            if (!ValidateMaterial(box.material, outError))
+                return false;
+
+            const CVector half{box.size.fX * 0.5f, box.size.fY * 0.5f, box.size.fZ * 0.5f};
+            CVector       minimum{box.position.fX - half.fX, box.position.fY - half.fY, box.position.fZ - half.fZ};
+            CVector       maximum{box.position.fX + half.fX, box.position.fY + half.fY, box.position.fZ + half.fZ};
+            if (!IsFinite(minimum) || !IsFinite(maximum))
+            {
+                outError = "box bounds overflowed";
+                return false;
+            }
+
+            ExtendBounds(minimum, boundsMin, boundsMax, boundsInitialized);
+            ExtendBounds(maximum, boundsMin, boundsMax, boundsInitialized);
+        }
+
+        std::size_t vertexBase = 0;
+        for (const Mesh& mesh : model.meshes)
+        {
+            for (const CVector& vertex : mesh.vertices)
+            {
+                if (!IsFinite(vertex))
+                {
+                    outError = "mesh vertices must be finite";
+                    return false;
+                }
+
+                if (!IsCompressedVertexInRange(vertex))
+                {
+                    outError = "mesh vertex coordinate exceeds GTA collision range [-256, 255.9921875]";
+                    return false;
+                }
+
+                vertices.push_back(VertexRecord{vertex.fX, vertex.fY, vertex.fZ});
+                ExtendBounds(vertex, boundsMin, boundsMax, boundsInitialized);
+            }
+
+            for (std::size_t index = 0; index < mesh.indices.size(); index += 3)
+            {
+                const std::uint32_t localA = mesh.indices[index];
+                const std::uint32_t localB = mesh.indices[index + 1];
+                const std::uint32_t localC = mesh.indices[index + 2];
+
+                if (localA >= mesh.vertices.size() || localB >= mesh.vertices.size() || localC >= mesh.vertices.size())
+                {
+                    outError = "mesh triangle index references a missing vertex";
+                    return false;
+                }
+
+                const std::size_t globalA = vertexBase + localA;
+                const std::size_t globalB = vertexBase + localB;
+                const std::size_t globalC = vertexBase + localC;
+                if (globalA > kMaxNativeCount || globalB > kMaxNativeCount || globalC > kMaxNativeCount)
+                {
+                    outError = "mesh triangle index exceeds 65535";
+                    return false;
+                }
+
+                faces.push_back(FaceRecord{static_cast<std::uint32_t>(globalA), static_cast<std::uint32_t>(globalB),
+                                           static_cast<std::uint32_t>(globalC), MakeSurface(mesh.material)});
+            }
+
+            vertexBase += mesh.vertices.size();
+        }
+
+        if (!boundsInitialized)
+        {
+            outError = "collision has no bounds";
+            return false;
+        }
+
+        const CVector center{(boundsMin.fX + boundsMax.fX) * 0.5f, (boundsMin.fY + boundsMax.fY) * 0.5f, (boundsMin.fZ + boundsMax.fZ) * 0.5f};
+        const double  extentX = static_cast<double>(boundsMax.fX) - center.fX;
+        const double  extentY = static_cast<double>(boundsMax.fY) - center.fY;
+        const double  extentZ = static_cast<double>(boundsMax.fZ) - center.fZ;
+        const double  radiusDouble = std::sqrt(extentX * extentX + extentY * extentY + extentZ * extentZ);
+
+        if (!std::isfinite(radiusDouble) || radiusDouble <= 0.0 || radiusDouble > std::numeric_limits<float>::max())
+        {
+            outError = "collision bounds produce an invalid bounding sphere";
+            return false;
+        }
+
+        const BoundsRecord bounds{static_cast<float>(radiusDouble), center.fX, center.fY, center.fZ, boundsMin.fX, boundsMin.fY,
+                                  boundsMin.fZ, boundsMax.fX, boundsMax.fY, boundsMax.fZ};
+
+        std::string payload;
+        payload.reserve(sizeof(bounds) + sizeof(std::uint32_t) * 5 + model.spheres.size() * sizeof(SphereRecord) +
+                        model.boxes.size() * sizeof(BoxRecord) + vertices.size() * sizeof(VertexRecord) + faces.size() * sizeof(FaceRecord));
+
+        Append(payload, bounds);
+
+        const std::uint32_t sphereCount = static_cast<std::uint32_t>(model.spheres.size());
+        Append(payload, sphereCount);
+        for (const Sphere& sphere : model.spheres)
+        {
+            Append(payload, SphereRecord{sphere.radius, sphere.position.fX, sphere.position.fY, sphere.position.fZ, MakeSurface(sphere.material)});
+        }
+
+        const std::uint32_t lineCount = 0;
+        Append(payload, lineCount);
+
+        const std::uint32_t boxCount = static_cast<std::uint32_t>(model.boxes.size());
+        Append(payload, boxCount);
+        for (const Box& box : model.boxes)
+        {
+            const CVector half{box.size.fX * 0.5f, box.size.fY * 0.5f, box.size.fZ * 0.5f};
+            Append(payload, BoxRecord{box.position.fX - half.fX, box.position.fY - half.fY, box.position.fZ - half.fZ,
+                                      box.position.fX + half.fX, box.position.fY + half.fY, box.position.fZ + half.fZ,
+                                      MakeSurface(box.material)});
+        }
+
+        const std::uint32_t vertexCount = static_cast<std::uint32_t>(vertices.size());
+        Append(payload, vertexCount);
+        for (const VertexRecord& vertex : vertices)
+            Append(payload, vertex);
+
+        const std::uint32_t triangleCount = static_cast<std::uint32_t>(faces.size());
+        Append(payload, triangleCount);
+        for (const FaceRecord& face : faces)
+            Append(payload, face);
+
+        ColFileHeader header{};
+        std::memcpy(header.version, "COLL", 4);
+        std::memcpy(header.name, "runtime", 7);
+        header.size = static_cast<std::uint32_t>(sizeof(header) - 8 + payload.size());
+
+        outBuffer.reserve(sizeof(header) + payload.size());
+        Append(outBuffer, header);
+        outBuffer.append(payload);
+        return true;
+    }
+}  // namespace RuntimeCollision

--- a/Client/mods/deathmatch/logic/CRuntimeColModel.h
+++ b/Client/mods/deathmatch/logic/CRuntimeColModel.h
@@ -1,0 +1,47 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  PURPOSE:     Runtime collision model serialization
+ *
+ *****************************************************************************/
+
+#pragma once
+
+#include <CVector.h>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace RuntimeCollision
+{
+    struct Sphere
+    {
+        CVector      position;
+        float        radius = 0.0f;
+        std::uint8_t material = 0;
+    };
+
+    struct Box
+    {
+        CVector      position;
+        CVector      size;
+        std::uint8_t material = 0;
+    };
+
+    struct Mesh
+    {
+        std::vector<CVector>       vertices;
+        std::vector<std::uint32_t> indices;
+        std::uint8_t               material = 0;
+    };
+
+    struct Model
+    {
+        std::vector<Sphere> spheres;
+        std::vector<Box>    boxes;
+        std::vector<Mesh>   meshes;
+    };
+
+    bool BuildCOLBuffer(const Model& model, std::string& outBuffer, std::string& outError);
+}  // namespace RuntimeCollision

--- a/Client/mods/deathmatch/logic/lua/CLuaCFunctions.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaCFunctions.cpp
@@ -11,6 +11,7 @@
 #include <StdInc.h>
 
 void RegisterRadioPlaybackFunctions();
+void RegisterRuntimeCollisionFunctions();
 
 static std::vector<CLuaCFunction*>             m_sFunctions;
 static std::map<lua_CFunction, CLuaCFunction*> ms_Functions;
@@ -126,6 +127,7 @@ bool CLuaCFunctions::IsRestricted(const char* szName)
 void CLuaCFunctions::RegisterFunctionsWithVM(lua_State* luaVM)
 {
     RegisterRadioPlaybackFunctions();
+    RegisterRuntimeCollisionFunctions();
 
     // Register all our functions to a lua VM
     std::vector<CLuaCFunction*>::const_iterator iter = m_sFunctions.begin();

--- a/Client/mods/deathmatch/logic/luadefs/CLuaRuntimeCollisionDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaRuntimeCollisionDefs.cpp
@@ -1,0 +1,439 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  PURPOSE:     Runtime collision model Lua bindings
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+#include "CLuaEngineDefs.h"
+#include "../CClientColModel.h"
+#include "../CRuntimeColModel.h"
+
+#include <cmath>
+#include <limits>
+#include <string>
+#include <utility>
+
+namespace
+{
+    int AbsoluteIndex(lua_State* luaVM, int index)
+    {
+        return index < 0 ? lua_gettop(luaVM) + index + 1 : index;
+    }
+
+    bool ReadFiniteNumber(lua_State* luaVM, int index, float& outValue, std::string& outError, const std::string& path)
+    {
+        if (!lua_isnumber(luaVM, index))
+        {
+            outError = path + " must be a number";
+            return false;
+        }
+
+        const lua_Number value = lua_tonumber(luaVM, index);
+        if (!std::isfinite(value) || value < -std::numeric_limits<float>::max() || value > std::numeric_limits<float>::max())
+        {
+            outError = path + " must be finite";
+            return false;
+        }
+
+        outValue = static_cast<float>(value);
+        return true;
+    }
+
+    bool ReadVectorTable(lua_State* luaVM, int index, CVector& outValue, std::string& outError, const std::string& path)
+    {
+        index = AbsoluteIndex(luaVM, index);
+        if (!lua_istable(luaVM, index) || lua_objlen(luaVM, index) != 3)
+        {
+            outError = path + " must be a 3-number table";
+            return false;
+        }
+
+        float values[3]{};
+        for (int component = 0; component < 3; ++component)
+        {
+            lua_rawgeti(luaVM, index, component + 1);
+            const bool success = ReadFiniteNumber(luaVM, -1, values[component], outError, path + "[" + std::to_string(component + 1) + "]");
+            lua_pop(luaVM, 1);
+            if (!success)
+                return false;
+        }
+
+        outValue = CVector(values[0], values[1], values[2]);
+        return true;
+    }
+
+    bool ReadVectorField(lua_State* luaVM, int tableIndex, const char* fieldName, CVector& outValue, std::string& outError, const std::string& path)
+    {
+        tableIndex = AbsoluteIndex(luaVM, tableIndex);
+        lua_getfield(luaVM, tableIndex, fieldName);
+        const bool success = ReadVectorTable(luaVM, -1, outValue, outError, path + "." + fieldName);
+        lua_pop(luaVM, 1);
+        return success;
+    }
+
+    bool ReadMaterialField(lua_State* luaVM, int tableIndex, std::uint8_t& outMaterial, std::string& outError, const std::string& path)
+    {
+        tableIndex = AbsoluteIndex(luaVM, tableIndex);
+        lua_getfield(luaVM, tableIndex, "material");
+
+        if (lua_isnil(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            outMaterial = 0;
+            return true;
+        }
+
+        if (!lua_isnumber(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            outError = path + ".material must be an integer in range 0-178";
+            return false;
+        }
+
+        const lua_Number value = lua_tonumber(luaVM, -1);
+        lua_pop(luaVM, 1);
+
+        if (!std::isfinite(value) || std::floor(value) != value || value < 0 || value > 178)
+        {
+            outError = path + ".material must be an integer in range 0-178";
+            return false;
+        }
+
+        outMaterial = static_cast<std::uint8_t>(value);
+        return true;
+    }
+
+    bool ParseSpheres(lua_State* luaVM, int rootIndex, RuntimeCollision::Model& outModel, std::string& outError)
+    {
+        rootIndex = AbsoluteIndex(luaVM, rootIndex);
+        lua_getfield(luaVM, rootIndex, "spheres");
+
+        if (lua_isnil(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            return true;
+        }
+
+        if (!lua_istable(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            outError = "spheres must be a table";
+            return false;
+        }
+
+        const int         arrayIndex = AbsoluteIndex(luaVM, -1);
+        const std::size_t count = lua_objlen(luaVM, arrayIndex);
+        outModel.spheres.reserve(count);
+
+        for (std::size_t i = 1; i <= count; ++i)
+        {
+            lua_rawgeti(luaVM, arrayIndex, static_cast<int>(i));
+            if (!lua_istable(luaVM, -1))
+            {
+                lua_pop(luaVM, 2);
+                outError = "spheres[" + std::to_string(i) + "] must be a table";
+                return false;
+            }
+
+            RuntimeCollision::Sphere sphere;
+            const std::string        path = "spheres[" + std::to_string(i) + "]";
+
+            if (!ReadVectorField(luaVM, -1, "position", sphere.position, outError, path))
+            {
+                lua_pop(luaVM, 2);
+                return false;
+            }
+
+            lua_getfield(luaVM, -1, "radius");
+            const bool radiusOk = ReadFiniteNumber(luaVM, -1, sphere.radius, outError, path + ".radius");
+            lua_pop(luaVM, 1);
+
+            if (!radiusOk || !ReadMaterialField(luaVM, -1, sphere.material, outError, path))
+            {
+                lua_pop(luaVM, 2);
+                return false;
+            }
+
+            outModel.spheres.push_back(sphere);
+            lua_pop(luaVM, 1);
+        }
+
+        lua_pop(luaVM, 1);
+        return true;
+    }
+
+    bool ParseBoxes(lua_State* luaVM, int rootIndex, RuntimeCollision::Model& outModel, std::string& outError)
+    {
+        rootIndex = AbsoluteIndex(luaVM, rootIndex);
+        lua_getfield(luaVM, rootIndex, "boxes");
+
+        if (lua_isnil(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            return true;
+        }
+
+        if (!lua_istable(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            outError = "boxes must be a table";
+            return false;
+        }
+
+        const int         arrayIndex = AbsoluteIndex(luaVM, -1);
+        const std::size_t count = lua_objlen(luaVM, arrayIndex);
+        outModel.boxes.reserve(count);
+
+        for (std::size_t i = 1; i <= count; ++i)
+        {
+            lua_rawgeti(luaVM, arrayIndex, static_cast<int>(i));
+            if (!lua_istable(luaVM, -1))
+            {
+                lua_pop(luaVM, 2);
+                outError = "boxes[" + std::to_string(i) + "] must be a table";
+                return false;
+            }
+
+            RuntimeCollision::Box box;
+            const std::string     path = "boxes[" + std::to_string(i) + "]";
+
+            if (!ReadVectorField(luaVM, -1, "position", box.position, outError, path) ||
+                !ReadVectorField(luaVM, -1, "size", box.size, outError, path) ||
+                !ReadMaterialField(luaVM, -1, box.material, outError, path))
+            {
+                lua_pop(luaVM, 2);
+                return false;
+            }
+
+            outModel.boxes.push_back(box);
+            lua_pop(luaVM, 1);
+        }
+
+        lua_pop(luaVM, 1);
+        return true;
+    }
+
+    bool ParseMeshVertices(lua_State* luaVM, int meshIndex, RuntimeCollision::Mesh& outMesh, std::string& outError, const std::string& path)
+    {
+        meshIndex = AbsoluteIndex(luaVM, meshIndex);
+        lua_getfield(luaVM, meshIndex, "vertices");
+
+        if (!lua_istable(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            outError = path + ".vertices must be a flat number table";
+            return false;
+        }
+
+        const int         verticesIndex = AbsoluteIndex(luaVM, -1);
+        const std::size_t componentCount = lua_objlen(luaVM, verticesIndex);
+        if (componentCount == 0 || componentCount % 3 != 0)
+        {
+            lua_pop(luaVM, 1);
+            outError = path + ".vertices must contain xyz triplets";
+            return false;
+        }
+
+        outMesh.vertices.reserve(componentCount / 3);
+        for (std::size_t i = 1; i <= componentCount; i += 3)
+        {
+            float components[3]{};
+            for (int component = 0; component < 3; ++component)
+            {
+                const std::size_t componentIndex = i + component;
+                lua_rawgeti(luaVM, verticesIndex, static_cast<int>(componentIndex));
+                const bool success = ReadFiniteNumber(luaVM, -1, components[component], outError,
+                                                      path + ".vertices[" + std::to_string(componentIndex) + "]");
+                lua_pop(luaVM, 1);
+                if (!success)
+                {
+                    lua_pop(luaVM, 1);
+                    return false;
+                }
+            }
+
+            outMesh.vertices.emplace_back(components[0], components[1], components[2]);
+        }
+
+        lua_pop(luaVM, 1);
+        return true;
+    }
+
+    bool ParseMeshIndices(lua_State* luaVM, int meshIndex, RuntimeCollision::Mesh& outMesh, std::string& outError, const std::string& path)
+    {
+        meshIndex = AbsoluteIndex(luaVM, meshIndex);
+        lua_getfield(luaVM, meshIndex, "indices");
+
+        if (!lua_istable(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            outError = path + ".indices must be a flat integer table";
+            return false;
+        }
+
+        const int         indicesIndex = AbsoluteIndex(luaVM, -1);
+        const std::size_t indexCount = lua_objlen(luaVM, indicesIndex);
+        if (indexCount == 0 || indexCount % 3 != 0)
+        {
+            lua_pop(luaVM, 1);
+            outError = path + ".indices must contain triangle triplets";
+            return false;
+        }
+
+        outMesh.indices.reserve(indexCount);
+        for (std::size_t i = 1; i <= indexCount; ++i)
+        {
+            lua_rawgeti(luaVM, indicesIndex, static_cast<int>(i));
+
+            if (!lua_isnumber(luaVM, -1))
+            {
+                lua_pop(luaVM, 2);
+                outError = path + ".indices[" + std::to_string(i) + "] must be a non-negative integer";
+                return false;
+            }
+
+            const lua_Number value = lua_tonumber(luaVM, -1);
+            lua_pop(luaVM, 1);
+
+            if (!std::isfinite(value) || std::floor(value) != value || value < 0 || value > std::numeric_limits<std::uint32_t>::max())
+            {
+                lua_pop(luaVM, 1);
+                outError = path + ".indices[" + std::to_string(i) + "] must be a non-negative integer";
+                return false;
+            }
+
+            outMesh.indices.push_back(static_cast<std::uint32_t>(value));
+        }
+
+        lua_pop(luaVM, 1);
+        return true;
+    }
+
+    bool ParseMeshes(lua_State* luaVM, int rootIndex, RuntimeCollision::Model& outModel, std::string& outError)
+    {
+        rootIndex = AbsoluteIndex(luaVM, rootIndex);
+        lua_getfield(luaVM, rootIndex, "meshes");
+
+        if (lua_isnil(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            return true;
+        }
+
+        if (!lua_istable(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            outError = "meshes must be a table";
+            return false;
+        }
+
+        const int         arrayIndex = AbsoluteIndex(luaVM, -1);
+        const std::size_t count = lua_objlen(luaVM, arrayIndex);
+        outModel.meshes.reserve(count);
+
+        for (std::size_t i = 1; i <= count; ++i)
+        {
+            lua_rawgeti(luaVM, arrayIndex, static_cast<int>(i));
+            if (!lua_istable(luaVM, -1))
+            {
+                lua_pop(luaVM, 2);
+                outError = "meshes[" + std::to_string(i) + "] must be a table";
+                return false;
+            }
+
+            RuntimeCollision::Mesh mesh;
+            const std::string      path = "meshes[" + std::to_string(i) + "]";
+
+            if (!ParseMeshVertices(luaVM, -1, mesh, outError, path) || !ParseMeshIndices(luaVM, -1, mesh, outError, path) ||
+                !ReadMaterialField(luaVM, -1, mesh.material, outError, path))
+            {
+                lua_pop(luaVM, 2);
+                return false;
+            }
+
+            outModel.meshes.push_back(std::move(mesh));
+            lua_pop(luaVM, 1);
+        }
+
+        lua_pop(luaVM, 1);
+        return true;
+    }
+
+    bool ParseCollisionTable(lua_State* luaVM, int index, RuntimeCollision::Model& outModel, std::string& outError)
+    {
+        if (!lua_istable(luaVM, index))
+        {
+            outError = "expected collision table";
+            return false;
+        }
+
+        return ParseSpheres(luaVM, index, outModel, outError) && ParseBoxes(luaVM, index, outModel, outError) &&
+               ParseMeshes(luaVM, index, outModel, outError);
+    }
+
+    int RuntimeEngineLoadCOL(lua_State* luaVM)
+    {
+        if (!lua_istable(luaVM, 1))
+            return CLuaEngineDefs::EngineLoadCOL(luaVM);
+
+        RuntimeCollision::Model model;
+        std::string             error;
+        std::string             buffer;
+        if (!ParseCollisionTable(luaVM, 1, model, error) || !RuntimeCollision::BuildCOLBuffer(model, buffer, error))
+            return luaL_error(luaVM, "Bad argument @ 'engineLoadCOL' [Invalid collision data: %s]", error.c_str());
+
+        CLuaMain*  luaMain = CLuaDefs::m_pLuaManager->GetVirtualMachine(luaVM);
+        CResource* resource = luaMain ? luaMain->GetResource() : nullptr;
+        if (!resource)
+        {
+            lua_pushboolean(luaVM, false);
+            return 1;
+        }
+
+        CClientColModel* col = new CClientColModel(CLuaDefs::m_pManager, INVALID_ELEMENT_ID);
+        if (!col->LoadGenerated(SString(buffer)))
+        {
+            delete col;
+            lua_pushboolean(luaVM, false);
+            return 1;
+        }
+
+        col->SetParent(resource->GetResourceCOLModelRoot());
+        lua_pushelement(luaVM, col);
+        return 1;
+    }
+
+    int RuntimeEngineSetCOLData(lua_State* luaVM)
+    {
+        CClientColModel* col = nullptr;
+        CScriptArgReader argStream(luaVM);
+        argStream.ReadUserData(col);
+
+        if (argStream.HasErrors())
+        {
+            const SString error = argStream.GetFullErrorMessage();
+            return luaL_error(luaVM, "%s", error.c_str());
+        }
+
+        if (!lua_istable(luaVM, 2))
+            return luaL_error(luaVM, "Bad argument @ 'engineSetCOLData' [Expected table at argument 2]");
+
+        RuntimeCollision::Model model;
+        std::string             error;
+        std::string             buffer;
+        if (!ParseCollisionTable(luaVM, 2, model, error) || !RuntimeCollision::BuildCOLBuffer(model, buffer, error))
+            return luaL_error(luaVM, "Bad argument @ 'engineSetCOLData' [Invalid collision data: %s]", error.c_str());
+
+        lua_pushboolean(luaVM, col->SetGenerated(SString(buffer)));
+        return 1;
+    }
+}  // namespace
+
+void RegisterRuntimeCollisionFunctions()
+{
+    CLuaCFunctions::AddFunction("engineLoadCOL", RuntimeEngineLoadCOL);
+    CLuaCFunctions::AddFunction("engineSetCOLData", RuntimeEngineSetCOLData);
+}

--- a/Tests/client/CRuntimeColModel_Tests.cpp
+++ b/Tests/client/CRuntimeColModel_Tests.cpp
@@ -1,0 +1,210 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  PURPOSE:     Runtime collision model serializer tests
+ *
+ *****************************************************************************/
+
+#include "../../Client/mods/deathmatch/logic/CRuntimeColModel.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <utility>
+
+namespace
+{
+#pragma pack(push, 1)
+    struct Header
+    {
+        char          version[4];
+        std::uint32_t size;
+        char          name[24];
+    };
+
+    struct Surface
+    {
+        std::uint8_t material;
+        std::uint8_t piece;
+        std::uint8_t brightness;
+        std::uint8_t lighting;
+    };
+
+    struct Bounds
+    {
+        float radius;
+        float centerX;
+        float centerY;
+        float centerZ;
+        float minX;
+        float minY;
+        float minZ;
+        float maxX;
+        float maxY;
+        float maxZ;
+    };
+
+    struct Face
+    {
+        std::uint32_t a;
+        std::uint32_t b;
+        std::uint32_t c;
+        Surface       surface;
+    };
+#pragma pack(pop)
+
+    template <class T>
+    T Read(const std::string& buffer, std::size_t offset)
+    {
+        T value{};
+        EXPECT_LE(offset + sizeof(T), buffer.size());
+        std::memcpy(&value, buffer.data() + offset, sizeof(T));
+        return value;
+    }
+
+    RuntimeCollision::Mesh Triangle(float offset, std::uint8_t material)
+    {
+        RuntimeCollision::Mesh mesh;
+        mesh.material = material;
+        mesh.vertices = {
+            CVector(-1.0f + offset, -1.0f, 0.0f),
+            CVector(1.0f + offset, -1.0f, 0.0f),
+            CVector(offset, 1.0f, 0.0f),
+        };
+        mesh.indices = {0, 1, 2};
+        return mesh;
+    }
+
+    TEST(CRuntimeColModel, SerializesMixedCollision)
+    {
+        RuntimeCollision::Model model;
+        model.spheres.push_back({CVector(0.0f, 0.0f, 1.5f), 1.0f, 2});
+        model.boxes.push_back({CVector(0.0f, 0.0f, 0.0f), CVector(2.0f, 4.0f, 1.0f), 1});
+        model.meshes.push_back(Triangle(0.0f, 3));
+
+        std::string buffer;
+        std::string error;
+        ASSERT_TRUE(RuntimeCollision::BuildCOLBuffer(model, buffer, error)) << error;
+        ASSERT_GE(buffer.size(), sizeof(Header) + sizeof(Bounds));
+
+        const Header header = Read<Header>(buffer, 0);
+        EXPECT_EQ(std::string(header.version, 4), "COLL");
+        EXPECT_EQ(header.size, buffer.size() - 8);
+
+        const Bounds bounds = Read<Bounds>(buffer, sizeof(Header));
+        EXPECT_FLOAT_EQ(bounds.minX, -1.0f);
+        EXPECT_FLOAT_EQ(bounds.minY, -2.0f);
+        EXPECT_FLOAT_EQ(bounds.minZ, -0.5f);
+        EXPECT_FLOAT_EQ(bounds.maxX, 1.0f);
+        EXPECT_FLOAT_EQ(bounds.maxY, 2.0f);
+        EXPECT_FLOAT_EQ(bounds.maxZ, 2.5f);
+
+        std::size_t offset = sizeof(Header) + sizeof(Bounds);
+        EXPECT_EQ(Read<std::uint32_t>(buffer, offset), 1u);
+        offset += sizeof(std::uint32_t) + 0x14;
+
+        EXPECT_EQ(Read<std::uint32_t>(buffer, offset), 0u);
+        offset += sizeof(std::uint32_t);
+
+        EXPECT_EQ(Read<std::uint32_t>(buffer, offset), 1u);
+        offset += sizeof(std::uint32_t) + 0x1C;
+
+        EXPECT_EQ(Read<std::uint32_t>(buffer, offset), 3u);
+        offset += sizeof(std::uint32_t) + 3 * 0x0C;
+
+        EXPECT_EQ(Read<std::uint32_t>(buffer, offset), 1u);
+        offset += sizeof(std::uint32_t);
+
+        const Face face = Read<Face>(buffer, offset);
+        EXPECT_EQ(face.a, 0u);
+        EXPECT_EQ(face.b, 1u);
+        EXPECT_EQ(face.c, 2u);
+        EXPECT_EQ(face.surface.material, 3u);
+        EXPECT_EQ(face.surface.lighting, 0xFFu);
+    }
+
+    TEST(CRuntimeColModel, OffsetsIndicesAcrossMeshes)
+    {
+        RuntimeCollision::Model model;
+        model.meshes.push_back(Triangle(-3.0f, 1));
+        model.meshes.push_back(Triangle(3.0f, 2));
+
+        std::string buffer;
+        std::string error;
+        ASSERT_TRUE(RuntimeCollision::BuildCOLBuffer(model, buffer, error)) << error;
+
+        std::size_t offset = sizeof(Header) + sizeof(Bounds);
+        offset += sizeof(std::uint32_t);  // spheres
+        offset += sizeof(std::uint32_t);  // lines
+        offset += sizeof(std::uint32_t);  // boxes
+
+        const std::uint32_t vertexCount = Read<std::uint32_t>(buffer, offset);
+        EXPECT_EQ(vertexCount, 6u);
+        offset += sizeof(std::uint32_t) + vertexCount * 0x0C;
+
+        const std::uint32_t faceCount = Read<std::uint32_t>(buffer, offset);
+        ASSERT_EQ(faceCount, 2u);
+        offset += sizeof(std::uint32_t);
+
+        const Face first = Read<Face>(buffer, offset);
+        const Face second = Read<Face>(buffer, offset + sizeof(Face));
+
+        EXPECT_EQ(first.a, 0u);
+        EXPECT_EQ(first.b, 1u);
+        EXPECT_EQ(first.c, 2u);
+        EXPECT_EQ(second.a, 3u);
+        EXPECT_EQ(second.b, 4u);
+        EXPECT_EQ(second.c, 5u);
+        EXPECT_EQ(second.surface.material, 2u);
+    }
+
+    TEST(CRuntimeColModel, RejectsMissingGeometry)
+    {
+        RuntimeCollision::Model model;
+        std::string             buffer;
+        std::string             error;
+
+        EXPECT_FALSE(RuntimeCollision::BuildCOLBuffer(model, buffer, error));
+        EXPECT_FALSE(error.empty());
+    }
+
+    TEST(CRuntimeColModel, RejectsInvalidTriangleIndex)
+    {
+        RuntimeCollision::Model model;
+        auto                    mesh = Triangle(0.0f, 0);
+        mesh.indices = {0, 1, 3};
+        model.meshes.push_back(std::move(mesh));
+
+        std::string buffer;
+        std::string error;
+        EXPECT_FALSE(RuntimeCollision::BuildCOLBuffer(model, buffer, error));
+        EXPECT_NE(error.find("missing vertex"), std::string::npos);
+    }
+
+    TEST(CRuntimeColModel, RejectsCompressedVertexOverflow)
+    {
+        RuntimeCollision::Model model;
+        auto                    mesh = Triangle(0.0f, 0);
+        mesh.vertices[0].fX = 256.0f;
+        model.meshes.push_back(std::move(mesh));
+
+        std::string buffer;
+        std::string error;
+        EXPECT_FALSE(RuntimeCollision::BuildCOLBuffer(model, buffer, error));
+        EXPECT_NE(error.find("GTA collision range"), std::string::npos);
+    }
+
+    TEST(CRuntimeColModel, RejectsInvalidPrimitiveDimensions)
+    {
+        RuntimeCollision::Model model;
+        model.spheres.push_back({CVector(), 0.0f, 0});
+
+        std::string buffer;
+        std::string error;
+        EXPECT_FALSE(RuntimeCollision::BuildCOLBuffer(model, buffer, error));
+        EXPECT_NE(error.find("radius"), std::string::npos);
+    }
+}  // namespace

--- a/Tests/client/premake5.lua
+++ b/Tests/client/premake5.lua
@@ -24,7 +24,8 @@ project "Tests_Client"
 		"premake5.lua",
 		"**.h",
 		"**.cpp",
-		"../../Client/mods/deathmatch/logic/CSampMapParser.cpp"
+		"../../Client/mods/deathmatch/logic/CSampMapParser.cpp",
+		"../../Client/mods/deathmatch/logic/CRuntimeColModel.cpp"
 	}
 
 	defines {

--- a/test-resources/runtime-collision-wall-demo/README.md
+++ b/test-resources/runtime-collision-wall-demo/README.md
@@ -1,0 +1,34 @@
+# Runtime collision wall demo
+
+Interactive Grove Street-friendly demo for runtime-generated model collision.
+
+The visible object has collisions disabled. A second invisible object uses the same temporary model ID with an `EngineCOL` created entirely from a Lua table, so every physical interaction comes from the generated collision rather than from non-uniform object scaling.
+
+## Run
+
+Deploy this resource to the server resource directory and start `runtime-collision-wall-demo`.
+
+Use:
+
+- `/wall` - start a new wall and replace the previous demo wall
+- left click - place the first endpoint, then lock the second endpoint
+- hold `E` / `Q` - extend / shorten the locked wall while continuing to move normally
+- hold `R` / `F` - raise / lower the locked wall
+- `T` or `/wallramp` - toggle the locked wall between a vertical wall and a sloped ramp
+- `/wallwire` - toggle the generated collision outline
+- `/wallreset` - remove the wall
+- `/wallcar` - spawn an Infernus and warp into it for an impact test
+- `/wallcarclear` - remove the test vehicle
+
+## Suggested video flow
+
+1. Start at Grove Street on foot and run `/wall`.
+2. Draw a short, low wall and lock it.
+3. Jump onto it.
+4. Hold `E` while standing/walking on it so the wall extends after creation.
+5. Hold `R` briefly so the top rises while the collision updates.
+6. Press `T` to turn the same runtime model into a small ramp.
+7. Walk down the ramp.
+8. Toggle `/wallwire` briefly to show the actual generated collision, then toggle it off.
+
+There is no presentation/marketing overlay in the resource; only normal debug chat/control hints are emitted.

--- a/test-resources/runtime-collision-wall-demo/README.md
+++ b/test-resources/runtime-collision-wall-demo/README.md
@@ -12,9 +12,9 @@ Use:
 
 - `/wall` - start a new wall and replace the previous demo wall
 - left click - place the first endpoint, then lock the second endpoint
-- hold `E` / `Q` - extend / shorten the locked wall while continuing to move normally
-- hold `R` / `F` - raise / lower the locked wall
-- `T` or `/wallramp` - toggle the locked wall between a vertical wall and a sloped ramp
+- hold `E` / `A` - extend / shorten the locked wall while continuing to move normally
+- hold `U` / `I` - raise / lower the locked wall
+- `P` or `/wallramp` - toggle the locked wall between a vertical wall and a sloped ramp
 - `/wallwire` - toggle the generated collision outline
 - `/wallreset` - remove the wall
 - `/wallcar` - spawn an Infernus and warp into it for an impact test
@@ -26,8 +26,8 @@ Use:
 2. Draw a short, low wall and lock it.
 3. Jump onto it.
 4. Hold `E` while standing/walking on it so the wall extends after creation.
-5. Hold `R` briefly so the top rises while the collision updates.
-6. Press `T` to turn the same runtime model into a small ramp.
+5. Hold `U` briefly so the top rises while the collision updates.
+6. Press `P` to turn the same runtime model into a small ramp.
 7. Walk down the ramp.
 8. Toggle `/wallwire` briefly to show the actual generated collision, then toggle it off.
 

--- a/test-resources/runtime-collision-wall-demo/client.lua
+++ b/test-resources/runtime-collision-wall-demo/client.lua
@@ -38,7 +38,6 @@ local editKeys = {
 local screenW, screenH = guiGetScreenSize()
 
 local function chat(message, r, g, b)
-    outputChatBox("[runtime-wall] " .. message, r or 80, g or 220, b or 255)
 end
 
 local function setEditorInput(enabled)
@@ -356,18 +355,18 @@ local function handleEditKey(keyName, state)
     local down = state == "down"
     if keyName == "e" then
         editKeys.extend = down
-    elseif keyName == "q" then
+    elseif keyName == "a" then
         editKeys.shorten = down
-    elseif keyName == "r" then
+    elseif keyName == "u" then
         editKeys.raise = down
-    elseif keyName == "f" then
+    elseif keyName == "i" then
         editKeys.lower = down
-    elseif keyName == "t" and down then
+    elseif keyName == "p" and down then
         toggleRamp()
     end
 end
 
-for _, keyName in ipairs({ "q", "e", "r", "f", "t" }) do
+for _, keyName in ipairs({ "a", "e", "u", "i", "p" }) do
     bindKey(keyName, "both", handleEditKey)
 end
 
@@ -410,7 +409,7 @@ addEventHandler("onClientClick", root, function(button, state)
         applyWallEndpoint(x, y, true)
         mode = "locked"
         setEditorInput(false)
-        chat("Wall locked. Hold E/Q for length, R/F for height, T to toggle ramp, /wallwire for collision.")
+        chat("Wall locked. Hold A/E for length, U/I for height, P to toggle ramp, /wallwire for collision.")
     end
 end)
 
@@ -528,4 +527,4 @@ addEventHandler("onClientResourceStop", resourceRoot, function()
     end
 end)
 
-chat("Ready: /wall. After locking: hold E/Q length, R/F height, T ramp, /wallwire collision.")
+chat("Ready: /wall. After locking: hold A/E length, U/I height, P ramp, /wallwire collision.")

--- a/test-resources/runtime-collision-wall-demo/client.lua
+++ b/test-resources/runtime-collision-wall-demo/client.lua
@@ -1,0 +1,531 @@
+local VISUAL_PARENT_MODEL = 980
+local INITIAL_WALL_HEIGHT = 1.2
+local WALL_THICKNESS = 0.45
+local MIN_WALL_LENGTH = 1.5
+local MAX_WALL_LENGTH = 40.0
+local MIN_WALL_HEIGHT = 0.45
+local MAX_WALL_HEIGHT = 6.0
+local VISUAL_BASE_LENGTH = 11.8
+local VISUAL_BASE_DEPTH = 1.0
+local VISUAL_BASE_HEIGHT = 4.5
+local COLLISION_MATERIAL = 1
+local COLLISION_UPDATE_MS = 33
+local LENGTH_EDIT_SPEED = 4.0
+local HEIGHT_EDIT_SPEED = 1.8
+local RAMP_ANGLE = 18.0
+local RAMP_THICKNESS = 0.35
+
+local wallModel = false
+local wallCol = false
+local visualObject = false
+local collisionObject = false
+
+local mode = "idle"
+local startPoint = false
+local wallState = false
+local wireframeEnabled = false
+local lastCollisionUpdate = 0
+local lastCollisionSignature = false
+local lastFrameTick = getTickCount()
+
+local editKeys = {
+    extend = false,
+    shorten = false,
+    raise = false,
+    lower = false
+}
+
+local screenW, screenH = guiGetScreenSize()
+
+local function chat(message, r, g, b)
+    outputChatBox("[runtime-wall] " .. message, r or 80, g or 220, b or 255)
+end
+
+local function setEditorInput(enabled)
+    showCursor(enabled)
+    toggleControl("fire", not enabled)
+    toggleControl("aim_weapon", not enabled)
+end
+
+local function makeCollision(state)
+    if state.shape == "ramp" then
+        return {
+            boxes = {
+                {
+                    position = { 0, 0, 0 },
+                    size = { state.length, WALL_THICKNESS, RAMP_THICKNESS },
+                    material = COLLISION_MATERIAL
+                }
+            }
+        }
+    end
+
+    return {
+        boxes = {
+            {
+                position = { 0, 0, 0 },
+                size = { state.length, WALL_THICKNESS, state.height },
+                material = COLLISION_MATERIAL
+            }
+        }
+    }
+end
+
+local function collisionSignature(state)
+    return string.format("%s:%.3f:%.3f", state.shape, state.length, state.height)
+end
+
+local function destroyWallObjects()
+    if isElement(visualObject) then
+        destroyElement(visualObject)
+    end
+    visualObject = false
+
+    if isElement(collisionObject) then
+        destroyElement(collisionObject)
+    end
+    collisionObject = false
+
+    if isElement(wallCol) then
+        destroyElement(wallCol)
+    end
+    wallCol = false
+
+    wallState = false
+    lastCollisionSignature = false
+end
+
+local function ensureModel()
+    if wallModel then
+        return true
+    end
+
+    wallModel = engineRequestModel("object", VISUAL_PARENT_MODEL)
+    if not wallModel then
+        chat("engineRequestModel failed; no free object model slot.", 255, 80, 80)
+        return false
+    end
+
+    return true
+end
+
+local function getCursorRay()
+    local cursorX, cursorY = getCursorPosition()
+    if not cursorX then
+        return false
+    end
+
+    local farX, farY, farZ = getWorldFromScreenPosition(cursorX * screenW, cursorY * screenH, 300)
+    if not farX then
+        return false
+    end
+
+    local cameraX, cameraY, cameraZ = getCameraMatrix()
+    return cameraX, cameraY, cameraZ, farX, farY, farZ
+end
+
+local function getCursorWorldHit()
+    local cameraX, cameraY, cameraZ, farX, farY, farZ = getCursorRay()
+    if not cameraX then
+        return false
+    end
+
+    local hit, hitX, hitY, hitZ = processLineOfSight(
+        cameraX, cameraY, cameraZ,
+        farX, farY, farZ,
+        true, false, false, true, false,
+        false, false, false,
+        localPlayer
+    )
+
+    if not hit then
+        return false
+    end
+
+    return hitX, hitY, hitZ
+end
+
+local function getCursorPointOnPlane(planeZ)
+    local cameraX, cameraY, cameraZ, farX, farY, farZ = getCursorRay()
+    if not cameraX then
+        return false
+    end
+
+    local directionZ = farZ - cameraZ
+    if math.abs(directionZ) < 0.0001 then
+        return false
+    end
+
+    local t = (planeZ - cameraZ) / directionZ
+    if t <= 0 then
+        return false
+    end
+
+    return cameraX + (farX - cameraX) * t,
+           cameraY + (farY - cameraY) * t,
+           planeZ
+end
+
+local function clampEndpoint(x, y)
+    local dx = x - startPoint.x
+    local dy = y - startPoint.y
+    local length = math.sqrt(dx * dx + dy * dy)
+
+    if length < 0.0001 then
+        return startPoint.x + MIN_WALL_LENGTH, startPoint.y, MIN_WALL_LENGTH
+    end
+
+    local clampedLength = math.max(MIN_WALL_LENGTH, math.min(MAX_WALL_LENGTH, length))
+    local scale = clampedLength / length
+    return startPoint.x + dx * scale, startPoint.y + dy * scale, clampedLength
+end
+
+local function updateCollision(force)
+    if not isElement(wallCol) or not wallState then
+        return false
+    end
+
+    local signature = collisionSignature(wallState)
+    local now = getTickCount()
+    if not force and signature == lastCollisionSignature then
+        return true
+    end
+
+    if not force and now - lastCollisionUpdate < COLLISION_UPDATE_MS then
+        return true
+    end
+
+    if not engineSetCOLData(wallCol, makeCollision(wallState)) then
+        chat("engineSetCOLData failed while editing the wall.", 255, 80, 80)
+        return false
+    end
+
+    lastCollisionUpdate = now
+    lastCollisionSignature = signature
+    return true
+end
+
+local function getRampCenterZ(state)
+    local pitch = math.rad(RAMP_ANGLE)
+    return state.baseZ + math.sin(pitch) * state.length * 0.5 + math.cos(pitch) * RAMP_THICKNESS * 0.5
+end
+
+local function applyWallTransform(forceCollision)
+    if not wallState or not isElement(visualObject) or not isElement(collisionObject) then
+        return false
+    end
+
+    local state = wallState
+    local middleX = state.startX + state.dirX * state.length * 0.5
+    local middleY = state.startY + state.dirY * state.length * 0.5
+    local pitch = 0
+    local centerZ
+    local visualHeight
+
+    if state.shape == "ramp" then
+        pitch = -RAMP_ANGLE
+        centerZ = getRampCenterZ(state)
+        visualHeight = RAMP_THICKNESS
+    else
+        centerZ = state.baseZ + state.height * 0.5
+        visualHeight = state.height
+    end
+
+    setElementPosition(collisionObject, middleX, middleY, centerZ)
+    setElementRotation(collisionObject, 0, pitch, state.angle)
+
+    setElementPosition(visualObject, middleX, middleY, centerZ)
+    setElementRotation(visualObject, 0, pitch, state.angle)
+    setObjectScale(
+        visualObject,
+        math.max(0.04, state.length / VISUAL_BASE_LENGTH),
+        math.max(0.08, WALL_THICKNESS / VISUAL_BASE_DEPTH),
+        math.max(0.04, visualHeight / VISUAL_BASE_HEIGHT)
+    )
+
+    state.middleX = middleX
+    state.middleY = middleY
+    state.centerZ = centerZ
+    state.pitch = pitch
+
+    return updateCollision(forceCollision)
+end
+
+local function applyWallEndpoint(endX, endY, forceCollision)
+    if not startPoint or not wallState then
+        return false
+    end
+
+    local clampedX, clampedY, length = clampEndpoint(endX, endY)
+    local dx = clampedX - startPoint.x
+    local dy = clampedY - startPoint.y
+    local inverseLength = 1 / length
+
+    wallState.length = length
+    wallState.dirX = dx * inverseLength
+    wallState.dirY = dy * inverseLength
+    wallState.angle = math.deg(math.atan2(dy, dx))
+
+    return applyWallTransform(forceCollision)
+end
+
+local function createWallAt(x, y, z)
+    destroyWallObjects()
+
+    startPoint = { x = x, y = y, z = z + 0.03 }
+    wallState = {
+        startX = startPoint.x,
+        startY = startPoint.y,
+        baseZ = startPoint.z,
+        dirX = 1,
+        dirY = 0,
+        angle = 0,
+        length = MIN_WALL_LENGTH,
+        height = INITIAL_WALL_HEIGHT,
+        shape = "wall"
+    }
+
+    wallCol = engineLoadCOL(makeCollision(wallState))
+    if not isElement(wallCol) then
+        chat("engineLoadCOL(table) failed.", 255, 80, 80)
+        return false
+    end
+
+    if not engineReplaceCOL(wallCol, wallModel) then
+        chat("engineReplaceCOL failed for the temporary model.", 255, 80, 80)
+        destroyWallObjects()
+        return false
+    end
+
+    collisionObject = createObject(wallModel, x, y, z + 0.03)
+    visualObject = createObject(wallModel, x, y, z + INITIAL_WALL_HEIGHT * 0.5)
+    if not isElement(collisionObject) or not isElement(visualObject) then
+        chat("Could not create wall objects.", 255, 80, 80)
+        destroyWallObjects()
+        return false
+    end
+
+    setElementFrozen(collisionObject, true)
+    setElementFrozen(visualObject, true)
+    setElementAlpha(collisionObject, 0)
+    setElementCollisionsEnabled(collisionObject, true)
+    setElementCollisionsEnabled(visualObject, false)
+    setElementDoubleSided(visualObject, true)
+    setObjectBreakable(collisionObject, false)
+    setObjectBreakable(visualObject, false)
+
+    lastCollisionUpdate = 0
+    lastCollisionSignature = false
+    return applyWallTransform(true)
+end
+
+local function resetDemo(keepEditor)
+    destroyWallObjects()
+    startPoint = false
+    mode = keepEditor and "pick-start" or "idle"
+    if not keepEditor then
+        setEditorInput(false)
+    end
+end
+
+local function beginWall()
+    if not ensureModel() then
+        return
+    end
+
+    resetDemo(true)
+    mode = "pick-start"
+    setEditorInput(true)
+    chat("Left-click the ground, move the mouse, then left-click again to lock the wall.")
+end
+
+local function toggleRamp()
+    if mode ~= "locked" or not wallState then
+        return
+    end
+
+    wallState.shape = wallState.shape == "ramp" and "wall" or "ramp"
+    applyWallTransform(true)
+end
+
+local function handleEditKey(keyName, state)
+    if mode ~= "locked" then
+        return
+    end
+
+    local down = state == "down"
+    if keyName == "e" then
+        editKeys.extend = down
+    elseif keyName == "q" then
+        editKeys.shorten = down
+    elseif keyName == "r" then
+        editKeys.raise = down
+    elseif keyName == "f" then
+        editKeys.lower = down
+    elseif keyName == "t" and down then
+        toggleRamp()
+    end
+end
+
+for _, keyName in ipairs({ "q", "e", "r", "f", "t" }) do
+    bindKey(keyName, "both", handleEditKey)
+end
+
+addCommandHandler("wall", beginWall)
+
+addCommandHandler("wallreset", function()
+    resetDemo(false)
+end)
+
+addCommandHandler("wallwire", function()
+    wireframeEnabled = not wireframeEnabled
+    chat("Collision wireframe " .. (wireframeEnabled and "enabled." or "disabled."))
+end)
+
+addCommandHandler("wallramp", toggleRamp)
+
+addEventHandler("onClientClick", root, function(button, state)
+    if button ~= "left" or state ~= "down" then
+        return
+    end
+
+    if mode == "pick-start" then
+        local x, y, z = getCursorWorldHit()
+        if not x then
+            return
+        end
+
+        if createWallAt(x, y, z) then
+            mode = "stretch"
+        end
+        return
+    end
+
+    if mode == "stretch" then
+        local x, y = getCursorPointOnPlane(startPoint.z)
+        if not x then
+            return
+        end
+
+        applyWallEndpoint(x, y, true)
+        mode = "locked"
+        setEditorInput(false)
+        chat("Wall locked. Hold E/Q for length, R/F for height, T to toggle ramp, /wallwire for collision.")
+    end
+end)
+
+local function updateStretch()
+    if mode ~= "stretch" or not startPoint then
+        return
+    end
+
+    local x, y = getCursorPointOnPlane(startPoint.z)
+    if x then
+        applyWallEndpoint(x, y, false)
+    end
+end
+
+local function updateLockedEdit(deltaSeconds)
+    if mode ~= "locked" or not wallState then
+        return
+    end
+
+    local changed = false
+    local lengthDirection = (editKeys.extend and 1 or 0) - (editKeys.shorten and 1 or 0)
+    if lengthDirection ~= 0 then
+        local nextLength = math.max(MIN_WALL_LENGTH, math.min(MAX_WALL_LENGTH, wallState.length + lengthDirection * LENGTH_EDIT_SPEED * deltaSeconds))
+        if nextLength ~= wallState.length then
+            wallState.length = nextLength
+            changed = true
+        end
+    end
+
+    if wallState.shape == "wall" then
+        local heightDirection = (editKeys.raise and 1 or 0) - (editKeys.lower and 1 or 0)
+        if heightDirection ~= 0 then
+            local nextHeight = math.max(MIN_WALL_HEIGHT, math.min(MAX_WALL_HEIGHT, wallState.height + heightDirection * HEIGHT_EDIT_SPEED * deltaSeconds))
+            if nextHeight ~= wallState.height then
+                wallState.height = nextHeight
+                changed = true
+            end
+        end
+    end
+
+    if changed then
+        applyWallTransform(false)
+    end
+end
+
+local function transformLocalPoint(state, x, y, z)
+    local pitch = math.rad(state.pitch or 0)
+    local yaw = math.rad(state.angle or 0)
+
+    local pitchX = x * math.cos(pitch) + z * math.sin(pitch)
+    local pitchZ = -x * math.sin(pitch) + z * math.cos(pitch)
+
+    local worldX = state.middleX + pitchX * math.cos(yaw) - y * math.sin(yaw)
+    local worldY = state.middleY + pitchX * math.sin(yaw) + y * math.cos(yaw)
+    local worldZ = state.centerZ + pitchZ
+    return worldX, worldY, worldZ
+end
+
+local function drawCollisionWireframe()
+    if not wireframeEnabled or not wallState or not isElement(collisionObject) then
+        return
+    end
+
+    local state = wallState
+    local halfLength = state.length * 0.5
+    local halfDepth = WALL_THICKNESS * 0.5
+    local halfHeight = (state.shape == "ramp" and RAMP_THICKNESS or state.height) * 0.5
+
+    local corners = {
+        { -halfLength, -halfDepth, -halfHeight },
+        {  halfLength, -halfDepth, -halfHeight },
+        {  halfLength,  halfDepth, -halfHeight },
+        { -halfLength,  halfDepth, -halfHeight },
+        { -halfLength, -halfDepth,  halfHeight },
+        {  halfLength, -halfDepth,  halfHeight },
+        {  halfLength,  halfDepth,  halfHeight },
+        { -halfLength,  halfDepth,  halfHeight }
+    }
+
+    local world = {}
+    for i, corner in ipairs(corners) do
+        world[i] = { transformLocalPoint(state, corner[1], corner[2], corner[3]) }
+    end
+
+    local edges = {
+        {1,2}, {2,3}, {3,4}, {4,1},
+        {5,6}, {6,7}, {7,8}, {8,5},
+        {1,5}, {2,6}, {3,7}, {4,8}
+    }
+
+    for _, edge in ipairs(edges) do
+        local a = world[edge[1]]
+        local b = world[edge[2]]
+        dxDrawLine3D(a[1], a[2], a[3], b[1], b[2], b[3], tocolor(0, 220, 255, 235), 3)
+    end
+end
+
+addEventHandler("onClientRender", root, function()
+    local now = getTickCount()
+    local deltaSeconds = math.min(0.1, math.max(0, now - lastFrameTick) / 1000)
+    lastFrameTick = now
+
+    updateStretch()
+    updateLockedEdit(deltaSeconds)
+    drawCollisionWireframe()
+end)
+
+addEventHandler("onClientResourceStop", resourceRoot, function()
+    setEditorInput(false)
+    destroyWallObjects()
+
+    if wallModel then
+        engineFreeModel(wallModel)
+        wallModel = false
+    end
+end)
+
+chat("Ready: /wall. After locking: hold E/Q length, R/F height, T ramp, /wallwire collision.")

--- a/test-resources/runtime-collision-wall-demo/meta.xml
+++ b/test-resources/runtime-collision-wall-demo/meta.xml
@@ -1,0 +1,5 @@
+<meta>
+    <info author="MTA Neon" name="Runtime collision wall demo" type="script" version="1.0" />
+    <script src="server.lua" type="server" />
+    <script src="client.lua" type="client" cache="false" />
+</meta>

--- a/test-resources/runtime-collision-wall-demo/server.lua
+++ b/test-resources/runtime-collision-wall-demo/server.lua
@@ -19,13 +19,11 @@ addCommandHandler("wallcar", function(player)
 
     local vehicle = createVehicle(411, spawnX, spawnY, z + 0.8, 0, 0, rz)
     if not vehicle then
-        outputChatBox("[runtime-wall] Could not create the test vehicle.", player, 255, 80, 80)
         return
     end
 
     spawnedVehicles[player] = vehicle
     warpPedIntoVehicle(player, vehicle)
-    outputChatBox("[runtime-wall] Test car spawned. Drive straight into the wall.", player, 100, 255, 120)
 end)
 
 addCommandHandler("wallcarclear", function(player)

--- a/test-resources/runtime-collision-wall-demo/server.lua
+++ b/test-resources/runtime-collision-wall-demo/server.lua
@@ -1,0 +1,42 @@
+local spawnedVehicles = {}
+
+local function destroyDemoVehicle(player)
+    local vehicle = spawnedVehicles[player]
+    if isElement(vehicle) then
+        destroyElement(vehicle)
+    end
+    spawnedVehicles[player] = nil
+end
+
+addCommandHandler("wallcar", function(player)
+    destroyDemoVehicle(player)
+
+    local x, y, z = getElementPosition(player)
+    local _, _, rz = getElementRotation(player)
+    local radians = math.rad(rz)
+    local spawnX = x - math.sin(radians) * 3.5
+    local spawnY = y + math.cos(radians) * 3.5
+
+    local vehicle = createVehicle(411, spawnX, spawnY, z + 0.8, 0, 0, rz)
+    if not vehicle then
+        outputChatBox("[runtime-wall] Could not create the test vehicle.", player, 255, 80, 80)
+        return
+    end
+
+    spawnedVehicles[player] = vehicle
+    warpPedIntoVehicle(player, vehicle)
+    outputChatBox("[runtime-wall] Test car spawned. Drive straight into the wall.", player, 100, 255, 120)
+end)
+
+addCommandHandler("wallcarclear", function(player)
+    destroyDemoVehicle(player)
+end)
+
+addEventHandler("onPlayerQuit", root, function()
+    destroyDemoVehicle(source)
+    spawnedVehicles[source] = nil
+end)
+
+addEventHandler("onResourceStart", resourceRoot, function()
+    outputServerLog("[runtime-collision-wall-demo] Ready. Client: /wall. Vehicle: /wallcar")
+end)


### PR DESCRIPTION
## Summary

- allow `engineLoadCOL` to accept structured Lua collision data while preserving file paths and raw COL data
- serialize validated spheres, boxes, and indexed meshes into an in-memory `COLL` buffer
- add `engineSetCOLData` for transactional live updates of an existing `EngineCOL`
- add serializer coverage for mixed primitives, multi-mesh index offsets, bounds, and invalid input
- include an interactive editable wall/ramp demo under `test-resources/runtime-collision-wall-demo`

## Behavior

```lua
local col = engineLoadCOL({
    boxes = {
        {
            position = { 0, 0, 0 },
            size = { 8, 4, 1 },
            material = 1
        }
    }
})

engineReplaceCOL(col, 1337)
engineSetCOLData(col, updatedCollision)
```

Updates build and parse the replacement collision first, retarget every model currently replaced by that `EngineCOL`, then destroy the previous native collision. Invalid input leaves the current collision unchanged.

Mesh indices are zero-based and vertices are validated against GTA:SA's compressed collision coordinate range. Bounds are generated automatically from all primitives.

## Interactive demo

Deploy `test-resources/runtime-collision-wall-demo`, then:

1. run `/wall`
2. left-click the ground to place the first end
3. move the mouse to stretch a short wall and left-click again to lock it
4. jump or walk onto the wall
5. hold `E` / `Q` to extend / shorten it after creation
6. hold `R` / `F` to raise / lower it while collision keeps updating
7. press `T` (or run `/wallramp`) to turn the same wall into a sloped ramp
8. walk down the ramp
9. use `/wallwire` to toggle the generated collision outline

`/wallreset` removes the wall and `/wallcar` remains available for an optional vehicle collision test. The visible object has collisions disabled; an invisible carrier object uses the runtime `EngineCOL`, so physical interaction comes from the generated collision rather than object scaling.

## Validation

- runtime serializer compiled in isolation with C++20 warnings enabled
- generated `COLL` header sizing and multi-mesh index flattening checked with a local harness
- Google Test coverage added for serialization and validation paths
- demo resource reviewed against current MTA client APIs for model allocation, non-uniform visual scaling, collision disabling, cursor raycasts and live object transforms
- full Windows client/runtime validation left for the VM sync/build pass