### PR TITLE
Fix dynamic object physics stream-in

### DIFF
--- a/Client/mods/deathmatch/logic/CClientObject.h
+++ b/Client/mods/deathmatch/logic/CClientObject.h
@@ -9,6 +9,7 @@
  *****************************************************************************/
 
 class CClientObject;
+class CClientObjectPhysicsManager;
 class CResource;
 
 #pragma once
@@ -37,6 +38,7 @@ class CClientObject : public CClientStreamElement
 {
     DECLARE_CLASS(CClientObject, CClientStreamElement)
     friend class CClientObjectManager;
+    friend class CClientObjectPhysicsManager;
     friend class CClientPed;
 
 public:
@@ -239,7 +241,7 @@ protected:
     const bool                    m_bIsLowLod;          // true if this object is low LOD
     CClientObject*                m_pLowLodObject;      // Pointer to low LOD version of this object
     std::vector<CClientObject*>   m_HighLodObjectList;  // List of objects that use this object as a low LOD version
-    bool                          m_IsHiddenLowLod;     // true if this object is low LOD and should not be drawn
+    bool                          m_IsHiddenLowLod;     // true if this object is low LOD and should be drawn
     std::shared_ptr<CClientModel> m_clientModel;
 
 public:

--- a/Client/mods/deathmatch/logic/CClientObjectPhysicsManager.h
+++ b/Client/mods/deathmatch/logic/CClientObjectPhysicsManager.h
@@ -102,11 +102,45 @@ private:
 
         if (!pObject->IsFrozen())
         {
-            pObjectSA->AddToMovingList();
             pObjectSA->SetStatic(false);
+            pObjectSA->AddToMovingList();
+
+            // The server can send the toss velocity before GTA has created the
+            // streamed CObject. CClientObject keeps those values cached, so
+            // restore them into every newly-created native instance.
+            pObjectSA->SetMoveSpeed(pObject->m_vecMoveSpeed);
+            CVector vecTurnSpeed = pObject->m_vecTurnSpeed;
+            pObjectSA->SetTurnSpeed(&vecTurnSpeed);
         }
 
         return true;
+    }
+
+    static void CacheLiveState(CClientObject* pObject)
+    {
+        CObjectSA* pObjectSA = GetObjectSA(pObject);
+        if (!pObjectSA)
+            return;
+
+        const CVector vecPosition = *pObjectSA->GetPosition();
+        CVector       vecRotation;
+        CVector       vecMoveSpeed;
+        CVector       vecTurnSpeed;
+        pObject->GetRotationRadians(vecRotation);
+        pObjectSA->GetMoveSpeed(&vecMoveSpeed);
+        pObjectSA->GetTurnSpeed(&vecTurnSpeed);
+
+        // Dynamic models such as weapons often have no object.dat group, so the
+        // normal CClientObject::StreamedInPulse path deliberately skips them.
+        // Keep the MTA element/streamer cache following the native GTA physics.
+        if (vecPosition != pObject->m_vecPosition)
+        {
+            pObject->m_vecPosition = vecPosition;
+            pObject->UpdateStreamPosition(vecPosition);
+        }
+        pObject->m_vecRotation = vecRotation;
+        pObject->m_vecMoveSpeed = vecMoveSpeed;
+        pObject->m_vecTurnSpeed = vecTurnSpeed;
     }
 
     static void Restore(CClientObject* pObject, SState& state)
@@ -184,7 +218,16 @@ public:
                 iter->second.bSnapshotValid = false;
                 Apply(pObject, iter->second);
             }
+
+            if (pObject->GetGameObject() && pObject->GetGameObject() == iter->second.pLastGameObject)
+                CacheLiveState(pObject);
+
             ++iter;
         }
+    }
+
+    static void Shutdown()
+    {
+        ms_Objects.clear();
     }
 };

--- a/Client/mods/deathmatch/logic/CClientWorldObjectManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientWorldObjectManager.cpp
@@ -10,6 +10,7 @@
 #include "StdInc.h"
 #include "CClientWorldObjectManager.h"
 #include "CClientWorldObject.h"
+#include "CClientObjectPhysicsManager.h"
 #include "../../../game_sa/CPoolSAInterface.h"
 #include "../../../game_sa/CPoolsSA.h"
 
@@ -125,6 +126,11 @@ void CClientWorldObjectManager::Pulse()
     if (!g_pClientGame || !g_pGame || !g_pMultiplayer)
         return;
 
+    // This manager already owns the unconditional client pre-frame pulse used
+    // by native-object features. Keep MTA-owned dynamic-object physics alive
+    // here too; CObjectSync may be compiled out entirely.
+    CClientObjectPhysicsManager::Pulse();
+
     RegisterForGame(g_pClientGame);
 
     if (g_pGame->GetSystemState() != SystemState::GS_PLAYING_GAME)
@@ -176,6 +182,7 @@ void CClientWorldObjectManager::Pulse()
 
 void CClientWorldObjectManager::Shutdown()
 {
+    CClientObjectPhysicsManager::Shutdown();
     ClearProxies();
 
     if (g_bHandlersInstalled && g_pMultiplayer)


### PR DESCRIPTION
Follow-up to #47. Run dynamic object physics from the unconditional client pre-frame path, restore cached linear/angular velocity when the native GTA object is created, and keep the MTA transform cache following weapon physics even without an object.dat group.