### PR TITLE
Add physical dropped weapon objects

### DIFF
--- a/Client/mods/deathmatch/logic/CClientObjectPhysicsManager.h
+++ b/Client/mods/deathmatch/logic/CClientObjectPhysicsManager.h
@@ -1,0 +1,190 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        mods/deathmatch/logic/CClientObjectPhysicsManager.h
+ *  PURPOSE:     Opt-in native GTA physics for MTA-owned objects
+ *
+ *****************************************************************************/
+
+#pragma once
+
+#include "CClientObject.h"
+#include "CClientObjectManager.h"
+#include "../../../game_sa/CObjectSA.h"
+
+#include <unordered_map>
+
+class CClientObjectPhysicsManager
+{
+private:
+    struct SState
+    {
+        CObject* pLastGameObject = nullptr;
+        bool     bSnapshotValid = false;
+
+        bool  bApplyGravity = false;
+        bool  bDisableCollisionForce = false;
+        bool  bCollidable = false;
+        bool  bDisableTurnForce = false;
+        bool  bDisableMoveForce = false;
+        bool  bInfiniteMass = false;
+        bool  bDisableZ = false;
+        bool  bDontApplySpeed = false;
+        bool  bCanBeCollidedWith = false;
+        float fMass = 0.0f;
+        float fTurnMass = 0.0f;
+    };
+
+    static inline std::unordered_map<CClientObject*, SState> ms_Objects;
+
+    static CObjectSA* GetObjectSA(CClientObject* pObject)
+    {
+        if (!pObject || !pObject->GetGameObject())
+            return nullptr;
+        return dynamic_cast<CObjectSA*>(pObject->GetGameObject());
+    }
+
+    static void Snapshot(CObjectSAInterface* pInterface, SState& state)
+    {
+        state.bApplyGravity = pInterface->bApplyGravity;
+        // CPhysicalSAInterface still uses the historical MTA name bDisableFriction
+        // for GTA's bDisableCollisionForce bit (0x4).
+        state.bDisableCollisionForce = pInterface->bDisableFriction;
+        state.bCollidable = pInterface->bCollidable;
+        state.bDisableTurnForce = pInterface->b0x10;
+        state.bDisableMoveForce = pInterface->bDisableMovement;
+        state.bInfiniteMass = pInterface->b0x40;
+        state.bDisableZ = pInterface->b0x80;
+        state.bDontApplySpeed = pInterface->bDontApplySpeed;
+        state.bCanBeCollidedWith = pInterface->bEnableCollision;
+        state.fMass = pInterface->m_fMass;
+        state.fTurnMass = pInterface->m_fTurnMass;
+        state.bSnapshotValid = true;
+    }
+
+    static bool Apply(CClientObject* pObject, SState& state)
+    {
+        CObjectSA* pObjectSA = GetObjectSA(pObject);
+        if (!pObjectSA)
+        {
+            state.pLastGameObject = nullptr;
+            state.bSnapshotValid = false;
+            return false;
+        }
+
+        CObjectSAInterface* pInterface = pObjectSA->GetObjectInterface();
+        if (!pInterface)
+            return false;
+
+        state.pLastGameObject = pObject->GetGameObject();
+        Snapshot(pInterface, state);
+
+        pInterface->bApplyGravity = true;
+        pInterface->bDisableFriction = false;
+        pInterface->bCollidable = true;
+        pInterface->b0x10 = false;
+        pInterface->bDisableMovement = false;
+        pInterface->b0x40 = false;
+        pInterface->b0x80 = false;
+        pInterface->bEnableCollision = true;
+
+        // Weapon models and other models without object.dat entries are initialized
+        // as effectively immovable (99999 mass/turn-mass). Give those models a sane
+        // fallback while preserving explicit object properties configured by scripts.
+        if (pInterface->m_fMass >= 99998.0f)
+            pObjectSA->SetMass(4.0f);
+        if (pInterface->m_fTurnMass >= 99998.0f)
+            pObjectSA->SetTurnMass(8.0f);
+
+        pObjectSA->SetUsesCollision(true);
+        pObjectSA->SetFrozen(pObject->IsFrozen());
+
+        if (!pObject->IsFrozen())
+        {
+            pObjectSA->AddToMovingList();
+            pObjectSA->SetStatic(false);
+        }
+
+        return true;
+    }
+
+    static void Restore(CClientObject* pObject, SState& state)
+    {
+        CObjectSA* pObjectSA = GetObjectSA(pObject);
+        if (!pObjectSA || pObject->GetGameObject() != state.pLastGameObject || !state.bSnapshotValid)
+            return;
+
+        CObjectSAInterface* pInterface = pObjectSA->GetObjectInterface();
+        if (!pInterface)
+            return;
+
+        pInterface->bApplyGravity = state.bApplyGravity;
+        pInterface->bDisableFriction = state.bDisableCollisionForce;
+        pInterface->bCollidable = state.bCollidable;
+        pInterface->b0x10 = state.bDisableTurnForce;
+        pInterface->bDisableMovement = state.bDisableMoveForce;
+        pInterface->b0x40 = state.bInfiniteMass;
+        pInterface->b0x80 = state.bDisableZ;
+        pInterface->bDontApplySpeed = state.bDontApplySpeed;
+        pInterface->bEnableCollision = state.bCanBeCollidedWith;
+        pObjectSA->SetMass(state.fMass);
+        pObjectSA->SetTurnMass(state.fTurnMass);
+        pObjectSA->SetUsesCollision(pObject->IsCollisionEnabled());
+    }
+
+public:
+    static bool SetEnabled(CClientObject* pObject, bool bEnabled)
+    {
+        if (!pObject)
+            return false;
+
+        if (!bEnabled)
+        {
+            auto iter = ms_Objects.find(pObject);
+            if (iter == ms_Objects.end())
+                return true;
+
+            Restore(pObject, iter->second);
+            ms_Objects.erase(iter);
+            return true;
+        }
+
+        SState& state = ms_Objects[pObject];
+        if (pObject->GetGameObject() != state.pLastGameObject || !state.bSnapshotValid)
+            Apply(pObject, state);
+        return true;
+    }
+
+    static bool IsEnabled(CClientObject* pObject)
+    {
+        return pObject && ms_Objects.contains(pObject);
+    }
+
+    static void Pulse()
+    {
+        if (!g_pClientGame || !g_pClientGame->GetManager())
+            return;
+
+        CClientObjectManager* pManager = g_pClientGame->GetManager()->GetObjectManager();
+        if (!pManager)
+            return;
+
+        for (auto iter = ms_Objects.begin(); iter != ms_Objects.end();)
+        {
+            CClientObject* pObject = iter->first;
+            if (!pManager->Exists(pObject))
+            {
+                iter = ms_Objects.erase(iter);
+                continue;
+            }
+
+            if (pObject->GetGameObject() != iter->second.pLastGameObject)
+            {
+                iter->second.bSnapshotValid = false;
+                Apply(pObject, iter->second);
+            }
+            ++iter;
+        }
+    }
+};

--- a/Client/mods/deathmatch/logic/CObjectSync.cpp
+++ b/Client/mods/deathmatch/logic/CObjectSync.cpp
@@ -11,12 +11,26 @@
 
 #include "StdInc.h"
 #include "net/SyncStructures.h"
+#include "CClientObjectPhysicsManager.h"
+
+#include <unordered_map>
 
 #ifdef WITH_OBJECT_SYNC
 
 using std::list;
 
     #define OBJECT_SYNC_RATE (g_TickRateSettings.iObjectSync)
+
+namespace
+{
+    struct SLastPhysicsSync
+    {
+        CVector vecVelocity;
+        CVector vecTurnVelocity;
+    };
+
+    std::unordered_map<CDeathmatchObject*, SLastPhysicsSync> g_LastPhysicsSync;
+}
 
 CObjectSync::CObjectSync(CClientObjectManager* pObjectManager)
 {
@@ -29,22 +43,14 @@ bool CObjectSync::ProcessPacket(unsigned char ucPacketID, NetBitStreamInterface&
     switch (ucPacketID)
     {
         case PACKET_ID_OBJECT_STARTSYNC:
-        {
             Packet_ObjectStartSync(BitStream);
             return true;
-        }
-
         case PACKET_ID_OBJECT_STOPSYNC:
-        {
             Packet_ObjectStopSync(BitStream);
             return true;
-        }
-
         case PACKET_ID_OBJECT_SYNC:
-        {
             Packet_ObjectSync(BitStream);
             return true;
-        }
     }
 
     return false;
@@ -52,7 +58,8 @@ bool CObjectSync::ProcessPacket(unsigned char ucPacketID, NetBitStreamInterface&
 
 void CObjectSync::DoPulse()
 {
-    // Has it been long enough since our last state's sync?
+    CClientObjectPhysicsManager::Pulse();
+
     unsigned long ulCurrentTime = CClientTime::GetTime();
     if (ulCurrentTime >= m_ulLastSyncTime + OBJECT_SYNC_RATE)
     {
@@ -64,17 +71,26 @@ void CObjectSync::DoPulse()
 void CObjectSync::AddObject(CDeathmatchObject* pObject)
 {
     m_List.push_front(pObject);
+
+    if (CClientObjectPhysicsManager::IsEnabled(pObject))
+    {
+        SLastPhysicsSync& state = g_LastPhysicsSync[pObject];
+        pObject->GetMoveSpeed(state.vecVelocity);
+        pObject->GetTurnSpeed(state.vecTurnVelocity);
+    }
 }
 
 void CObjectSync::RemoveObject(CDeathmatchObject* pObject)
 {
     if (!m_List.empty())
         m_List.remove(pObject);
+    g_LastPhysicsSync.erase(pObject);
 }
 
 void CObjectSync::ClearObjects()
 {
     m_List.clear();
+    g_LastPhysicsSync.clear();
 }
 
 bool CObjectSync::Exists(CDeathmatchObject* pObject)
@@ -84,135 +100,116 @@ bool CObjectSync::Exists(CDeathmatchObject* pObject)
 
 void CObjectSync::Packet_ObjectStartSync(NetBitStreamInterface& BitStream)
 {
-    // Read out the ID
     ElementID ID;
-    if (BitStream.Read(ID))
-    {
-        // Grab the object
-        CDeathmatchObject* pObject = static_cast<CDeathmatchObject*>(m_pObjectManager->Get(ID));
-        if (pObject)
-        {
-            // Read out the position and rotation
-            SPositionSync        position;
-            SRotationRadiansSync rotation;
-            if (BitStream.Read(&position) && BitStream.Read(&rotation))
-            {
-    // Disabled due to problem when attached in the editor - issue #5886
-    #if 0
-                pObject->SetOrientation ( position.data.vecPosition, rotation.data.vecRotation );
-    #endif
-            }
-            // No velocity due to issue #3522
+    if (!BitStream.Read(ID))
+        return;
 
-            // Read out the health
-            SObjectHealthSync health;
-            if (BitStream.Read(&health))
-            {
-                pObject->SetHealth(health.data.fValue);
-            }
+    CDeathmatchObject* pObject = static_cast<CDeathmatchObject*>(m_pObjectManager->Get(ID));
+    const bool         bDynamicPhysics = BitStream.ReadBit();
 
-            AddObject(pObject);
-        }
-    }
+    SPositionSync        position;
+    SRotationRadiansSync rotation;
+    SVelocitySync        velocity;
+    SVelocitySync        turnVelocity;
+    SObjectHealthSync    health;
+    if (!BitStream.Read(&position) || !BitStream.Read(&rotation) || !BitStream.Read(&velocity) || !BitStream.Read(&turnVelocity) || !BitStream.Read(&health))
+        return;
+
+    if (!pObject)
+        return;
+
+    CClientObjectPhysicsManager::SetEnabled(pObject, bDynamicPhysics);
+
+    // Keep the long-standing attached-object orientation workaround intact.
+    // Dynamic objects are already receiving authoritative snapshots before a
+    // syncer migration, so only velocity needs to be restored here.
+    pObject->SetMoveSpeed(velocity.data.vecVelocity);
+    pObject->SetTurnSpeed(turnVelocity.data.vecVelocity);
+    pObject->SetHealth(health.data.fValue);
+
+    AddObject(pObject);
 }
 
 void CObjectSync::Packet_ObjectStopSync(NetBitStreamInterface& BitStream)
 {
-    // Read out the ID
     ElementID ID;
-    if (BitStream.Read(ID))
-    {
-        // Grab the object
-        CDeathmatchObject* pObject = static_cast<CDeathmatchObject*>(m_pObjectManager->Get(ID));
-        if (pObject)
-        {
-            RemoveObject(pObject);
-        }
-    }
+    if (!BitStream.Read(ID))
+        return;
+
+    CDeathmatchObject* pObject = static_cast<CDeathmatchObject*>(m_pObjectManager->Get(ID));
+    if (pObject)
+        RemoveObject(pObject);
 }
 
 void CObjectSync::Packet_ObjectSync(NetBitStreamInterface& BitStream)
 {
-    // While we're not out of bytes
     while (BitStream.GetNumberOfUnreadBits() > 8)
     {
-        // Read out the ID
         ElementID ID;
-        if (!BitStream.Read(ID))
-            return;
-
-        // Read out the sync time context. See CClientEntity for documentation on that.
         unsigned char ucSyncTimeContext;
-        if (!BitStream.Read(ucSyncTimeContext))
+        if (!BitStream.Read(ID) || !BitStream.Read(ucSyncTimeContext))
             return;
 
-        // Read out flags
-        SIntegerSync<unsigned char, 3> flags(0);
+        SIntegerSync<unsigned char, 5> flags(0);
         if (!BitStream.Read(&flags))
             return;
 
-        // Read out the position if we need
         SPositionSync position;
-        if (flags & 0x1)
-        {
-            if (!BitStream.Read(&position))
-                return;
-        }
-
-        // Read out the rotation
         SRotationRadiansSync rotation;
-        if (flags & 0x2)
-        {
-            if (!BitStream.Read(&rotation))
-                return;
-        }
-
-        // Read out the health
         SObjectHealthSync health;
-        if (flags & 0x4)
-        {
-            if (!BitStream.Read(&health))
-                return;
-        }
+        SVelocitySync velocity;
+        SVelocitySync turnVelocity;
 
-        // Grab the object
+        if ((flags & 0x1) && !BitStream.Read(&position))
+            return;
+        if ((flags & 0x2) && !BitStream.Read(&rotation))
+            return;
+        if ((flags & 0x4) && !BitStream.Read(&health))
+            return;
+        if ((flags & 0x8) && !BitStream.Read(&velocity))
+            return;
+        if ((flags & 0x10) && !BitStream.Read(&turnVelocity))
+            return;
+
         CDeathmatchObject* pObject = static_cast<CDeathmatchObject*>(m_pObjectManager->Get(ID));
-        // Only update the sync if this packet is from the same context
-        if (pObject && pObject->CanUpdateSync(ucSyncTimeContext))
-        {
-            if (flags & 0x1)
-                pObject->SetPosition(position.data.vecPosition);
-            if (flags & 0x2)
-                pObject->SetRotationRadians(rotation.data.vecRotation);
-            if (flags & 0x4)
-                pObject->SetHealth(health.data.fValue);
-        }
+        if (!pObject || !pObject->CanUpdateSync(ucSyncTimeContext))
+            continue;
+
+        // Velocity fields are accepted by the server only for dynamic objects,
+        // so they also act as a self-describing fallback for clients that joined
+        // after the original SET_OBJECT_DYNAMIC_PHYSICS RPC.
+        if ((flags & 0x18) && !CClientObjectPhysicsManager::IsEnabled(pObject))
+            CClientObjectPhysicsManager::SetEnabled(pObject, true);
+
+        if (flags & 0x1)
+            pObject->SetPosition(position.data.vecPosition);
+        if (flags & 0x2)
+            pObject->SetRotationRadians(rotation.data.vecRotation);
+        if (flags & 0x4)
+            pObject->SetHealth(health.data.fValue);
+        if (flags & 0x8)
+            pObject->SetMoveSpeed(velocity.data.vecVelocity);
+        if (flags & 0x10)
+            pObject->SetTurnSpeed(turnVelocity.data.vecVelocity);
     }
 }
 
 void CObjectSync::Sync()
 {
-    // Got any items?
-    if (m_List.size() > 0)
-    {
-        // Write each object to packet
-        CBitStream                               bitStream;
-        list<CDeathmatchObject*>::const_iterator iter = m_List.begin();
-        for (; iter != m_List.end(); iter++)
-        {
-            WriteObjectInformation(bitStream.pBitStream, *iter);
-        }
+    if (m_List.empty())
+        return;
 
-        // Send the packet
-        g_pNet->SendPacket(PACKET_ID_OBJECT_SYNC, bitStream.pBitStream, PACKET_PRIORITY_MEDIUM, PACKET_RELIABILITY_UNRELIABLE_SEQUENCED);
-    }
+    CBitStream bitStream;
+    for (CDeathmatchObject* pObject : m_List)
+        WriteObjectInformation(bitStream.pBitStream, pObject);
+
+    g_pNet->SendPacket(PACKET_ID_OBJECT_SYNC, bitStream.pBitStream, PACKET_PRIORITY_MEDIUM, PACKET_RELIABILITY_UNRELIABLE_SEQUENCED);
 }
 
 void CObjectSync::WriteObjectInformation(NetBitStreamInterface* pBitStream, CDeathmatchObject* pObject)
 {
     unsigned char ucFlags = 0;
 
-    // What's changed?
     CVector vecPosition, vecRotation;
     pObject->GetPosition(vecPosition);
     pObject->GetRotationRadians(vecRotation);
@@ -224,46 +221,66 @@ void CObjectSync::WriteObjectInformation(NetBitStreamInterface* pBitStream, CDea
     if (pObject->GetHealth() != pObject->m_LastSyncedData.fHealth)
         ucFlags |= 0x4;
 
-    // Don't sync if nothing changed
+    CVector vecVelocity;
+    CVector vecTurnVelocity;
+    if (CClientObjectPhysicsManager::IsEnabled(pObject))
+    {
+        pObject->GetMoveSpeed(vecVelocity);
+        pObject->GetTurnSpeed(vecTurnVelocity);
+        SLastPhysicsSync& state = g_LastPhysicsSync[pObject];
+        if (vecVelocity != state.vecVelocity)
+            ucFlags |= 0x8;
+        if (vecTurnVelocity != state.vecTurnVelocity)
+            ucFlags |= 0x10;
+    }
+
     if (ucFlags == 0)
         return;
 
-    // Write the ID
     pBitStream->Write(pObject->GetID());
-
-    // Write the sync time context
     pBitStream->Write(pObject->GetSyncTimeContext());
 
-    // Write flags
-    SIntegerSync<unsigned char, 3> flags(ucFlags);
+    SIntegerSync<unsigned char, 5> flags(ucFlags);
     pBitStream->Write(&flags);
 
-    // Write changed stuff
-    // Position
     if (ucFlags & 0x1)
     {
         SPositionSync position;
-        pObject->GetPosition(position.data.vecPosition);
+        position.data.vecPosition = vecPosition;
         pBitStream->Write(&position);
-        pObject->m_LastSyncedData.vecPosition = position.data.vecPosition;
+        pObject->m_LastSyncedData.vecPosition = vecPosition;
     }
 
-    // Rotation
     if (ucFlags & 0x2)
     {
         SRotationRadiansSync rotation;
-        pObject->GetRotationRadians(rotation.data.vecRotation);
+        rotation.data.vecRotation = vecRotation;
         pBitStream->Write(&rotation);
-        pObject->m_LastSyncedData.vecRotation = rotation.data.vecRotation;
+        pObject->m_LastSyncedData.vecRotation = vecRotation;
     }
 
-    // Health
     if (ucFlags & 0x4)
     {
         SObjectHealthSync health;
         health.data.fValue = pObject->GetHealth();
         pBitStream->Write(&health);
         pObject->m_LastSyncedData.fHealth = health.data.fValue;
+    }
+
+    if (ucFlags & 0x8)
+    {
+        SVelocitySync velocity;
+        velocity.data.vecVelocity = vecVelocity;
+        pBitStream->Write(&velocity);
+        g_LastPhysicsSync[pObject].vecVelocity = vecVelocity;
+    }
+
+    if (ucFlags & 0x10)
+    {
+        SVelocitySync turnVelocity;
+        turnVelocity.data.vecVelocity = vecTurnVelocity;
+        pBitStream->Write(&turnVelocity);
+        g_LastPhysicsSync[pObject].vecTurnVelocity = vecTurnVelocity;
     }
 }
 

--- a/Client/mods/deathmatch/logic/rpc/CObjectRPCs.cpp
+++ b/Client/mods/deathmatch/logic/rpc/CObjectRPCs.cpp
@@ -11,6 +11,7 @@
 
 #include <StdInc.h>
 #include "CObjectRPCs.h"
+#include "../CClientObjectPhysicsManager.h"
 
 void CObjectRPCs::LoadFunctions()
 {
@@ -21,6 +22,7 @@ void CObjectRPCs::LoadFunctions()
     AddHandler(SET_OBJECT_SCALE, SetObjectScale, "SetObjectScale");
     AddHandler(SET_OBJECT_VISIBLE_IN_ALL_DIMENSIONS, SetObjectVisibleInAllDimensions, "SetObjectVisibleInAllDimensions");
     AddHandler(SET_OBJECT_BREAKABLE, SetObjectBreakable, "SetObjectBreakable");
+    AddHandler(SET_OBJECT_DYNAMIC_PHYSICS, SetObjectDynamicPhysics, "SetObjectDynamicPhysics");
     AddHandler(BREAK_OBJECT, BreakObject, "BreakObject");
     AddHandler(RESPAWN_OBJECT, RespawnObject, "RespawnObject");
     AddHandler(TOGGLE_OBJECT_RESPAWN, ToggleObjectRespawn, "ToggleObjectRespawn");
@@ -33,30 +35,21 @@ void CObjectRPCs::DestroyAllObjects(NetBitStreamInterface& bitStream)
 
 void CObjectRPCs::SetObjectRotation(CClientEntity* pSource, NetBitStreamInterface& bitStream)
 {
-    // Grab the object
     CDeathmatchObject* pObject = static_cast<CDeathmatchObject*>(m_pObjectManager->Get(pSource->GetID()));
     if (pObject)
     {
-        // Read out the new rotation
         CVector vecRotation;
         if (bitStream.Read(vecRotation.fX) && bitStream.Read(vecRotation.fY) && bitStream.Read(vecRotation.fZ))
-        {
-            // Set the new rotation
             pObject->SetRotationRadians(vecRotation);
-
-            // Kayl: removed update of target rotation, move uses delta and anyway setRotation is NOT possible when moving
-        }
     }
 }
 
 void CObjectRPCs::MoveObject(CClientEntity* pSource, NetBitStreamInterface& bitStream)
 {
-    // Grab the object
     CDeathmatchObject* pObject = static_cast<CDeathmatchObject*>(m_pObjectManager->Get(pSource->GetID()));
     if (pObject)
     {
         CPositionRotationAnimation* pAnimation = CPositionRotationAnimation::FromBitStream(bitStream);
-
         if (pAnimation)
         {
             pObject->StartMovement(*pAnimation);
@@ -67,19 +60,15 @@ void CObjectRPCs::MoveObject(CClientEntity* pSource, NetBitStreamInterface& bitS
 
 void CObjectRPCs::StopObject(CClientEntity* pSource, NetBitStreamInterface& bitStream)
 {
-    // Grab the object
     CDeathmatchObject* pObject = static_cast<CDeathmatchObject*>(m_pObjectManager->Get(pSource->GetID()));
     if (pObject)
     {
-        // Read out the position and rotation
         CVector vecSourcePosition;
         CVector vecSourceRotation;
         if (bitStream.Read(vecSourcePosition.fX) && bitStream.Read(vecSourcePosition.fY) && bitStream.Read(vecSourcePosition.fZ) &&
             bitStream.Read(vecSourceRotation.fX) && bitStream.Read(vecSourceRotation.fY) && bitStream.Read(vecSourceRotation.fZ))
         {
-            // Stop the movement
             pObject->StopMovement();
-            // Set it to the source position and rotation
             pObject->SetOrientation(vecSourcePosition, vecSourceRotation);
         }
     }
@@ -91,7 +80,6 @@ void CObjectRPCs::SetObjectScale(CClientEntity* pSource, NetBitStreamInterface& 
     if (pObject)
     {
         CVector vecScale;
-
         bitStream.Read(vecScale.fX);
         vecScale.fY = vecScale.fX;
         vecScale.fZ = vecScale.fX;
@@ -104,15 +92,12 @@ void CObjectRPCs::SetObjectScale(CClientEntity* pSource, NetBitStreamInterface& 
 void CObjectRPCs::SetObjectVisibleInAllDimensions(CClientEntity* pSource, NetBitStreamInterface& bitStream)
 {
     CDeathmatchObject* pObject = static_cast<CDeathmatchObject*>(m_pObjectManager->Get(pSource->GetID()));
-
     if (pObject)
     {
         bool           bVisible;
         unsigned short usNewDimension;
-
         bitStream.ReadBit(bVisible);
         bitStream.Read(usNewDimension);
-
         pObject->SetVisibleInAllDimensions(bVisible, usNewDimension);
     }
 }
@@ -120,17 +105,20 @@ void CObjectRPCs::SetObjectVisibleInAllDimensions(CClientEntity* pSource, NetBit
 void CObjectRPCs::SetObjectBreakable(CClientEntity* pSource, NetBitStreamInterface& bitStream)
 {
     CDeathmatchObject* pObject = static_cast<CDeathmatchObject*>(m_pObjectManager->Get(pSource->GetID()));
-
     if (pObject)
-    {
         pObject->SetBreakable(bitStream.ReadBit());
-    }
+}
+
+void CObjectRPCs::SetObjectDynamicPhysics(CClientEntity* pSource, NetBitStreamInterface& bitStream)
+{
+    CDeathmatchObject* pObject = static_cast<CDeathmatchObject*>(m_pObjectManager->Get(pSource->GetID()));
+    if (pObject)
+        CClientObjectPhysicsManager::SetEnabled(pObject, bitStream.ReadBit());
 }
 
 void CObjectRPCs::BreakObject(CClientEntity* pSource, NetBitStreamInterface& bitStream)
 {
     auto* pObject = static_cast<CDeathmatchObject*>(m_pObjectManager->Get(pSource->GetID()));
-
     if (pObject)
         pObject->Break();
 }
@@ -138,7 +126,6 @@ void CObjectRPCs::BreakObject(CClientEntity* pSource, NetBitStreamInterface& bit
 void CObjectRPCs::RespawnObject(CClientEntity* pSource, NetBitStreamInterface& bitStream)
 {
     auto* pObject = static_cast<CDeathmatchObject*>(m_pObjectManager->Get(pSource->GetID()));
-
     if (pObject)
         g_pClientGame->GetObjectRespawner()->Respawn(pObject);
 }
@@ -146,7 +133,6 @@ void CObjectRPCs::RespawnObject(CClientEntity* pSource, NetBitStreamInterface& b
 void CObjectRPCs::ToggleObjectRespawn(CClientEntity* pSource, NetBitStreamInterface& bitStream)
 {
     auto* pObject = static_cast<CDeathmatchObject*>(m_pObjectManager->Get(pSource->GetID()));
-
     if (pObject)
         pObject->SetRespawnEnabled(bitStream.ReadBit());
 }

--- a/Client/mods/deathmatch/logic/rpc/CObjectRPCs.h
+++ b/Client/mods/deathmatch/logic/rpc/CObjectRPCs.h
@@ -26,6 +26,7 @@ public:
     DECLARE_ELEMENT_RPC(SetObjectScale);
     DECLARE_ELEMENT_RPC(SetObjectVisibleInAllDimensions);
     DECLARE_ELEMENT_RPC(SetObjectBreakable);
+    DECLARE_ELEMENT_RPC(SetObjectDynamicPhysics);
     DECLARE_ELEMENT_RPC(BreakObject);
     DECLARE_ELEMENT_RPC(RespawnObject);
     DECLARE_ELEMENT_RPC(ToggleObjectRespawn);

--- a/Server/mods/deathmatch/logic/CObject.h
+++ b/Server/mods/deathmatch/logic/CObject.h
@@ -79,6 +79,13 @@ public:
     bool IsSyncable() { return m_bSyncable; }
     void SetSyncable(bool bSyncable) { m_bSyncable = bSyncable; }
 
+    bool IsDynamicPhysics() const noexcept { return m_bDynamicPhysics; }
+    void SetDynamicPhysics(bool bEnabled) noexcept { m_bDynamicPhysics = bEnabled; }
+    const CVector& GetPhysicsVelocity() const noexcept { return m_vecPhysicsVelocity; }
+    void SetPhysicsVelocity(const CVector& vecVelocity) noexcept { m_vecPhysicsVelocity = vecVelocity; }
+    const CVector& GetPhysicsTurnVelocity() const noexcept { return m_vecPhysicsTurnVelocity; }
+    void SetPhysicsTurnVelocity(const CVector& vecVelocity) noexcept { m_vecPhysicsTurnVelocity = vecVelocity; }
+
     CPlayer* GetSyncer() { return m_pSyncer; }
     void     SetSyncer(CPlayer* pPlayer);
 
@@ -110,6 +117,9 @@ private:
     float          m_fHealth;
     bool           m_bBreakable;
     bool           m_bSyncable;
+    bool           m_bDynamicPhysics = false;
+    CVector        m_vecPhysicsVelocity{};
+    CVector        m_vecPhysicsTurnVelocity{};
     CPlayer*       m_pSyncer;
     bool           m_bVisibleInAllDimensions = false;
     bool           m_bRespawnable;

--- a/Server/mods/deathmatch/logic/CObjectSync.cpp
+++ b/Server/mods/deathmatch/logic/CObjectSync.cpp
@@ -12,10 +12,27 @@
 #include "StdInc.h"
 #include "CObjectSync.h"
 
+#include <cmath>
+
 #ifdef WITH_OBJECT_SYNC
 
     #define SYNC_RATE                500
     #define MAX_PLAYER_SYNC_DISTANCE 100.0f
+
+namespace
+{
+    constexpr float MAX_DYNAMIC_OBJECT_VELOCITY = 25.0f;
+    constexpr float MAX_DYNAMIC_OBJECT_TURN_VELOCITY = 20.0f;
+
+    bool IsSaneVector(const CVector& vec, float maxMagnitude)
+    {
+        if (!std::isfinite(vec.fX) || !std::isfinite(vec.fY) || !std::isfinite(vec.fZ))
+            return false;
+
+        const float magnitudeSquared = vec.fX * vec.fX + vec.fY * vec.fY + vec.fZ * vec.fZ;
+        return magnitudeSquared <= maxMagnitude * maxMagnitude;
+    }
+}
 
 CObjectSync::CObjectSync(CPlayerManager* pPlayerManager, CObjectManager* pObjectManager)
 {
@@ -25,7 +42,6 @@ CObjectSync::CObjectSync(CPlayerManager* pPlayerManager, CObjectManager* pObject
 
 void CObjectSync::DoPulse()
 {
-    // Time to check for players that should no longer be syncing a object or objects that should be synced?
     if (m_UpdateTimer.Get() > SYNC_RATE)
     {
         m_UpdateTimer.Reset();
@@ -46,17 +62,13 @@ bool CObjectSync::ProcessPacket(CPacket& Packet)
 
 void CObjectSync::OverrideSyncer(CObject* pObject, CPlayer* pPlayer, bool bPersist)
 {
-    // If the object already has a syncer, tell him not to sync it anymore
     CPlayer* pSyncer = pObject->GetSyncer();
     if (pSyncer)
     {
         if (pSyncer == pPlayer)
         {
-            if (bPersist == false)
-            {
+            if (!bPersist)
                 SetSyncerAsPersistent(false);
-            }
-
             return;
         }
 
@@ -72,60 +84,40 @@ void CObjectSync::OverrideSyncer(CObject* pObject, CPlayer* pPlayer, bool bPersi
 
 void CObjectSync::Update()
 {
-    // Update all objects
-    list<CObject*>::const_iterator iter = m_pObjectManager->IterBegin();
-    for (; iter != m_pObjectManager->IterEnd(); iter++)
-    {
+    for (auto iter = m_pObjectManager->IterBegin(); iter != m_pObjectManager->IterEnd(); ++iter)
         UpdateObject(*iter);
-    }
 }
 
 void CObjectSync::UpdateObject(CObject* pObject)
 {
     CPlayer* pSyncer = pObject->GetSyncer();
 
-    // Does the object need to be synced?
-    // We have no reason to sync static and unbreakable objects
-    if (!pObject->IsSyncable() || (pObject->IsStatic() && !pObject->IsBreakable()))
+    if (!pObject->IsSyncable() || (!pObject->IsDynamicPhysics() && pObject->IsStatic() && !pObject->IsBreakable()))
     {
         if (pSyncer)
-        {
-            // Tell the syncer to stop syncing
             StopSync(pObject);
-        }
         return;
     }
 
-    // Does the object have syncer?
     if (pSyncer)
     {
-        // Does the syncer still near the object?
-        if (!IsSyncerPersistent() && !IsPointNearPoint3D(pSyncer->GetPosition(), pObject->GetPosition(), MAX_PLAYER_SYNC_DISTANCE) ||
-            (pObject->GetDimension() != pSyncer->GetDimension()))
+        if ((!IsSyncerPersistent() && !IsPointNearPoint3D(pSyncer->GetPosition(), pObject->GetPosition(), MAX_PLAYER_SYNC_DISTANCE)) ||
+            pObject->GetDimension() != pSyncer->GetDimension())
         {
-            // Stop him from syncing it
             StopSync(pObject);
-
-            // Find a new syncer
             FindSyncer(pObject);
         }
     }
     else
     {
-        // Try to find a syncer
         FindSyncer(pObject);
     }
 }
 
 void CObjectSync::FindSyncer(CObject* pObject)
 {
-    // Find a player close enough to it
-    CPlayer* pPlayer = FindPlayerCloseToObject(pObject, MAX_PLAYER_SYNC_DISTANCE);
-    if (pPlayer)
-    {
-        // Tell him to start syncing it
+    if (CPlayer* pPlayer = FindPlayerCloseToObject(pObject, MAX_PLAYER_SYNC_DISTANCE))
         StartSync(pPlayer, pObject);
-    }
 }
 
 void CObjectSync::StartSync(CPlayer* pPlayer, CObject* pObject)
@@ -133,106 +125,91 @@ void CObjectSync::StartSync(CPlayer* pPlayer, CObject* pObject)
     if (!pObject->IsSyncable())
         return;
 
-    // Tell the player
     pPlayer->Send(CObjectStartSyncPacket(pObject));
-
-    // Mark him as the syncing player
     pObject->SetSyncer(pPlayer);
 
-    // Call the onElementStartSync event
     CLuaArguments Arguments;
-    Arguments.PushElement(pPlayer);  // New syncer
+    Arguments.PushElement(pPlayer);
     pObject->CallEvent("onElementStartSync", Arguments);
 }
 
 void CObjectSync::StopSync(CObject* pObject)
 {
-    // Tell the player that used to sync it
     CPlayer* pSyncer = pObject->GetSyncer();
     pSyncer->Send(CObjectStopSyncPacket(pObject));
-
-    // Unmark him as the syncing player
     pObject->SetSyncer(NULL);
-
     SetSyncerAsPersistent(false);
 
-    // Call the onElementStopSync event
     CLuaArguments Arguments;
-    Arguments.PushElement(pSyncer);  // Old syncer
+    Arguments.PushElement(pSyncer);
     pObject->CallEvent("onElementStopSync", Arguments);
 }
 
 CPlayer* CObjectSync::FindPlayerCloseToObject(CObject* pObject, float fMaxDistance)
 {
-    // Grab the object position
-    CVector vecPosition = pObject->GetPosition();
+    CVector  vecPosition = pObject->GetPosition();
+    CPlayer* pSyncer = NULL;
 
-    // See if any players are close enough
-    CPlayer*                       pSyncer = NULL;
-    list<CPlayer*>::const_iterator iter = m_pPlayerManager->IterBegin();
-    for (; iter != m_pPlayerManager->IterEnd(); iter++)
+    for (auto iter = m_pPlayerManager->IterBegin(); iter != m_pPlayerManager->IterEnd(); ++iter)
     {
         CPlayer* pPlayer = *iter;
-        // Is he joined?
-        if (pPlayer->IsJoined())
+        if (pPlayer->IsJoined() && IsPointNearPoint3D(vecPosition, pPlayer->GetPosition(), fMaxDistance) && pPlayer->GetDimension() == pObject->GetDimension())
         {
-            // Is he near the object?
-            if (IsPointNearPoint3D(vecPosition, pPlayer->GetPosition(), fMaxDistance) && (pPlayer->GetDimension() == pObject->GetDimension()))
-            {
-                // Prefer a player that syncs less objects
-                if (!pSyncer || pPlayer->CountSyncingObjects() < pSyncer->CountSyncingObjects())
-                {
-                    pSyncer = pPlayer;
-                }
-            }
+            if (!pSyncer || pPlayer->CountSyncingObjects() < pSyncer->CountSyncingObjects())
+                pSyncer = pPlayer;
         }
     }
 
-    // Return the player we found
     return pSyncer;
 }
 
 void CObjectSync::Packet_ObjectSync(CObjectSyncPacket& Packet)
 {
-    // Grab the player
     CPlayer* pPlayer = Packet.GetSourcePlayer();
-    if (pPlayer && pPlayer->IsJoined())
+    if (!pPlayer || !pPlayer->IsJoined())
+        return;
+
+    for (auto iter = Packet.IterBegin(); iter != Packet.IterEnd(); ++iter)
     {
-        // Apply the data for each object in the packet
-        vector<CObjectSyncPacket::SyncData*>::const_iterator iter = Packet.IterBegin();
-        for (; iter != Packet.IterEnd(); iter++)
+        CObjectSyncPacket::SyncData* pData = *iter;
+        CElement*                    pElement = CElementIDs::GetElement(pData->ID);
+        if (!pElement || !IS_OBJECT(pElement))
+            continue;
+
+        CObject* pObject = static_cast<CObject*>(pElement);
+        if (pObject->GetSyncer() != pPlayer || !pObject->CanUpdateSync(pData->ucSyncTimeContext))
+            continue;
+
+        if (pData->ucFlags & 0x8)
         {
-            CObjectSyncPacket::SyncData* pData = *iter;
-
-            // Grab the element
-            CElement* pElement = CElementIDs::GetElement(pData->ID);
-            if (pElement && IS_OBJECT(pElement))
-            {
-                CObject* pObject = static_cast<CObject*>(pElement);
-
-                // Is the player syncing this object?
-                if ((pObject->GetSyncer() == pPlayer) && pObject->CanUpdateSync(pData->ucSyncTimeContext))
-                {
-                    // Apply the data to the object
-                    if (pData->ucFlags & 0x1)
-                    {
-                        pObject->SetPosition(pData->vecPosition);
-                        g_pGame->GetColManager()->DoHitDetection(pObject->GetPosition(), pObject);
-                    }
-                    if (pData->ucFlags & 0x2)
-                        pObject->SetRotation(pData->vecRotation);
-                    if (pData->ucFlags & 0x4)
-                        pObject->SetHealth(pData->fHealth);
-
-                    // Send this sync
-                    pData->bSend = true;
-                }
-            }
+            if (!pObject->IsDynamicPhysics() || !IsSaneVector(pData->vecVelocity, MAX_DYNAMIC_OBJECT_VELOCITY))
+                pData->ucFlags &= ~0x8;
+            else
+                pObject->SetPhysicsVelocity(pData->vecVelocity);
         }
 
-        // Tell everyone
-        m_pPlayerManager->BroadcastOnlyJoined(Packet, pPlayer);
+        if (pData->ucFlags & 0x10)
+        {
+            if (!pObject->IsDynamicPhysics() || !IsSaneVector(pData->vecTurnVelocity, MAX_DYNAMIC_OBJECT_TURN_VELOCITY))
+                pData->ucFlags &= ~0x10;
+            else
+                pObject->SetPhysicsTurnVelocity(pData->vecTurnVelocity);
+        }
+
+        if (pData->ucFlags & 0x1)
+        {
+            pObject->SetPosition(pData->vecPosition);
+            g_pGame->GetColManager()->DoHitDetection(pObject->GetPosition(), pObject);
+        }
+        if (pData->ucFlags & 0x2)
+            pObject->SetRotation(pData->vecRotation);
+        if (pData->ucFlags & 0x4)
+            pObject->SetHealth(pData->fHealth);
+
+        pData->bSend = pData->ucFlags != 0;
     }
+
+    m_pPlayerManager->BroadcastOnlyJoined(Packet, pPlayer);
 }
 
 #endif

--- a/Server/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
@@ -11,9 +11,11 @@
 
 #include "StdInc.h"
 #include "../CServerModelManager.h"
+#include "../packets/CElementRPCPacket.h"
 #include "CLuaObjectDefs.h"
 #include "CStaticFunctionDefinitions.h"
 #include "CScriptArgReader.h"
+#include <net/rpc_enums.h>
 
 void CLuaObjectDefs::LoadFunctions()
 {
@@ -28,18 +30,19 @@ void CLuaObjectDefs::LoadFunctions()
         {"isObjectBreakable", ArgumentParser<IsObjectBreakable>},
         {"isObjectMoving", ArgumentParser<IsObjectMoving>},
         {"isObjectRespawnable", ArgumentParser<IsObjectRespawnable>},
+        {"isObjectDynamicPhysics", ArgumentParser<IsObjectDynamicPhysics>},
 
         // Object set funcs
         {"setObjectRotation", SetObjectRotation},
         {"setObjectScale", SetObjectScale},
         {"setObjectBreakable", ArgumentParser<SetObjectBreakable>},
+        {"setObjectDynamicPhysics", ArgumentParser<SetObjectDynamicPhysics>},
         {"moveObject", MoveObject},
         {"stopObject", StopObject},
         {"breakObject", ArgumentParser<BreakObject>},
         {"toggleObjectRespawn", ArgumentParser<ToggleObjectRespawn>},
     };
 
-    // Add functions
     for (const auto& [name, func] : functions)
         CLuaCFunctions::AddFunction(name, func);
 }
@@ -60,18 +63,20 @@ void CLuaObjectDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setBreakable", "setObjectBreakable");
     lua_classfunction(luaVM, "isMoving", "isObjectMoving");
     lua_classfunction(luaVM, "toggleRespawn", "toggleObjectRespawn");
+    lua_classfunction(luaVM, "isDynamicPhysics", "isObjectDynamicPhysics");
+    lua_classfunction(luaVM, "setDynamicPhysics", "setObjectDynamicPhysics");
 
     lua_classvariable(luaVM, "scale", "setObjectScale", "getObjectScale");
     lua_classvariable(luaVM, "breakable", "setObjectBreakable", "isObjectBreakable");
     lua_classvariable(luaVM, "moving", nullptr, "isObjectMoving");
     lua_classvariable(luaVM, "isRespawnable", nullptr, "isObjectRespawnable");
+    lua_classvariable(luaVM, "dynamicPhysics", "setObjectDynamicPhysics", "isObjectDynamicPhysics");
 
     lua_registerclass(luaVM, "Object", "Element");
 }
 
 int CLuaObjectDefs::CreateObject(lua_State* luaVM)
 {
-    //  object createObject ( int modelid, float x, float y, float z, [float rx, float ry, float rz, bool lowLOD] )
     ushort  usModelID;
     CVector vecPosition;
     CVector vecRotation;
@@ -98,9 +103,7 @@ int CLuaObjectDefs::CreateObject(lua_State* luaVM)
                     {
                         CElementGroup* pGroup = pResource->GetElementGroup();
                         if (pGroup)
-                        {
                             pGroup->Add(pObject);
-                        }
 
                         lua_pushelement(luaVM, pObject);
                         return 1;
@@ -170,6 +173,11 @@ bool CLuaObjectDefs::IsObjectBreakable(CObject* const pObject)
     return pObject->IsBreakable();
 }
 
+bool CLuaObjectDefs::IsObjectDynamicPhysics(CObject* const pObject) noexcept
+{
+    return pObject && pObject->IsDynamicPhysics();
+}
+
 int CLuaObjectDefs::SetObjectRotation(lua_State* luaVM)
 {
     CElement* pElement;
@@ -202,18 +210,12 @@ int CLuaObjectDefs::SetObjectScale(lua_State* luaVM)
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pObject);
 
-    // Caz - This function looks weird but it works
-    // the function is designed to support the following syntaxes
-    // setObjectScale ( obj, 2 ) -- all other components are set to 2
-    // setObjectScale ( obj, 2, 1, 5 ) -- custom scaling on 3 axis
-
     if (argStream.NextIsVector3D())
     {
         argStream.ReadVector3D(vecScale);
     }
     else
     {
-        // Caz - Here is what I am talking about.
         argStream.ReadNumber(vecScale.fX);
         argStream.ReadNumber(vecScale.fY, vecScale.fX);
         argStream.ReadNumber(vecScale.fZ, vecScale.fX);
@@ -241,10 +243,6 @@ bool CLuaObjectDefs::IsObjectMoving(CObject* const pObject)
 
 int CLuaObjectDefs::MoveObject(lua_State* luaVM)
 {
-    //  bool moveObject ( object theObject, int time,
-    //      float targetx, float targety, float targetz,
-    //      [ float moverx, float movery, float moverz,
-    //      string strEasingType, float fEasingPeriod, float fEasingAmplitude, float fEasingOvershoot ] )
     CElement*           pElement;
     int                 iTime;
     CVector             vecTargetPosition;
@@ -313,6 +311,24 @@ int CLuaObjectDefs::StopObject(lua_State* luaVM)
 bool CLuaObjectDefs::SetObjectBreakable(CObject* const pObject, const bool bBreakable)
 {
     return CStaticFunctionDefinitions::SetObjectBreakable(pObject, bBreakable);
+}
+
+bool CLuaObjectDefs::SetObjectDynamicPhysics(CObject* const pObject, const bool bEnabled)
+{
+    if (!pObject)
+        return false;
+
+    pObject->SetDynamicPhysics(bEnabled);
+    if (!bEnabled)
+    {
+        pObject->SetPhysicsVelocity(CVector());
+        pObject->SetPhysicsTurnVelocity(CVector());
+    }
+
+    CBitStream bitStream;
+    bitStream.pBitStream->WriteBit(bEnabled);
+    m_pPlayerManager->BroadcastOnlyJoined(CElementRPCPacket(pObject, SET_OBJECT_DYNAMIC_PHYSICS, *bitStream.pBitStream));
+    return true;
 }
 
 bool CLuaObjectDefs::BreakObject(CObject* const pObject)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaObjectDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaObjectDefs.h
@@ -29,12 +29,14 @@ public:
     static bool IsObjectBreakable(CObject* const pObject);
     static bool IsObjectMoving(CObject* const pObject);
     static bool IsObjectRespawnable(CObject* const pObject) noexcept;
+    static bool IsObjectDynamicPhysics(CObject* const pObject) noexcept;
 
     // Object set functions
     LUA_DECLARE(SetObjectName);
     LUA_DECLARE(SetObjectRotation);
     LUA_DECLARE(SetObjectScale);
     static bool SetObjectBreakable(CObject* const pObject, const bool bBreakable);
+    static bool SetObjectDynamicPhysics(CObject* const pObject, const bool bEnabled);
     LUA_DECLARE(MoveObject);
     LUA_DECLARE(StopObject);
     static bool BreakObject(CObject* const pObject);

--- a/Server/mods/deathmatch/logic/packets/CObjectStartSyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CObjectStartSyncPacket.cpp
@@ -19,20 +19,25 @@ bool CObjectStartSyncPacket::Write(NetBitStreamInterface& BitStream) const
     if (!m_pObject)
         return false;
 
-    // Write the ID
     BitStream.Write(m_pObject->GetID());
+    BitStream.WriteBit(m_pObject->IsDynamicPhysics());
 
-    // Write the position
     SPositionSync position;
     position.data.vecPosition = m_pObject->GetPosition();
     BitStream.Write(&position);
 
-    // Write the rotation
     SRotationRadiansSync rotation;
     m_pObject->GetRotation(rotation.data.vecRotation);
     BitStream.Write(&rotation);
 
-    // Write the health
+    SVelocitySync velocity;
+    velocity.data.vecVelocity = m_pObject->GetPhysicsVelocity();
+    BitStream.Write(&velocity);
+
+    SVelocitySync turnVelocity;
+    turnVelocity.data.vecVelocity = m_pObject->GetPhysicsTurnVelocity();
+    BitStream.Write(&turnVelocity);
+
     SObjectHealthSync health;
     health.data.fValue = m_pObject->GetHealth();
     BitStream.Write(&health);

--- a/Server/mods/deathmatch/logic/packets/CObjectSyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CObjectSyncPacket.cpp
@@ -3,7 +3,7 @@
  *  PROJECT:     Multi Theft Auto v1.0
  *  LICENSE:     See LICENSE in the top level directory
  *  FILE:        mods/deathmatch/logic/packets/CObjectSyncPacket.cpp
- *  PURPOSE:     Header for object sync packet class
+ *  PURPOSE:     Object sync packet class
  *
  *  Multi Theft Auto is available from https://www.multitheftauto.com/
  *
@@ -17,116 +17,142 @@ CObjectSyncPacket::~CObjectSyncPacket()
 {
     std::vector<SyncData*>::const_iterator iter = m_Syncs.begin();
     for (; iter != m_Syncs.end(); ++iter)
-    {
         delete *iter;
-    }
     m_Syncs.clear();
 }
 
 bool CObjectSyncPacket::Read(NetBitStreamInterface& BitStream)
 {
-    // While we're not out of bytes
     while (BitStream.GetNumberOfUnreadBits() > 8)
     {
-        // Read out the sync data
         SyncData* pData = new SyncData;
         pData->bSend = false;
 
-        // Read out the ID
-        if (!BitStream.Read(pData->ID))
+        if (!BitStream.Read(pData->ID) || !BitStream.Read(pData->ucSyncTimeContext))
+        {
+            delete pData;
             return false;
+        }
 
-        // Read the sync time context
-        if (!BitStream.Read(pData->ucSyncTimeContext))
-            return false;
-
-        // Read out flags
-        SIntegerSync<unsigned char, 3> flags;
+        SIntegerSync<unsigned char, 5> flags;
         if (!BitStream.Read(&flags))
+        {
+            delete pData;
             return false;
+        }
         pData->ucFlags = flags;
 
-        // Read out the position if we need
         if (flags & 0x1)
         {
             SPositionSync position;
             if (!BitStream.Read(&position))
+            {
+                delete pData;
                 return false;
+            }
             pData->vecPosition = position.data.vecPosition;
         }
 
-        // Read out the rotation
         if (flags & 0x2)
         {
             SRotationRadiansSync rotation;
             if (!BitStream.Read(&rotation))
+            {
+                delete pData;
                 return false;
+            }
             pData->vecRotation = rotation.data.vecRotation;
         }
 
-        // Read out the health
         if (flags & 0x4)
         {
             SObjectHealthSync health;
             if (!BitStream.Read(&health))
+            {
+                delete pData;
                 return false;
+            }
             pData->fHealth = health.data.fValue;
         }
 
-        // Add it to our list
+        if (flags & 0x8)
+        {
+            SVelocitySync velocity;
+            if (!BitStream.Read(&velocity))
+            {
+                delete pData;
+                return false;
+            }
+            pData->vecVelocity = velocity.data.vecVelocity;
+        }
+
+        if (flags & 0x10)
+        {
+            SVelocitySync turnVelocity;
+            if (!BitStream.Read(&turnVelocity))
+            {
+                delete pData;
+                return false;
+            }
+            pData->vecTurnVelocity = turnVelocity.data.vecVelocity;
+        }
+
         m_Syncs.push_back(pData);
     }
 
-    return m_Syncs.size() > 0;
+    return !m_Syncs.empty();
 }
 
 bool CObjectSyncPacket::Write(NetBitStreamInterface& BitStream) const
 {
-    bool                                   bSent = false;
-    std::vector<SyncData*>::const_iterator iter = m_Syncs.begin();
-    // Write syncs
-    for (; iter != m_Syncs.end(); ++iter)
+    bool bSent = false;
+    for (SyncData* pData : m_Syncs)
     {
-        SyncData* pData = *iter;
-        // If we're not supposed to ignore the packet
-        if (pData->bSend)
+        if (!pData->bSend || pData->ucFlags == 0)
+            continue;
+
+        BitStream.Write(pData->ID);
+        BitStream.Write(pData->ucSyncTimeContext);
+
+        SIntegerSync<unsigned char, 5> flags(pData->ucFlags);
+        BitStream.Write(&flags);
+
+        if (flags & 0x1)
         {
-            // Write the ID
-            BitStream.Write(pData->ID);
-
-            // Write the sync time context
-            BitStream.Write(pData->ucSyncTimeContext);
-
-            // Write flags
-            SIntegerSync<unsigned char, 3> flags(pData->ucFlags);
-            BitStream.Write(&flags);
-
-            // Write position if we need
-            if (flags & 0x1)
-            {
-                SPositionSync position;
-                position.data.vecPosition = pData->vecPosition;
-                BitStream.Write(&position);
-            }
-
-            // Write rotation
-            if (flags & 0x2)
-            {
-                SRotationRadiansSync rotation;
-                rotation.data.vecRotation = pData->vecRotation;
-                BitStream.Write(&rotation);
-            }
-
-            // Write health
-            if (flags & 0x4)
-            {
-                SObjectHealthSync health;
-                health.data.fValue = pData->fHealth;
-            }
-
-            // We've sent atleast one sync
-            bSent = true;
+            SPositionSync position;
+            position.data.vecPosition = pData->vecPosition;
+            BitStream.Write(&position);
         }
+
+        if (flags & 0x2)
+        {
+            SRotationRadiansSync rotation;
+            rotation.data.vecRotation = pData->vecRotation;
+            BitStream.Write(&rotation);
+        }
+
+        if (flags & 0x4)
+        {
+            SObjectHealthSync health;
+            health.data.fValue = pData->fHealth;
+            BitStream.Write(&health);
+        }
+
+        if (flags & 0x8)
+        {
+            SVelocitySync velocity;
+            velocity.data.vecVelocity = pData->vecVelocity;
+            BitStream.Write(&velocity);
+        }
+
+        if (flags & 0x10)
+        {
+            SVelocitySync turnVelocity;
+            turnVelocity.data.vecVelocity = pData->vecTurnVelocity;
+            BitStream.Write(&turnVelocity);
+        }
+
+        bSent = true;
     }
 
     return bSent;

--- a/Server/mods/deathmatch/logic/packets/CObjectSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CObjectSyncPacket.h
@@ -23,6 +23,8 @@ public:
         ElementID     ID;
         CVector       vecPosition;
         CVector       vecRotation;
+        CVector       vecVelocity;
+        CVector       vecTurnVelocity;
         float         fHealth;
         unsigned char ucSyncTimeContext;
         unsigned char ucFlags;

--- a/Shared/sdk/net/rpc_enums.h
+++ b/Shared/sdk/net/rpc_enums.h
@@ -298,5 +298,7 @@ enum eElementRPCFunctions
     ALLOCATE_SERVER_MODEL,
     FREE_SERVER_MODEL,
 
+    SET_OBJECT_DYNAMIC_PHYSICS,
+
     NUM_RPC_FUNCS  // Add above this line
 };

--- a/test-resources/physical-dropped-weapons/README.md
+++ b/test-resources/physical-dropped-weapons/README.md
@@ -1,0 +1,30 @@
+# Physical dropped weapons test resource
+
+Validation/showcase resource for Neon dynamic object physics and object velocity sync.
+
+## Setup
+
+Copy `physical-dropped-weapons` into the server resources directory and start it on a Neon client/server build containing this checkpoint.
+
+## Commands
+
+- `/physdrop` — drops the currently selected supported weapon; falls back to an AK-47 when unarmed/unsupported.
+- `/physdrop <weaponId> <ammo>` — drops a chosen weapon model and stores its test ammo server-side.
+- `/physpickup` — picks up the closest dropped weapon within 2.5 metres.
+- `E` — same as `/physpickup`.
+- `/physclear` — removes all test drops.
+
+The test command intentionally does not remove the weapon from the player, so the same drop can be spawned repeatedly while tuning physics.
+
+## Acceptance checks
+
+1. Stand on flat ground and run `/physdrop 30 90`. The AK should leave the player with forward/up velocity, rotate, collide, bounce slightly and settle.
+2. Drop from a roof or stairs. The final server position should follow the actual physics result rather than the creation point.
+3. Push a settled weapon with a player or vehicle. Object sync should resume while it moves and become quiet again once velocity/turn velocity reach zero.
+4. Connect a second client. Both clients should see the same final transform; the server-selected object syncer sends position, rotation, linear velocity and angular velocity.
+5. Disconnect the current nearby syncer while a weapon is moving. The replacement syncer receives the last server velocity/turn velocity in `CObjectStartSyncPacket` and continues from that state.
+6. Pick the weapon up with `E`. The server validates element ownership, dimension/interior and distance, removes the authoritative drop before granting the weapon, then destroys the physical object.
+
+## Notes
+
+`setObjectDynamicPhysics(object, true)` is server-side and opt-in. Normal MTA objects retain the old ObjectSync behaviour and do not send velocity fields. The physical state is reapplied when GTA recreates the streamed `CObject`, which matters for weapon models that otherwise receive the 99999-mass/no-gravity fallback from `object.dat` handling.

--- a/test-resources/physical-dropped-weapons/client.lua
+++ b/test-resources/physical-dropped-weapons/client.lua
@@ -1,0 +1,58 @@
+local pickupRadius = 2.5
+
+local function getClosestDrop(maxDistance)
+    local px, py, pz = getElementPosition(localPlayer)
+    local closest, closestDistanceSquared
+    local limitSquared = maxDistance * maxDistance
+
+    for _, object in ipairs(getElementsByType("object", root, true)) do
+        if getElementData(object, "physicalDrop") then
+            local ox, oy, oz = getElementPosition(object)
+            local dx, dy, dz = px - ox, py - oy, pz - oz
+            local distanceSquared = dx * dx + dy * dy + dz * dz
+            if distanceSquared <= limitSquared and (not closestDistanceSquared or distanceSquared < closestDistanceSquared) then
+                closest = object
+                closestDistanceSquared = distanceSquared
+            end
+        end
+    end
+
+    return closest, closestDistanceSquared and math.sqrt(closestDistanceSquared) or nil
+end
+
+local function pickupClosestDrop()
+    local object = getClosestDrop(pickupRadius)
+    if object then
+        triggerServerEvent("physicalDrop:pickup", resourceRoot, object)
+    end
+end
+
+addCommandHandler("physpickup", pickupClosestDrop)
+bindKey("e", "down", pickupClosestDrop)
+
+addEventHandler("onClientResourceStart", resourceRoot, function()
+    triggerServerEvent("physicalDrop:ready", resourceRoot)
+    outputChatBox("[physical-drop] /physdrop [weapon] [ammo] to throw; E or /physpickup to collect.", 160, 220, 255)
+end)
+
+addEventHandler("onClientRender", root, function()
+    local px, py, pz = getElementPosition(localPlayer)
+
+    for _, object in ipairs(getElementsByType("object", root, true)) do
+        if getElementData(object, "physicalDrop") then
+            local x, y, z = getElementPosition(object)
+            local dx, dy, dz = px - x, py - y, pz - z
+            local distanceSquared = dx * dx + dy * dy + dz * dz
+            if distanceSquared < 20 * 20 then
+                local sx, sy = getScreenFromWorldPosition(x, y, z + 0.35, 0.06)
+                if sx then
+                    local weapon = getElementData(object, "physicalDrop:weapon") or "?"
+                    local ammo = getElementData(object, "physicalDrop:ammo") or "?"
+                    local distance = math.sqrt(distanceSquared)
+                    local text = ("weapon %s | ammo %s | %.1fm"):format(tostring(weapon), tostring(ammo), distance)
+                    dxDrawText(text, sx - 180, sy - 15, sx + 180, sy + 15, tocolor(255, 255, 255, 230), 1, "default-bold", "center", "center")
+                end
+            end
+        end
+    end
+end)

--- a/test-resources/physical-dropped-weapons/meta.xml
+++ b/test-resources/physical-dropped-weapons/meta.xml
@@ -1,0 +1,5 @@
+<meta>
+    <info author="Neon" name="Physical dropped weapons" type="script" version="1.0.0" />
+    <script src="server.lua" type="server" />
+    <script src="client.lua" type="client" cache="false" />
+</meta>

--- a/test-resources/physical-dropped-weapons/server.lua
+++ b/test-resources/physical-dropped-weapons/server.lua
@@ -1,0 +1,161 @@
+local weaponModels = {
+    [22] = 346, -- Colt 45
+    [23] = 347, -- Silenced pistol
+    [24] = 348, -- Desert Eagle
+    [25] = 349, -- Shotgun
+    [26] = 350, -- Sawed-off
+    [27] = 351, -- Combat shotgun
+    [28] = 352, -- Uzi
+    [29] = 353, -- MP5
+    [30] = 355, -- AK-47
+    [31] = 356, -- M4
+    [32] = 372, -- Tec-9
+    [33] = 357, -- Country rifle
+    [34] = 358, -- Sniper rifle
+    [35] = 359, -- Rocket launcher
+    [36] = 360, -- Heat-seeking RPG
+    [37] = 361, -- Flamethrower
+    [38] = 362, -- Minigun
+    [39] = 363, -- Satchel
+    [41] = 365, -- Spraycan
+    [42] = 366, -- Fire extinguisher
+    [43] = 367, -- Camera
+    [46] = 371, -- Parachute
+}
+
+local drops = {}
+
+local function message(player, text, r, g, b)
+    outputChatBox("[physical-drop] " .. text, player, r or 210, g or 230, b or 255)
+end
+
+local function clamp(value, minimum, maximum)
+    return math.max(minimum, math.min(maximum, value))
+end
+
+local function createPhysicalDrop(player, weapon, ammo)
+    local model = weaponModels[weapon]
+    if not model then
+        message(player, "Unsupported weapon id " .. tostring(weapon), 255, 140, 120)
+        return false
+    end
+
+    local x, y, z = getElementPosition(player)
+    local _, _, heading = getElementRotation(player)
+    local radians = math.rad(heading)
+    local forwardX, forwardY = -math.sin(radians), math.cos(radians)
+
+    local object = createObject(model, x + forwardX * 1.0, y + forwardY * 1.0, z + 0.85, 0, 0, heading)
+    if not object then
+        message(player, "createObject failed for model " .. tostring(model), 255, 100, 100)
+        return false
+    end
+
+    setElementInterior(object, getElementInterior(player))
+    setElementDimension(object, getElementDimension(player))
+    setElementData(object, "physicalDrop", true)
+    setElementData(object, "physicalDrop:weapon", weapon)
+    setElementData(object, "physicalDrop:ammo", ammo)
+
+    if not setObjectDynamicPhysics(object, true) then
+        destroyElement(object)
+        message(player, "setObjectDynamicPhysics failed", 255, 100, 100)
+        return false
+    end
+
+    -- MTA velocity is expressed in GTA frame units. These values give a short
+    -- CS-like toss without turning the weapon into a projectile.
+    setElementVelocity(object, forwardX * 0.18, forwardY * 0.18, 0.11)
+    setElementAngularVelocity(object, 0.07, 0.11, 0.16)
+
+    drops[object] = {
+        weapon = weapon,
+        ammo = ammo,
+        owner = player,
+        createdAt = getTickCount(),
+    }
+
+    addEventHandler("onElementDestroy", object, function()
+        drops[source] = nil
+    end)
+
+    message(player, ("Dropped weapon %d / model %d / ammo %d"):format(weapon, model, ammo), 120, 255, 160)
+    return object
+end
+
+addCommandHandler("physdrop", function(player, _, weaponArgument, ammoArgument)
+    if not isElement(player) or getElementType(player) ~= "player" then
+        return
+    end
+
+    local weapon = tonumber(weaponArgument) or getPedWeapon(player)
+    if weapon == 0 or not weaponModels[weapon] then
+        weapon = 30
+    end
+
+    local ammo = tonumber(ammoArgument)
+    if not ammo then
+        ammo = weapon == getPedWeapon(player) and getPedTotalAmmo(player) or 90
+    end
+    ammo = clamp(math.floor(ammo), 1, 9999)
+
+    createPhysicalDrop(player, weapon, ammo)
+end)
+
+addCommandHandler("physclear", function(player)
+    local count = 0
+    for object in pairs(drops) do
+        if isElement(object) then
+            destroyElement(object)
+            count = count + 1
+        end
+    end
+    drops = {}
+    if isElement(player) then
+        message(player, "Cleared " .. count .. " drops")
+    end
+end)
+
+addEvent("physicalDrop:pickup", true)
+addEventHandler("physicalDrop:pickup", resourceRoot, function(object)
+    local player = client
+    local data = object and drops[object]
+    if not player or not data or not isElement(object) then
+        return
+    end
+
+    if getElementDimension(player) ~= getElementDimension(object) or getElementInterior(player) ~= getElementInterior(object) then
+        return
+    end
+
+    local px, py, pz = getElementPosition(player)
+    local ox, oy, oz = getElementPosition(object)
+    local dx, dy, dz = px - ox, py - oy, pz - oz
+    if dx * dx + dy * dy + dz * dz > 2.5 * 2.5 then
+        return
+    end
+
+    -- The authoritative table is removed before granting the item so two
+    -- pickup requests in the same frame cannot duplicate it.
+    drops[object] = nil
+    local weapon, ammo = data.weapon, data.ammo
+    destroyElement(object)
+    giveWeapon(player, weapon, ammo, true)
+    message(player, ("Picked up weapon %d with %d ammo"):format(weapon, ammo), 120, 255, 160)
+end)
+
+-- A player that joins after a drop was created did not see the original RPC.
+-- Replaying the idempotent setter when its client resource is ready gives it
+-- the same physics state; existing clients are unaffected.
+addEvent("physicalDrop:ready", true)
+addEventHandler("physicalDrop:ready", resourceRoot, function()
+    if not client then
+        return
+    end
+
+    for object in pairs(drops) do
+        if isElement(object) then
+            setObjectDynamicPhysics(object, true)
+        end
+    end
+end)


### PR DESCRIPTION
## Summary
- add opt-in `setObjectDynamicPhysics` server API and client GTA physics bridge
- override no-`object.dat` weapon defaults and reapply physics after streaming
- extend object sync with linear/angular velocity plus syncer migration state
- validate dynamic object velocity updates server-side
- fix missing object-health write in `CObjectSyncPacket::Write`
- add `physical-dropped-weapons` test/showcase resource with server-authoritative pickup

## Test resource
Start `test-resources/physical-dropped-weapons`, then use `/physdrop 30 90`; press `E` or `/physpickup` to collect. README includes multi-client, roof-drop, vehicle-push and syncer-migration checks.

## Protocol note
This extends the `PACKET_ID_OBJECT_SYNC` layout from 3 to 5 flags and extends `CObjectStartSyncPacket`, so client/server should be built from the same Neon checkpoint.