### PR TITLE
Add client-side custom foliage elements

### DIFF
--- a/Client/game_sa/CGameSA.h
+++ b/Client/game_sa/CGameSA.h
@@ -169,7 +169,7 @@ public:
     CFxManagerSA*             GetFxManagerSA() { return m_pFxManager; }
     CIplStore*                GetIplStore() { return m_pIplStore; };
     CCoverManagerSA*          GetCoverManager() const noexcept { return m_pCoverManager; };
-    CPlantManagerSA*          GetPlantManager() const noexcept { return m_pPlantManager; };
+    CPlantManagerSA*          GetPlantManager() noexcept override { return m_pPlantManager; };
     CBuildingRemoval*         GetBuildingRemoval() { return m_pBuildingRemoval; }
     CRenderer*                GetRenderer() const noexcept override { return m_pRenderer.get(); }
 

--- a/Client/game_sa/CPlantManagerSA.cpp
+++ b/Client/game_sa/CPlantManagerSA.cpp
@@ -59,13 +59,13 @@ namespace
     }
 }
 
-bool CPlantManager::IsValidSurface(std::uint8_t surface)
+bool CPlantManagerSA::IsValidSurface(std::uint8_t surface)
 {
     using GetSurfProperties = void*(__cdecl*)(uint16);
     return reinterpret_cast<GetSurfProperties>(FUNC_GET_SURF_PROPERTIES)(surface) != nullptr;
 }
 
-bool CPlantManager::IsValidTriangle(const CVector& v1, const CVector& v2, const CVector& v3)
+bool CPlantManagerSA::IsValidTriangle(const CVector& v1, const CVector& v2, const CVector& v3)
 {
     if (!IsFiniteVector(v1) || !IsFiniteVector(v2) || !IsFiniteVector(v3))
         return false;
@@ -85,7 +85,7 @@ bool CPlantManager::IsValidTriangle(const CVector& v1, const CVector& v2, const 
     return std::isfinite(crossLengthSquared) && crossLengthSquared > 1.0e-8f;
 }
 
-PlantTriangleHandle CPlantManager::CreateTriangle(const CVector& v1, const CVector& v2, const CVector& v3, std::uint8_t surface, float density)
+PlantTriangleHandle CPlantManagerSA::CreateTriangle(const CVector& v1, const CVector& v2, const CVector& v3, std::uint8_t surface, float density)
 {
     if (!IsValidTriangle(v1, v2, v3) || !IsValidSurface(surface) || !std::isfinite(density) || density < 0.0f || density > MAX_CUSTOM_DENSITY)
         return nullptr;
@@ -108,7 +108,7 @@ PlantTriangleHandle CPlantManager::CreateTriangle(const CVector& v1, const CVect
     return result;
 }
 
-void CPlantManager::DestroyTriangle(PlantTriangleHandle handle)
+void CPlantManagerSA::DestroyTriangle(PlantTriangleHandle handle)
 {
     if (!handle)
         return;

--- a/Client/game_sa/CPlantManagerSA.cpp
+++ b/Client/game_sa/CPlantManagerSA.cpp
@@ -1,7 +1,12 @@
-
 #include "StdInc.h"
 #include "CPlantManagerSA.h"
 #include "CPtrNodeSingleListSA.h"
+#include <game/CPlantManager.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
 
 class CPlantLocTri;
 
@@ -21,6 +26,96 @@ public:
         ((CPlantColEntEntry_ReleaseEntry)0x5DB8A0)(this);
     };
 };
+
+namespace
+{
+    constexpr std::uintptr_t FUNC_PLANT_LOC_TRI_ADD = 0x5DC290;
+    constexpr std::uintptr_t FUNC_PLANT_LOC_TRI_RELEASE = 0x5DB6D0;
+    constexpr std::uintptr_t FUNC_GET_SURF_PROPERTIES = 0x6F9DE0;
+    constexpr std::uintptr_t VAR_UNUSED_LOC_TRI_LIST_HEAD = 0xC03984;
+    constexpr float          MAX_CUSTOM_DENSITY = 10.0f;
+
+    struct CPlantLocTriSAInterface
+    {
+        CVector m_V1;
+        CVector m_V2;
+        CVector m_V3;
+        CVector m_Center;
+        float   m_fSphereRadius;
+        float   m_fSeed[3];
+        uint16  m_usMaxPlants[3];
+        uint8   m_ucSurface;
+        uint8   m_ucLighting;
+        uint8   m_ucFlags;
+        CPlantLocTriSAInterface* m_pNext;
+        CPlantLocTriSAInterface* m_pPrev;
+    };
+
+    static_assert(sizeof(CPlantLocTriSAInterface) == 0x54, "Unexpected CPlantLocTri layout");
+
+    bool IsFiniteVector(const CVector& value)
+    {
+        return std::isfinite(value.fX) && std::isfinite(value.fY) && std::isfinite(value.fZ);
+    }
+}
+
+bool CPlantManager::IsValidSurface(std::uint8_t surface)
+{
+    using GetSurfProperties = void*(__cdecl*)(uint16);
+    return reinterpret_cast<GetSurfProperties>(FUNC_GET_SURF_PROPERTIES)(surface) != nullptr;
+}
+
+bool CPlantManager::IsValidTriangle(const CVector& v1, const CVector& v2, const CVector& v3)
+{
+    if (!IsFiniteVector(v1) || !IsFiniteVector(v2) || !IsFiniteVector(v3))
+        return false;
+
+    const float ax = v2.fX - v1.fX;
+    const float ay = v2.fY - v1.fY;
+    const float az = v2.fZ - v1.fZ;
+    const float bx = v3.fX - v1.fX;
+    const float by = v3.fY - v1.fY;
+    const float bz = v3.fZ - v1.fZ;
+
+    const float cx = ay * bz - az * by;
+    const float cy = az * bx - ax * bz;
+    const float cz = ax * by - ay * bx;
+    const float crossLengthSquared = cx * cx + cy * cy + cz * cz;
+
+    return std::isfinite(crossLengthSquared) && crossLengthSquared > 1.0e-8f;
+}
+
+PlantTriangleHandle CPlantManager::CreateTriangle(const CVector& v1, const CVector& v2, const CVector& v3, std::uint8_t surface, float density)
+{
+    if (!IsValidTriangle(v1, v2, v3) || !IsValidSurface(surface) || !std::isfinite(density) || density < 0.0f || density > MAX_CUSTOM_DENSITY)
+        return nullptr;
+
+    auto* triangle = *reinterpret_cast<CPlantLocTriSAInterface**>(VAR_UNUSED_LOC_TRI_LIST_HEAD);
+    if (!triangle)
+        return nullptr;
+
+    using AddPlantTriangle = CPlantLocTriSAInterface*(__thiscall*)(CPlantLocTriSAInterface*, const CVector&, const CVector&, const CVector&, uint8, uint8, bool, bool);
+    auto* result = reinterpret_cast<AddPlantTriangle>(FUNC_PLANT_LOC_TRI_ADD)(triangle, v1, v2, v3, surface, 0xFF, true, false);
+    if (!result)
+        return nullptr;
+
+    for (auto& count : result->m_usMaxPlants)
+    {
+        const long scaled = std::lround(static_cast<double>(count) * static_cast<double>(density));
+        count = static_cast<uint16>(std::clamp<long>(scaled, 0, std::numeric_limits<uint16>::max()));
+    }
+
+    return result;
+}
+
+void CPlantManager::DestroyTriangle(PlantTriangleHandle handle)
+{
+    if (!handle)
+        return;
+
+    using ReleasePlantTriangle = void(__thiscall*)(CPlantLocTriSAInterface*);
+    reinterpret_cast<ReleasePlantTriangle>(FUNC_PLANT_LOC_TRI_RELEASE)(static_cast<CPlantLocTriSAInterface*>(handle));
+}
 
 void CPlantManagerSA::RemoveAllPlants()
 {

--- a/Client/game_sa/CPlantManagerSA.h
+++ b/Client/game_sa/CPlantManagerSA.h
@@ -1,12 +1,18 @@
 #pragma once
 
 #include "CEntitySA.h"
+#include <game/CPlantManager.h>
 
-class CPlantManagerSA
+class CPlantManagerSA : public CPlantManager
 {
 public:
     CPlantManagerSA() = default;
     ~CPlantManagerSA() = default;
+
+    PlantTriangleHandle CreateTriangle(const CVector& v1, const CVector& v2, const CVector& v3, std::uint8_t surface, float density) override;
+    void                DestroyTriangle(PlantTriangleHandle handle) override;
+    bool                IsValidSurface(std::uint8_t surface) override;
+    bool                IsValidTriangle(const CVector& v1, const CVector& v2, const CVector& v3) override;
 
     void RemovePlant(CEntitySAInterface* enity)
     {

--- a/Client/mods/deathmatch/logic/CClientFoliage.cpp
+++ b/Client/mods/deathmatch/logic/CClientFoliage.cpp
@@ -1,0 +1,159 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.x
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Client/mods/deathmatch/logic/CClientFoliage.cpp
+ *  PURPOSE:     Client custom foliage element
+ *
+ *****************************************************************************/
+
+#include <StdInc.h>
+#include "CClientFoliage.h"
+#include "CClientFoliageManager.h"
+
+CClientFoliage::CClientFoliage(CClientManager* pManager, ElementID ID) : CClientEntity(ID)
+{
+    m_pManager = pManager;
+    m_pFoliageManager = &CClientFoliageManager::GetSingleton();
+
+    SetTypeName("foliage");
+    m_pFoliageManager->AddToList(this);
+}
+
+CClientFoliage::~CClientFoliage()
+{
+    StreamOut();
+    Unlink();
+}
+
+bool CClientFoliage::Initialize(const CVector& v1, const CVector& v2, const CVector& v3, std::uint8_t surface, float density)
+{
+    if (!CPlantManager::IsValidTriangle(v1, v2, v3) || !CPlantManager::IsValidSurface(surface) || !std::isfinite(density) || density < 0.0f || density > 10.0f)
+        return false;
+
+    m_vecVertices[0] = v1;
+    m_vecVertices[1] = v2;
+    m_vecVertices[2] = v3;
+    m_ucSurface = surface;
+    m_fDensity = density;
+
+    if (m_usDimension == m_pFoliageManager->GetDimension())
+        return StreamIn();
+
+    return true;
+}
+
+void CClientFoliage::GetPosition(CVector& vecPosition) const
+{
+    vecPosition.fX = (m_vecVertices[0].fX + m_vecVertices[1].fX + m_vecVertices[2].fX) / 3.0f;
+    vecPosition.fY = (m_vecVertices[0].fY + m_vecVertices[1].fY + m_vecVertices[2].fY) / 3.0f;
+    vecPosition.fZ = (m_vecVertices[0].fZ + m_vecVertices[1].fZ + m_vecVertices[2].fZ) / 3.0f;
+}
+
+void CClientFoliage::SetPosition(const CVector& vecPosition)
+{
+    CVector currentPosition;
+    GetPosition(currentPosition);
+
+    const CVector delta(vecPosition.fX - currentPosition.fX, vecPosition.fY - currentPosition.fY, vecPosition.fZ - currentPosition.fZ);
+    SetVertices(CVector(m_vecVertices[0].fX + delta.fX, m_vecVertices[0].fY + delta.fY, m_vecVertices[0].fZ + delta.fZ),
+                CVector(m_vecVertices[1].fX + delta.fX, m_vecVertices[1].fY + delta.fY, m_vecVertices[1].fZ + delta.fZ),
+                CVector(m_vecVertices[2].fX + delta.fX, m_vecVertices[2].fY + delta.fY, m_vecVertices[2].fZ + delta.fZ));
+}
+
+void CClientFoliage::SetDimension(unsigned short usDimension)
+{
+    CClientEntity::SetDimension(usDimension);
+    RelateDimension(m_pFoliageManager->GetDimension());
+}
+
+void CClientFoliage::GetVertices(CVector& v1, CVector& v2, CVector& v3) const
+{
+    v1 = m_vecVertices[0];
+    v2 = m_vecVertices[1];
+    v3 = m_vecVertices[2];
+}
+
+bool CClientFoliage::SetVertices(const CVector& v1, const CVector& v2, const CVector& v3)
+{
+    return Rebuild(v1, v2, v3, m_ucSurface, m_fDensity);
+}
+
+bool CClientFoliage::SetSurface(std::uint8_t surface)
+{
+    return Rebuild(m_vecVertices[0], m_vecVertices[1], m_vecVertices[2], surface, m_fDensity);
+}
+
+bool CClientFoliage::SetDensity(float density)
+{
+    return Rebuild(m_vecVertices[0], m_vecVertices[1], m_vecVertices[2], m_ucSurface, density);
+}
+
+bool CClientFoliage::StreamIn()
+{
+    if (m_pNativeTriangle)
+        return true;
+
+    if (m_usDimension != m_pFoliageManager->GetDimension())
+        return true;
+
+    m_pNativeTriangle = CPlantManager::CreateTriangle(m_vecVertices[0], m_vecVertices[1], m_vecVertices[2], m_ucSurface, m_fDensity);
+    return m_pNativeTriangle != nullptr;
+}
+
+void CClientFoliage::StreamOut()
+{
+    if (!m_pNativeTriangle)
+        return;
+
+    CPlantManager::DestroyTriangle(m_pNativeTriangle);
+    m_pNativeTriangle = nullptr;
+}
+
+void CClientFoliage::RelateDimension(unsigned short usDimension)
+{
+    if (usDimension == m_usDimension)
+        StreamIn();
+    else
+        StreamOut();
+}
+
+void CClientFoliage::Unlink()
+{
+    if (m_pFoliageManager)
+    {
+        m_pFoliageManager->RemoveFromList(this);
+        m_pFoliageManager = nullptr;
+    }
+}
+
+bool CClientFoliage::Rebuild(const CVector& v1, const CVector& v2, const CVector& v3, std::uint8_t surface, float density)
+{
+    if (!CPlantManager::IsValidTriangle(v1, v2, v3) || !CPlantManager::IsValidSurface(surface) || !std::isfinite(density) || density < 0.0f || density > 10.0f)
+        return false;
+
+    const CVector oldVertices[3] = {m_vecVertices[0], m_vecVertices[1], m_vecVertices[2]};
+    const auto    oldSurface = m_ucSurface;
+    const float   oldDensity = m_fDensity;
+    const bool    active = m_usDimension == m_pFoliageManager->GetDimension();
+
+    if (active)
+        StreamOut();
+
+    m_vecVertices[0] = v1;
+    m_vecVertices[1] = v2;
+    m_vecVertices[2] = v3;
+    m_ucSurface = surface;
+    m_fDensity = density;
+
+    if (!active || StreamIn())
+        return true;
+
+    m_vecVertices[0] = oldVertices[0];
+    m_vecVertices[1] = oldVertices[1];
+    m_vecVertices[2] = oldVertices[2];
+    m_ucSurface = oldSurface;
+    m_fDensity = oldDensity;
+    StreamIn();
+    return false;
+}

--- a/Client/mods/deathmatch/logic/CClientFoliage.cpp
+++ b/Client/mods/deathmatch/logic/CClientFoliage.cpp
@@ -28,7 +28,8 @@ CClientFoliage::~CClientFoliage()
 
 bool CClientFoliage::Initialize(const CVector& v1, const CVector& v2, const CVector& v3, std::uint8_t surface, float density)
 {
-    if (!CPlantManager::IsValidTriangle(v1, v2, v3) || !CPlantManager::IsValidSurface(surface) || !std::isfinite(density) || density < 0.0f || density > 10.0f)
+    CPlantManager* plantManager = g_pGame->GetPlantManager();
+    if (!plantManager || !plantManager->IsValidTriangle(v1, v2, v3) || !plantManager->IsValidSurface(surface) || !std::isfinite(density) || density < 0.0f || density > 10.0f)
         return false;
 
     m_vecVertices[0] = v1;
@@ -97,7 +98,8 @@ bool CClientFoliage::StreamIn()
     if (m_usDimension != m_pFoliageManager->GetDimension())
         return true;
 
-    m_pNativeTriangle = CPlantManager::CreateTriangle(m_vecVertices[0], m_vecVertices[1], m_vecVertices[2], m_ucSurface, m_fDensity);
+    CPlantManager* plantManager = g_pGame->GetPlantManager();
+    m_pNativeTriangle = plantManager ? plantManager->CreateTriangle(m_vecVertices[0], m_vecVertices[1], m_vecVertices[2], m_ucSurface, m_fDensity) : nullptr;
     return m_pNativeTriangle != nullptr;
 }
 
@@ -106,7 +108,8 @@ void CClientFoliage::StreamOut()
     if (!m_pNativeTriangle)
         return;
 
-    CPlantManager::DestroyTriangle(m_pNativeTriangle);
+    if (CPlantManager* plantManager = g_pGame->GetPlantManager())
+        plantManager->DestroyTriangle(m_pNativeTriangle);
     m_pNativeTriangle = nullptr;
 }
 
@@ -129,7 +132,8 @@ void CClientFoliage::Unlink()
 
 bool CClientFoliage::Rebuild(const CVector& v1, const CVector& v2, const CVector& v3, std::uint8_t surface, float density)
 {
-    if (!CPlantManager::IsValidTriangle(v1, v2, v3) || !CPlantManager::IsValidSurface(surface) || !std::isfinite(density) || density < 0.0f || density > 10.0f)
+    CPlantManager* plantManager = g_pGame->GetPlantManager();
+    if (!plantManager || !plantManager->IsValidTriangle(v1, v2, v3) || !plantManager->IsValidSurface(surface) || !std::isfinite(density) || density < 0.0f || density > 10.0f)
         return false;
 
     const CVector oldVertices[3] = {m_vecVertices[0], m_vecVertices[1], m_vecVertices[2]};

--- a/Client/mods/deathmatch/logic/CClientFoliage.h
+++ b/Client/mods/deathmatch/logic/CClientFoliage.h
@@ -1,0 +1,56 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.x
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Client/mods/deathmatch/logic/CClientFoliage.h
+ *  PURPOSE:     Client custom foliage element
+ *
+ *****************************************************************************/
+
+#pragma once
+
+#include "CClientEntity.h"
+#include <game/CPlantManager.h>
+#include <cstdint>
+
+class CClientFoliageManager;
+
+class CClientFoliage final : public CClientEntity
+{
+    friend class CClientFoliageManager;
+
+public:
+    CClientFoliage(CClientManager* pManager, ElementID ID);
+    ~CClientFoliage();
+
+    eClientEntityType GetType() const { return CCLIENTUNKNOWN; }
+
+    bool Initialize(const CVector& v1, const CVector& v2, const CVector& v3, std::uint8_t surface, float density);
+
+    void GetPosition(CVector& vecPosition) const override;
+    void SetPosition(const CVector& vecPosition) override;
+    void SetDimension(unsigned short usDimension) override;
+
+    void GetVertices(CVector& v1, CVector& v2, CVector& v3) const;
+    bool SetVertices(const CVector& v1, const CVector& v2, const CVector& v3);
+
+    std::uint8_t GetSurface() const { return m_ucSurface; }
+    bool         SetSurface(std::uint8_t surface);
+
+    float GetDensity() const { return m_fDensity; }
+    bool  SetDensity(float density);
+
+    bool StreamIn();
+    void StreamOut();
+    void RelateDimension(unsigned short usDimension);
+    void Unlink();
+
+private:
+    bool Rebuild(const CVector& v1, const CVector& v2, const CVector& v3, std::uint8_t surface, float density);
+
+    CClientFoliageManager* m_pFoliageManager = nullptr;
+    CVector                m_vecVertices[3];
+    std::uint8_t           m_ucSurface = 0;
+    float                  m_fDensity = 1.0f;
+    PlantTriangleHandle    m_pNativeTriangle = nullptr;
+};

--- a/Client/mods/deathmatch/logic/CClientFoliage.h
+++ b/Client/mods/deathmatch/logic/CClientFoliage.h
@@ -23,7 +23,7 @@ public:
     CClientFoliage(CClientManager* pManager, ElementID ID);
     ~CClientFoliage();
 
-    eClientEntityType GetType() const { return CCLIENTUNKNOWN; }
+    eClientEntityType GetType() const { return CCLIENTDUMMY; }
 
     bool Initialize(const CVector& v1, const CVector& v2, const CVector& v3, std::uint8_t surface, float density);
 

--- a/Client/mods/deathmatch/logic/CClientFoliageManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientFoliageManager.cpp
@@ -1,0 +1,58 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.x
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Client/mods/deathmatch/logic/CClientFoliageManager.cpp
+ *  PURPOSE:     Client custom foliage manager
+ *
+ *****************************************************************************/
+
+#include <StdInc.h>
+#include "CClientFoliageManager.h"
+#include "CClientFoliage.h"
+
+CClientFoliageManager& CClientFoliageManager::GetSingleton()
+{
+    static CClientFoliageManager manager;
+    return manager;
+}
+
+CClientFoliage* CClientFoliageManager::Create(CClientManager* pManager, ElementID ID)
+{
+    if (m_List.size() >= MAX_CUSTOM_FOLIAGE)
+        return nullptr;
+
+    if (ID != INVALID_ELEMENT_ID && Get(ID))
+        return nullptr;
+
+    return new CClientFoliage(pManager, ID);
+}
+
+CClientFoliage* CClientFoliageManager::Get(ElementID ID)
+{
+    for (CClientFoliage* pFoliage : m_List)
+    {
+        if (pFoliage->GetID() == ID)
+            return pFoliage;
+    }
+
+    return nullptr;
+}
+
+void CClientFoliageManager::SetDimension(unsigned short usDimension)
+{
+    m_usDimension = usDimension;
+
+    for (CClientFoliage* pFoliage : m_List)
+        pFoliage->RelateDimension(usDimension);
+}
+
+void CClientFoliageManager::AddToList(CClientFoliage* pFoliage)
+{
+    m_List.push_back(pFoliage);
+}
+
+void CClientFoliageManager::RemoveFromList(CClientFoliage* pFoliage)
+{
+    m_List.remove(pFoliage);
+}

--- a/Client/mods/deathmatch/logic/CClientFoliageManager.h
+++ b/Client/mods/deathmatch/logic/CClientFoliageManager.h
@@ -1,0 +1,43 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.x
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Client/mods/deathmatch/logic/CClientFoliageManager.h
+ *  PURPOSE:     Client custom foliage manager
+ *
+ *****************************************************************************/
+
+#pragma once
+
+#include "CClientEntity.h"
+#include <cstddef>
+#include <list>
+
+class CClientFoliage;
+class CClientManager;
+
+class CClientFoliageManager
+{
+    friend class CClientFoliage;
+
+public:
+    static CClientFoliageManager& GetSingleton();
+
+    CClientFoliage* Create(CClientManager* pManager, ElementID ID);
+    CClientFoliage* Get(ElementID ID);
+
+    void           SetDimension(unsigned short usDimension);
+    unsigned short GetDimension() const { return m_usDimension; }
+    std::size_t    GetCount() const { return m_List.size(); }
+
+    static constexpr std::size_t MAX_CUSTOM_FOLIAGE = 64;
+
+private:
+    CClientFoliageManager() = default;
+
+    void AddToList(CClientFoliage* pFoliage);
+    void RemoveFromList(CClientFoliage* pFoliage);
+
+    std::list<CClientFoliage*> m_List;
+    unsigned short             m_usDimension = 0;
+};

--- a/Client/mods/deathmatch/logic/CClientPointLightsManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientPointLightsManager.cpp
@@ -9,6 +9,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include "CClientFoliageManager.h"
 #include <game/CPointLights.h>
 
 using std::list;
@@ -84,6 +85,7 @@ void CClientPointLightsManager::SetDimension(unsigned short usDimension)
     }
 
     m_usDimension = usDimension;
+    CClientFoliageManager::GetSingleton().SetDimension(usDimension);
 }
 
 void CClientPointLightsManager::DoPulse()

--- a/Client/mods/deathmatch/logic/luadefs/CLuaClassDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaClassDefs.cpp
@@ -278,6 +278,10 @@ const char* CLuaClassDefs::GetXmlNodeClass(CXMLNode* pXmlNode)
 const char* CLuaClassDefs::GetEntityClass(CClientEntity* pEntity)
 {
     assert(pEntity);
+
+    if (pEntity->GetTypeHash() == CClientEntity::GetTypeHashFromString("foliage"))
+        return "Foliage";
+
     switch (pEntity->GetType())
     {
         case CCLIENTCAMERA:

--- a/Client/mods/deathmatch/logic/luadefs/CLuaFoliageDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaFoliageDefs.cpp
@@ -1,0 +1,205 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.x
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Client/mods/deathmatch/logic/luadefs/CLuaFoliageDefs.cpp
+ *  PURPOSE:     Lua custom foliage definitions
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+#include "CLuaFoliageDefs.h"
+#include "../CClientFoliage.h"
+#include "../CClientFoliageManager.h"
+
+namespace
+{
+    CClientFoliage* ReadFoliage(CScriptArgReader& argStream)
+    {
+        CClientEntity* pEntity = nullptr;
+        argStream.ReadUserData(pEntity);
+
+        if (argStream.HasErrors() || !pEntity || pEntity->GetTypeHash() != CClientEntity::GetTypeHashFromString("foliage"))
+            return nullptr;
+
+        return static_cast<CClientFoliage*>(pEntity);
+    }
+
+    void PushVector3(lua_State* luaVM, const CVector& value)
+    {
+        lua_getglobal(luaVM, "Vector3");
+        lua_pushnumber(luaVM, value.fX);
+        lua_pushnumber(luaVM, value.fY);
+        lua_pushnumber(luaVM, value.fZ);
+        lua_call(luaVM, 3, 1);
+    }
+}
+
+void CLuaFoliageDefs::LoadFunctions()
+{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
+        {"createFoliage", CreateFoliage},             {"getFoliageSurface", GetFoliageSurface},
+        {"setFoliageSurface", SetFoliageSurface},     {"getFoliageVertices", GetFoliageVertices},
+        {"setFoliageVertices", SetFoliageVertices},   {"getFoliageDensity", GetFoliageDensity},
+        {"setFoliageDensity", SetFoliageDensity},
+    };
+
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
+}
+
+void CLuaFoliageDefs::AddClass(lua_State* luaVM)
+{
+    lua_newclass(luaVM);
+
+    lua_classfunction(luaVM, "create", "createFoliage");
+    lua_classfunction(luaVM, "getSurface", "getFoliageSurface");
+    lua_classfunction(luaVM, "setSurface", "setFoliageSurface");
+    lua_classfunction(luaVM, "getVertices", "getFoliageVertices");
+    lua_classfunction(luaVM, "setVertices", "setFoliageVertices");
+    lua_classfunction(luaVM, "getDensity", "getFoliageDensity");
+    lua_classfunction(luaVM, "setDensity", "setFoliageDensity");
+
+    lua_classvariable(luaVM, "surface", "setFoliageSurface", "getFoliageSurface");
+    lua_classvariable(luaVM, "density", "setFoliageDensity", "getFoliageDensity");
+
+    lua_registerclass(luaVM, "Foliage", "Element");
+}
+
+int CLuaFoliageDefs::CreateFoliage(lua_State* luaVM)
+{
+    CVector v1;
+    CVector v2;
+    CVector v3;
+    int     surface;
+    float   density;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadVector3D(v1);
+    argStream.ReadVector3D(v2);
+    argStream.ReadVector3D(v3);
+    argStream.ReadNumber(surface);
+    argStream.ReadNumber(density, 1.0f);
+
+    if (!argStream.HasErrors() && surface >= 0 && surface <= 255)
+    {
+        CLuaMain*  pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
+        CResource* pResource = pLuaMain ? pLuaMain->GetResource() : nullptr;
+        if (pResource)
+        {
+            auto& foliageManager = CClientFoliageManager::GetSingleton();
+            foliageManager.SetDimension(m_pManager->GetPointLightsManager()->GetDimension());
+
+            CClientFoliage* pFoliage = foliageManager.Create(m_pManager, INVALID_ELEMENT_ID);
+            if (pFoliage)
+            {
+                if (pFoliage->Initialize(v1, v2, v3, static_cast<std::uint8_t>(surface), density))
+                {
+                    pFoliage->SetParent(pResource->GetResourceDynamicEntity());
+                    if (CElementGroup* pGroup = pResource->GetElementGroup())
+                        pGroup->Add(pFoliage);
+
+                    lua_pushelement(luaVM, pFoliage);
+                    return 1;
+                }
+
+                delete pFoliage;
+            }
+        }
+    }
+    else if (argStream.HasErrors())
+    {
+        m_pScriptDebugging->LogCustom(luaVM, SString("Bad argument @ '%s' [%s]", lua_tostring(luaVM, lua_upvalueindex(1)), *argStream.GetErrorMessage()));
+    }
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFoliageDefs::GetFoliageSurface(lua_State* luaVM)
+{
+    CScriptArgReader argStream(luaVM);
+    CClientFoliage* pFoliage = ReadFoliage(argStream);
+
+    if (pFoliage)
+    {
+        lua_pushnumber(luaVM, pFoliage->GetSurface());
+        return 1;
+    }
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFoliageDefs::SetFoliageSurface(lua_State* luaVM)
+{
+    CScriptArgReader argStream(luaVM);
+    CClientFoliage* pFoliage = ReadFoliage(argStream);
+    int             surface = -1;
+    argStream.ReadNumber(surface);
+
+    lua_pushboolean(luaVM, pFoliage && !argStream.HasErrors() && surface >= 0 && surface <= 255 && pFoliage->SetSurface(static_cast<std::uint8_t>(surface)));
+    return 1;
+}
+
+int CLuaFoliageDefs::GetFoliageVertices(lua_State* luaVM)
+{
+    CScriptArgReader argStream(luaVM);
+    CClientFoliage* pFoliage = ReadFoliage(argStream);
+
+    if (pFoliage)
+    {
+        CVector v1;
+        CVector v2;
+        CVector v3;
+        pFoliage->GetVertices(v1, v2, v3);
+        PushVector3(luaVM, v1);
+        PushVector3(luaVM, v2);
+        PushVector3(luaVM, v3);
+        return 3;
+    }
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFoliageDefs::SetFoliageVertices(lua_State* luaVM)
+{
+    CScriptArgReader argStream(luaVM);
+    CClientFoliage* pFoliage = ReadFoliage(argStream);
+    CVector         v1;
+    CVector         v2;
+    CVector         v3;
+    argStream.ReadVector3D(v1);
+    argStream.ReadVector3D(v2);
+    argStream.ReadVector3D(v3);
+
+    lua_pushboolean(luaVM, pFoliage && !argStream.HasErrors() && pFoliage->SetVertices(v1, v2, v3));
+    return 1;
+}
+
+int CLuaFoliageDefs::GetFoliageDensity(lua_State* luaVM)
+{
+    CScriptArgReader argStream(luaVM);
+    CClientFoliage* pFoliage = ReadFoliage(argStream);
+
+    if (pFoliage)
+    {
+        lua_pushnumber(luaVM, pFoliage->GetDensity());
+        return 1;
+    }
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFoliageDefs::SetFoliageDensity(lua_State* luaVM)
+{
+    CScriptArgReader argStream(luaVM);
+    CClientFoliage* pFoliage = ReadFoliage(argStream);
+    float           density = 0.0f;
+    argStream.ReadNumber(density);
+
+    lua_pushboolean(luaVM, pFoliage && !argStream.HasErrors() && pFoliage->SetDensity(density));
+    return 1;
+}

--- a/Client/mods/deathmatch/logic/luadefs/CLuaFoliageDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaFoliageDefs.h
@@ -1,0 +1,27 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.x
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Client/mods/deathmatch/logic/luadefs/CLuaFoliageDefs.h
+ *  PURPOSE:     Lua custom foliage definitions
+ *
+ *****************************************************************************/
+
+#pragma once
+
+#include "CLuaDefs.h"
+
+class CLuaFoliageDefs : public CLuaDefs
+{
+public:
+    static void LoadFunctions();
+    static void AddClass(lua_State* luaVM);
+
+    LUA_DECLARE(CreateFoliage);
+    LUA_DECLARE(GetFoliageSurface);
+    LUA_DECLARE(SetFoliageSurface);
+    LUA_DECLARE(GetFoliageVertices);
+    LUA_DECLARE(SetFoliageVertices);
+    LUA_DECLARE(GetFoliageDensity);
+    LUA_DECLARE(SetFoliageDensity);
+};

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.cpp
@@ -10,6 +10,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include "CLuaFoliageDefs.h"
 
 void CLuaPointLightDefs::LoadFunctions()
 {
@@ -21,6 +22,8 @@ void CLuaPointLightDefs::LoadFunctions()
     // Add functions
     for (const auto& [name, func] : functions)
         CLuaCFunctions::AddFunction(name, func);
+
+    CLuaFoliageDefs::LoadFunctions();
 }
 
 void CLuaPointLightDefs::AddClass(lua_State* luaVM)
@@ -43,6 +46,8 @@ void CLuaPointLightDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "direction", "setLightDirection", "getLightDirection");
 
     lua_registerclass(luaVM, "Light", "Element");
+
+    CLuaFoliageDefs::AddClass(luaVM);
 }
 
 int CLuaPointLightDefs::CreateLight(lua_State* luaVM)

--- a/Client/sdk/game/CGame.h
+++ b/Client/sdk/game/CGame.h
@@ -50,6 +50,7 @@ class CHud;
 class CKeyGen;
 class CModelInfo;
 class CObjectGroupPhysicalProperties;
+class CPlantManager;
 class CPad;
 class CPathFind;
 class CPed;
@@ -737,4 +738,9 @@ public:
     virtual bool UpdateAmbientPedCivilianCouplePresentation(unsigned int nativePresentationId, CPed* a, CPed* b) = 0;
     virtual bool ReleaseAmbientPedCivilianCouplePresentation(unsigned int nativePresentationId, CPed* a, CPed* b) = 0;
     virtual bool IsAmbientPedCivilianCouplePresentationActive(unsigned int nativePresentationId, CPed* a, CPed* b) const = 0;
+
+    // Custom foliage calls GTA plant natives through Game SA. Keep the
+    // process-local implementation behind the module boundary so client.dll
+    // does not link directly against symbols owned by game_sa.dll.
+    virtual CPlantManager* GetPlantManager() = 0;
 };

--- a/Client/sdk/game/CPlantManager.h
+++ b/Client/sdk/game/CPlantManager.h
@@ -17,9 +17,11 @@ using PlantTriangleHandle = void*;
 class CPlantManager
 {
 public:
-    static PlantTriangleHandle CreateTriangle(const CVector& v1, const CVector& v2, const CVector& v3, std::uint8_t surface, float density);
-    static void                DestroyTriangle(PlantTriangleHandle handle);
+    virtual ~CPlantManager() = default;
 
-    static bool IsValidSurface(std::uint8_t surface);
-    static bool IsValidTriangle(const CVector& v1, const CVector& v2, const CVector& v3);
+    virtual PlantTriangleHandle CreateTriangle(const CVector& v1, const CVector& v2, const CVector& v3, std::uint8_t surface, float density) = 0;
+    virtual void                DestroyTriangle(PlantTriangleHandle handle) = 0;
+
+    virtual bool IsValidSurface(std::uint8_t surface) = 0;
+    virtual bool IsValidTriangle(const CVector& v1, const CVector& v2, const CVector& v3) = 0;
 };

--- a/Client/sdk/game/CPlantManager.h
+++ b/Client/sdk/game/CPlantManager.h
@@ -1,0 +1,25 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.x
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Client/sdk/game/CPlantManager.h
+ *  PURPOSE:     Custom procedural foliage triangle interface
+ *
+ *****************************************************************************/
+
+#pragma once
+
+#include <CVector.h>
+#include <cstdint>
+
+using PlantTriangleHandle = void*;
+
+class CPlantManager
+{
+public:
+    static PlantTriangleHandle CreateTriangle(const CVector& v1, const CVector& v2, const CVector& v3, std::uint8_t surface, float density);
+    static void                DestroyTriangle(PlantTriangleHandle handle);
+
+    static bool IsValidSurface(std::uint8_t surface);
+    static bool IsValidTriangle(const CVector& v1, const CVector& v2, const CVector& v3);
+};

--- a/test-resources/foliage-draw-demo/client.lua
+++ b/test-resources/foliage-draw-demo/client.lua
@@ -21,7 +21,9 @@ end
 local function clearTriangle()
     destroyFoliage()
     points = {}
+    cursorWorld = nil
     errorText = nil
+    showCursor(true)
 end
 
 local function createTriangleFoliage()
@@ -80,6 +82,8 @@ addEventHandler("onClientClick", root, function(button, state, _, _, worldX, wor
     points[#points + 1] = Vector3(worldX, worldY, worldZ + 0.06)
     if #points == 3 then
         createTriangleFoliage()
+        cursorWorld = nil
+        showCursor(false)
     end
 end)
 

--- a/test-resources/foliage-draw-demo/client.lua
+++ b/test-resources/foliage-draw-demo/client.lua
@@ -1,0 +1,157 @@
+local surfaces = {3, 9, 10, 11}
+local surfaceIndex = #surfaces
+local density = 1.0
+local points = {}
+local foliage
+local cursorWorld
+local errorText
+local cursorWasShowing = isCursorShowing()
+
+local function currentSurface()
+    return surfaces[surfaceIndex]
+end
+
+local function destroyFoliage()
+    if isElement(foliage) then
+        destroyElement(foliage)
+    end
+    foliage = nil
+end
+
+local function clearTriangle()
+    destroyFoliage()
+    points = {}
+    errorText = nil
+end
+
+local function createTriangleFoliage()
+    destroyFoliage()
+
+    foliage = createFoliage(points[1], points[2], points[3], currentSurface(), density)
+    if not isElement(foliage) then
+        foliage = nil
+        errorText = "creation failed"
+        return
+    end
+
+    setElementDimension(foliage, getElementDimension(localPlayer))
+    errorText = nil
+end
+
+local function setSurfaceIndex(index)
+    local nextIndex = ((index - 1) % #surfaces) + 1
+    local nextSurface = surfaces[nextIndex]
+
+    if isElement(foliage) and not setFoliageSurface(foliage, nextSurface) then
+        errorText = "surface change failed"
+        return
+    end
+
+    surfaceIndex = nextIndex
+    errorText = nil
+end
+
+local function setDensity(value)
+    local nextDensity = math.max(0, math.min(10, value))
+
+    if isElement(foliage) and not setFoliageDensity(foliage, nextDensity) then
+        errorText = "density change failed"
+        return
+    end
+
+    density = nextDensity
+    errorText = nil
+end
+
+addEventHandler("onClientClick", root, function(button, state, _, _, worldX, worldY, worldZ)
+    if state ~= "down" then
+        return
+    end
+
+    if button == "right" then
+        clearTriangle()
+        return
+    end
+
+    if button ~= "left" or #points >= 3 or not worldX then
+        return
+    end
+
+    points[#points + 1] = Vector3(worldX, worldY, worldZ + 0.06)
+    if #points == 3 then
+        createTriangleFoliage()
+    end
+end)
+
+addEventHandler("onClientCursorMove", root, function(_, _, _, _, worldX, worldY, worldZ)
+    if worldX then
+        cursorWorld = Vector3(worldX, worldY, worldZ + 0.06)
+    else
+        cursorWorld = nil
+    end
+end)
+
+bindKey("arrow_l", "down", function()
+    setSurfaceIndex(surfaceIndex - 1)
+end)
+
+bindKey("arrow_r", "down", function()
+    setSurfaceIndex(surfaceIndex + 1)
+end)
+
+bindKey("mouse_wheel_up", "down", function()
+    setDensity(density + 0.25)
+end)
+
+bindKey("mouse_wheel_down", "down", function()
+    setDensity(density - 0.25)
+end)
+
+local function drawPoint(point)
+    local size = 0.18
+    dxDrawLine3D(point.x - size, point.y, point.z + 0.04, point.x + size, point.y, point.z + 0.04, tocolor(255, 255, 255, 230), 3)
+    dxDrawLine3D(point.x, point.y - size, point.z + 0.04, point.x, point.y + size, point.z + 0.04, tocolor(255, 255, 255, 230), 3)
+end
+
+local function drawLine(a, b)
+    dxDrawLine3D(a.x, a.y, a.z + 0.04, b.x, b.y, b.z + 0.04, tocolor(255, 255, 255, 210), 2)
+end
+
+addEventHandler("onClientRender", root, function()
+    for _, point in ipairs(points) do
+        drawPoint(point)
+    end
+
+    if #points >= 2 then
+        drawLine(points[1], points[2])
+    end
+
+    if #points == 3 then
+        drawLine(points[2], points[3])
+        drawLine(points[3], points[1])
+    elseif cursorWorld and #points > 0 then
+        drawLine(points[#points], cursorWorld)
+        if #points == 2 then
+            drawLine(cursorWorld, points[1])
+        end
+    end
+
+    local status = string.format("surface %d    density %.2f", currentSurface(), density)
+    dxDrawText(status, 24, 24, 600, 48, tocolor(255, 255, 255, 245), 1.1, "default-bold")
+    dxDrawText("LMB: point    RMB: reset    arrows: surface    wheel: density", 24, 50, 760, 72, tocolor(225, 225, 225, 235), 1.0, "default")
+
+    if errorText then
+        dxDrawText(errorText, 24, 76, 500, 98, tocolor(255, 120, 120, 245), 1.0, "default-bold")
+    end
+end)
+
+addEventHandler("onClientResourceStart", resourceRoot, function()
+    showCursor(true)
+end)
+
+addEventHandler("onClientResourceStop", resourceRoot, function()
+    destroyFoliage()
+    if not cursorWasShowing then
+        showCursor(false)
+    end
+end)

--- a/test-resources/foliage-draw-demo/meta.xml
+++ b/test-resources/foliage-draw-demo/meta.xml
@@ -1,0 +1,4 @@
+<meta>
+    <info author="MTA Neon" name="Foliage draw demo" type="script" version="1.0.0" />
+    <script src="client.lua" type="client" />
+</meta>

--- a/test-resources/foliage-test/README.md
+++ b/test-resources/foliage-test/README.md
@@ -1,0 +1,122 @@
+# Custom foliage test and showcase
+
+This opt-in client resource validates the custom `foliage` element added for
+issue #40 and also provides deterministic visual scenes that are easy to record
+for a PR/demo video. It uses only the public Lua API exposed by the feature; no
+test-only native hooks are required.
+
+Run it in a normal streamed GTA:SA world area. Plant availability is driven by
+GTA surface properties, so the resource probes surfaces instead of hardcoding a
+single `plants.dat` assumption. A surface that has no plant definitions, or a
+native plant pool that is already heavily occupied, can legitimately reject a
+triangle.
+
+## Commands
+
+```text
+/foliage_test
+/foliage_test_all
+/foliage_probe [count]
+/foliage_stress [count=32] [cycles=5]
+/foliage_captest
+/foliage_demo [surface]
+/foliage_demo_surfaces
+/foliage_demo_dimension
+/foliage_video [surface|surfaces]
+/foliage_cinematic
+/foliage_lifetime [surface]
+/foliage_overlay
+/foliage_clear
+/foliage_help
+```
+
+### Functional regression
+
+`/foliage_test` checks:
+
+- registration of all seven foliage Lua functions;
+- automatic discovery of working native plant surfaces;
+- creation and `foliage` element typing;
+- surface and density getter round-trips;
+- density values `0`, `0.5`, `1`, `2`, and the supported upper bound `10`;
+- rejection of negative and greater-than-10 density values;
+- generic `setElementPosition` translation/rebuild;
+- three-vertex getter/setter rebuild and round-trip;
+- valid surface switching plus out-of-range surface rejection;
+- element dimension change and restore;
+- OOP `density` property and `Foliage.create` registration;
+- rejection of invalid create arguments and degenerate triangles;
+- creation on several independently probed surfaces;
+- explicit destruction and invalidation of the element handle.
+
+`/foliage_test_all` runs that suite and then the cap test. The cap test attempts
+65 simultaneous custom foliage elements and expects number 65 to be rejected
+when the harness owns all 64 custom slots. If creation stops earlier, the result
+is reported as a warning rather than a false failure because vanilla GTA plant
+triangles or foliage from another resource may already occupy native capacity.
+
+`/foliage_stress 32 5` is the recommended repeated-lifetime smoke test. It
+performs five create/destroy cycles of 32 foliage elements and reports the
+actual number created.
+
+### Resource lifetime
+
+`/foliage_lifetime` creates one persistent patch owned by this resource. Stop or
+restart `foliage-test` from the server console. The patch must disappear without
+calling `/foliage_clear`. The stop handler deliberately does not destroy foliage
+itself, so this exercises normal resource `ElementGroup` teardown and the native
+foliage destructor path.
+
+## Visual showcase
+
+`/foliage_demo` creates four outlined triangles near the player using the same
+working surface at densities `0x`, `0.5x`, `1x`, and `2x`. The zero-density
+triangle remains outlined so the empty control is still visible.
+
+`/foliage_demo_surfaces` probes up to four surfaces and renders one `1x` patch
+for each, with a floating surface label. This is useful for showing that the API
+is not a single hardcoded grass preset.
+
+`/foliage_demo_dimension` moves all current demo elements to a different
+dimension and back. The foliage should disappear and reappear while the green
+triangle guides remain visible, making dimension streaming easy to verify on
+video.
+
+`/foliage_cinematic` toggles a slow orbit camera around the current showcase.
+`/foliage_video` is the one-command recording mode: it builds a showcase and
+enables the orbit camera. Run `/foliage_video` again to restore the player
+camera and clean the demo. Use `/foliage_video surfaces` for the multi-surface
+scene, or `/foliage_video <surfaceId>` to force a known working surface for the
+density scene.
+
+The HUD is intentionally compact in video mode. `/foliage_overlay` can hide it
+entirely for clean B-roll; world-space patch labels and triangle boundaries stay
+visible.
+
+## Suggested PR video
+
+A short capture can demonstrate both correctness and the visible result:
+
+1. Start the resource and run `/foliage_test_all`. Hold on the PASS/FAIL HUD long
+   enough to show the regression result.
+2. Run `/foliage_video`. Record one orbit around the `0x`, `0.5x`, `1x`, and
+   `2x` patches.
+3. Stop video mode, run `/foliage_video surfaces`, and record the distinct
+   surface variants.
+4. Stop video mode, run `/foliage_demo`, then `/foliage_demo_dimension` twice to
+   capture the foliage disappearing and returning by dimension.
+5. Optionally finish with `/foliage_lifetime`, then restart the resource from the
+   server console to show automatic cleanup.
+
+For an apples-to-apples density shot, keep the same camera, weather, time of
+day, graphics settings, and location. Avoid running unrelated vegetation or
+limit-stress resources during the cap test.
+
+## Expected limitations
+
+This harness cannot prove the final rendered plant count from Lua because GTA's
+native plant manager owns the generated plants. It validates the public element
+state and exercises the native add/release paths; the density, dimension, and
+resource-stop behavior should also be checked visually. A cap test that reaches
+fewer than 64 custom elements is inconclusive rather than automatically broken
+when the shared GTA plant pool is already under pressure.

--- a/test-resources/foliage-test/client.lua
+++ b/test-resources/foliage-test/client.lua
@@ -9,20 +9,21 @@ local state = {
     demo = {},
     demoMode = nil,
     demoCenter = nil,
+    demoHidden = false,
     cinematic = false,
     cinematicTick = 0,
     video = false,
     lifetime = nil,
 }
 
-local function pushLog(level, text)
+local function log(level, text)
     local line = string.format("[%s] %s", level, text)
     table.insert(state.logs, 1, line)
     while #state.logs > 9 do
         table.remove(state.logs)
     end
 
-    local r, g, b = 210, 210, 210
+    local r, g, b = 215, 215, 215
     if level == "PASS" then
         r, g, b = 90, 220, 120
     elseif level == "FAIL" then
@@ -38,18 +39,18 @@ end
 local function check(name, condition, detail)
     if condition then
         state.pass = state.pass + 1
-        pushLog("PASS", name)
+        log("PASS", name)
         return true
     end
 
     state.fail = state.fail + 1
-    pushLog("FAIL", name .. (detail and (" - " .. detail) or ""))
+    log("FAIL", name .. (detail and (" - " .. tostring(detail)) or ""))
     return false
 end
 
-local function warning(text)
+local function warn(text)
     state.warn = state.warn + 1
-    pushLog("WARN", text)
+    log("WARN", text)
 end
 
 local function nearlyEqual(a, b, epsilon)
@@ -60,7 +61,7 @@ local function vectorEqual(a, b, epsilon)
     return a and b and nearlyEqual(a.x, b.x, epsilon) and nearlyEqual(a.y, b.y, epsilon) and nearlyEqual(a.z, b.z, epsilon)
 end
 
-local function surfaceListText()
+local function surfaceText()
     local result = {}
     for i, surface in ipairs(state.surfaces) do
         result[i] = tostring(surface)
@@ -68,17 +69,13 @@ local function surfaceListText()
     return #result > 0 and table.concat(result, ", ") or "none"
 end
 
-local function playerOrigin()
-    local x, y, z = getElementPosition(localPlayer)
-    return x, y, z
+local function playerPosition()
+    return getElementPosition(localPlayer)
 end
 
 local function groundZ(x, y, fallbackZ)
     local z = getGroundPosition(x, y, fallbackZ + 100.0)
-    if type(z) ~= "number" then
-        return fallbackZ
-    end
-    return z + 0.06
+    return type(z) == "number" and (z + 0.06) or fallbackZ
 end
 
 local function makeTriangle(cx, cy, size, fallbackZ)
@@ -92,7 +89,7 @@ local function makeTriangle(cx, cy, size, fallbackZ)
            Vector3(x3, y3, groundZ(x3, y3, fallbackZ))
 end
 
-local function destroyList(elements)
+local function destroyElements(elements)
     for i = #elements, 1, -1 do
         if isElement(elements[i]) then
             destroyElement(elements[i])
@@ -109,9 +106,17 @@ local function stopCinematic()
 end
 
 local function clearDemo()
-    destroyList(state.demo)
+    for i = #state.demo, 1, -1 do
+        local entry = state.demo[i]
+        if entry and isElement(entry.element) then
+            destroyElement(entry.element)
+        end
+        state.demo[i] = nil
+    end
+
     state.demoMode = nil
     state.demoCenter = nil
+    state.demoHidden = false
     state.video = false
     stopCinematic()
 end
@@ -124,18 +129,16 @@ local function clearLifetime()
 end
 
 local function createAt(cx, cy, size, surface, density)
-    local _, _, pz = playerOrigin()
+    local _, _, pz = playerPosition()
     local v1, v2, v3 = makeTriangle(cx, cy, size, pz)
-    local foliage = createFoliage(v1, v2, v3, surface, density)
-    return foliage, v1, v2, v3
+    return createFoliage(v1, v2, v3, surface, density), v1, v2, v3
 end
 
-local function probeWorkingSurfaces(wanted, quiet)
+local function probeSurfaces(wanted, quiet)
     wanted = math.max(1, math.min(16, tonumber(wanted) or 4))
-
     if type(createFoliage) ~= "function" then
         if not quiet then
-            pushLog("FAIL", "createFoliage is not registered")
+            log("FAIL", "createFoliage is not registered")
         end
         return state.surfaces
     end
@@ -144,8 +147,7 @@ local function probeWorkingSurfaces(wanted, quiet)
         return state.surfaces
     end
 
-    local px, py = playerOrigin()
-    local _, _, pz = playerOrigin()
+    local px, py, pz = playerPosition()
     local v1, v2, v3 = makeTriangle(px + 4, py + 4, 30, pz)
 
     for surface = 0, 255 do
@@ -164,9 +166,9 @@ local function probeWorkingSurfaces(wanted, quiet)
 
     if not quiet then
         if #state.surfaces > 0 then
-            pushLog("INFO", "Working foliage surfaces: " .. surfaceListText())
+            log("INFO", "Working foliage surfaces: " .. surfaceText())
         else
-            pushLog("WARN", "No working foliage surface found at this test triangle")
+            warn("No working foliage surface found at the current test area")
         end
     end
 
@@ -194,73 +196,71 @@ end
 local function runCoreTests()
     state.pass, state.fail, state.warn = 0, 0, 0
     state.logs = {}
-    pushLog("INFO", "Starting custom foliage core regression suite")
+    log("INFO", "Starting custom foliage core regression suite")
 
     if not apiAvailable() then
-        pushLog("FAIL", "Core suite aborted because one or more foliage functions are missing")
+        log("FAIL", "Core suite aborted: foliage API is incomplete")
         return false
     end
 
-    probeWorkingSurfaces(4, true)
-    if not check("At least one native surface can create foliage", #state.surfaces > 0) then
-        warning("Move to a normal streamed world area and retry /foliage_probe")
+    probeSurfaces(4, true)
+    if not check("At least one native surface creates foliage", #state.surfaces > 0) then
+        warn("Move to a normal streamed world area and retry /foliage_probe")
         return false
     end
 
     local surface = state.surfaces[1]
-    local px, py, pz = playerOrigin()
+    local px, py, pz = playerPosition()
     local v1, v2, v3 = makeTriangle(px + 4, py + 4, 24, pz)
     local foliage = createFoliage(v1, v2, v3, surface, 1.0)
-
     if not check("createFoliage returns an element", isElement(foliage)) then
         return false
     end
 
-    check("Element type is foliage", getElementType(foliage) == "foliage", tostring(getElementType(foliage)))
+    check("Element type is foliage", getElementType(foliage) == "foliage", getElementType(foliage))
     check("Surface getter round-trip", getFoliageSurface(foliage) == surface)
     check("Density getter round-trip", nearlyEqual(getFoliageDensity(foliage), 1.0))
 
-    local densities = {0.0, 0.5, 1.0, 2.0, 10.0}
-    for _, density in ipairs(densities) do
-        local setOk = setFoliageDensity(foliage, density)
-        check(string.format("Density setter accepts %.1f", density), setOk == true)
+    for _, density in ipairs({0.0, 0.5, 1.0, 2.0, 10.0}) do
+        check(string.format("Density setter accepts %.1f", density), setFoliageDensity(foliage, density) == true)
         check(string.format("Density getter reports %.1f", density), nearlyEqual(getFoliageDensity(foliage), density))
     end
-
     check("Density setter rejects negative values", setFoliageDensity(foliage, -0.1) == false)
     check("Density setter rejects values above 10", setFoliageDensity(foliage, 10.01) == false)
     setFoliageDensity(foliage, 1.0)
 
+    local beforeX, beforeY, beforeZ = getElementPosition(foliage)
+    check("Generic setElementPosition rebuilds foliage", setElementPosition(foliage, beforeX + 1.0, beforeY, beforeZ) == true)
+    local afterX, afterY, afterZ = getElementPosition(foliage)
+    check("Generic position getter reports translated centroid", nearlyEqual(afterX, beforeX + 1.0) and nearlyEqual(afterY, beforeY) and nearlyEqual(afterZ, beforeZ))
+
     local rv1, rv2, rv3 = getFoliageVertices(foliage)
     check("Vertex getter returns three Vector3 values", rv1 and rv2 and rv3 and rv1.x and rv2.x and rv3.x)
-
     if rv1 and rv2 and rv3 then
         local moved1 = Vector3(rv1.x + 2.0, rv1.y, rv1.z)
         local moved2 = Vector3(rv2.x + 2.0, rv2.y, rv2.z)
         local moved3 = Vector3(rv3.x + 2.0, rv3.y, rv3.z)
         check("Vertex setter rebuilds native foliage", setFoliageVertices(foliage, moved1, moved2, moved3) == true)
-
         local gv1, gv2, gv3 = getFoliageVertices(foliage)
         check("Vertex setter/getter round-trip", vectorEqual(gv1, moved1) and vectorEqual(gv2, moved2) and vectorEqual(gv3, moved3))
     end
 
     if #state.surfaces >= 2 then
         local second = state.surfaces[2]
-        check("Surface setter rebuilds with another valid surface", setFoliageSurface(foliage, second) == true)
+        check("Surface setter accepts another working surface", setFoliageSurface(foliage, second) == true)
         check("Surface getter reports changed surface", getFoliageSurface(foliage) == second)
         check("Surface setter restores original surface", setFoliageSurface(foliage, surface) == true)
     else
-        warning("Only one usable surface found; multi-surface setter test skipped")
+        warn("Only one working surface found; valid multi-surface setter test skipped")
     end
-
     check("Surface setter rejects -1", setFoliageSurface(foliage, -1) == false)
     check("Surface setter rejects 256", setFoliageSurface(foliage, 256) == false)
 
     local originalDimension = getElementDimension(foliage)
-    local hiddenDimension = originalDimension == 0 and 1 or 0
-    check("Element dimension can be changed", setElementDimension(foliage, hiddenDimension) == true)
-    check("Dimension getter reports hidden dimension", getElementDimension(foliage) == hiddenDimension)
-    check("Element dimension can be restored", setElementDimension(foliage, originalDimension) == true)
+    local otherDimension = originalDimension == 0 and 1 or 0
+    check("Dimension can be changed", setElementDimension(foliage, otherDimension) == true)
+    check("Dimension getter reports changed dimension", getElementDimension(foliage) == otherDimension)
+    check("Dimension can be restored", setElementDimension(foliage, originalDimension) == true)
     check("Dimension getter reports restored dimension", getElementDimension(foliage) == originalDimension)
 
     local propertyOk, propertyDensity = pcall(function()
@@ -281,19 +281,13 @@ local function runCoreTests()
         destroyElement(oopFoliage)
     end
 
-    local invalidSurfaceLow = createFoliage(v1, v2, v3, -1, 1.0)
-    local invalidSurfaceHigh = createFoliage(v1, v2, v3, 256, 1.0)
-    check("createFoliage rejects surface -1", invalidSurfaceLow == false)
-    check("createFoliage rejects surface 256", invalidSurfaceHigh == false)
-
-    local invalidDensityLow = createFoliage(v1, v2, v3, surface, -0.1)
-    local invalidDensityHigh = createFoliage(v1, v2, v3, surface, 10.01)
-    check("createFoliage rejects density below 0", invalidDensityLow == false)
-    check("createFoliage rejects density above 10", invalidDensityHigh == false)
+    check("createFoliage rejects surface -1", createFoliage(v1, v2, v3, -1, 1.0) == false)
+    check("createFoliage rejects surface 256", createFoliage(v1, v2, v3, 256, 1.0) == false)
+    check("createFoliage rejects density below 0", createFoliage(v1, v2, v3, surface, -0.1) == false)
+    check("createFoliage rejects density above 10", createFoliage(v1, v2, v3, surface, 10.01) == false)
 
     local same = Vector3(px, py, pz)
-    local degenerate = createFoliage(same, same, same, surface, 1.0)
-    check("createFoliage rejects degenerate triangle", degenerate == false)
+    check("createFoliage rejects a degenerate triangle", createFoliage(same, same, same, surface, 1.0) == false)
 
     for i = 1, math.min(4, #state.surfaces) do
         local testElement = createFoliage(v1, v2, v3, state.surfaces[i], 1.0)
@@ -303,31 +297,30 @@ local function runCoreTests()
         end
     end
 
-    local destroyed = destroyElement(foliage)
-    check("destroyElement succeeds", destroyed == true)
+    check("destroyElement succeeds", destroyElement(foliage) == true)
     check("Destroyed foliage handle becomes invalid", not isElement(foliage))
-
-    pushLog("INFO", string.format("Core suite finished: %d pass, %d fail, %d warn", state.pass, state.fail, state.warn))
+    log("INFO", string.format("Core suite finished: %d pass, %d fail, %d warn", state.pass, state.fail, state.warn))
     return state.fail == 0
 end
 
 local function runCapTest()
     if type(createFoliage) ~= "function" then
-        pushLog("FAIL", "createFoliage is not registered")
+        log("FAIL", "createFoliage is not registered")
         return false
     end
 
     clearDemo()
     clearLifetime()
-    probeWorkingSurfaces(1, true)
+    probeSurfaces(1, true)
     if #state.surfaces == 0 then
-        warning("Cap test skipped: no working surface")
+        warn("Cap test skipped: no working surface")
         return false
     end
 
     local surface = state.surfaces[1]
-    local px, py, pz = playerOrigin()
+    local px, py, pz = playerPosition()
     local created = {}
+    local rejectedAt = nil
 
     for i = 1, 65 do
         local col = (i - 1) % 8
@@ -335,40 +328,38 @@ local function runCapTest()
         local v1, v2, v3 = makeTriangle(px + (col - 3.5) * 3.0, py + (row - 3.5) * 3.0, 24, pz)
         local foliage = createFoliage(v1, v2, v3, surface, 1.0)
         if not isElement(foliage) then
-            if i == 65 and #created == 64 then
-                check("Global custom foliage cap rejects element 65", true)
-            else
-                warning(string.format("Creation stopped at %d/%d; native pool or other foliage may already consume capacity", #created, 64))
-            end
+            rejectedAt = i
             break
         end
         table.insert(created, foliage)
     end
 
-    if #created == 65 then
-        check("Global custom foliage cap rejects element 65", false, "65 custom foliage elements were created")
-    elseif #created == 64 then
-        pushLog("PASS", "Created 64 custom foliage elements before the cap")
+    local createdCount = #created
+    if createdCount == 64 and rejectedAt == 65 then
+        check("Global custom foliage cap rejects element 65", true)
+    elseif createdCount == 65 then
+        check("Global custom foliage cap rejects element 65", false, "65 elements were accepted")
+    else
+        warn(string.format("Cap test reached %d/64; native pool or foliage from another resource may already consume capacity", createdCount))
     end
 
-    destroyList(created)
-    pushLog("INFO", "Cap test cleanup complete")
-    return #created <= 64
+    destroyElements(created)
+    log("INFO", "Cap test cleanup complete")
+    return createdCount <= 64
 end
 
 local function runStress(count, cycles)
     count = math.max(1, math.min(64, tonumber(count) or 32))
     cycles = math.max(1, math.min(20, tonumber(cycles) or 5))
-
-    probeWorkingSurfaces(1, true)
+    probeSurfaces(1, true)
     if #state.surfaces == 0 then
-        warning("Stress test skipped: no working surface")
+        warn("Stress test skipped: no working surface")
         return
     end
 
     local surface = state.surfaces[1]
-    local px, py, pz = playerOrigin()
-    local totalCreated = 0
+    local px, py, pz = playerPosition()
+    local total = 0
 
     for cycle = 1, cycles do
         local elements = {}
@@ -378,16 +369,16 @@ local function runStress(count, cycles)
             local v1, v2, v3 = makeTriangle(px + (col - 3.5) * 3.0, py + (row - 3.5) * 3.0, 24, pz)
             local foliage = createFoliage(v1, v2, v3, surface, 1.0 + (i % 4) * 0.25)
             if not isElement(foliage) then
-                warning(string.format("Stress cycle %d stopped at %d/%d creations", cycle, #elements, count))
+                warn(string.format("Stress cycle %d stopped at %d/%d creations", cycle, #elements, count))
                 break
             end
             table.insert(elements, foliage)
-            totalCreated = totalCreated + 1
+            total = total + 1
         end
-        destroyList(elements)
+        destroyElements(elements)
     end
 
-    pushLog("INFO", string.format("Stress complete: %d create/destroy operations across %d cycles", totalCreated, cycles))
+    log("INFO", string.format("Stress complete: %d create/destroy operations across %d cycles", total, cycles))
 end
 
 local function addDemoPatch(cx, cy, size, surface, density, label)
@@ -408,88 +399,65 @@ local function addDemoPatch(cx, cy, size, surface, density, label)
     return true
 end
 
-local function destroyDemoElements()
-    for i = #state.demo, 1, -1 do
-        local entry = state.demo[i]
-        if entry and isElement(entry.element) then
-            destroyElement(entry.element)
-        end
-        state.demo[i] = nil
-    end
-end
-
 local function prepareDemoCenter()
-    local px, py, pz = playerOrigin()
-    state.demoCenter = Vector3(px, py + 8.0, groundZ(px, py + 8.0, pz) + 1.0)
-    return px, py, pz
+    local px, py, pz = playerPosition()
+    state.demoCenter = Vector3(px, py + 11.0, groundZ(px, py + 11.0, pz) + 1.0)
+    return px, py
 end
 
 local function startDensityDemo(surfaceArg)
-    destroyDemoElements()
-    stopCinematic()
-    state.video = false
-
+    clearDemo()
     local requested = tonumber(surfaceArg)
     if requested then
         requested = math.floor(requested)
         if requested < 0 or requested > 255 then
-            warning("Requested surface must be between 0 and 255")
+            warn("Requested surface must be between 0 and 255")
             requested = nil
         end
     end
 
-    probeWorkingSurfaces(1, true)
+    probeSurfaces(1, true)
     local surface = requested or state.surfaces[1]
     if surface == nil then
-        warning("Density demo could not find a working surface")
+        warn("Density demo could not find a working surface")
         return false
     end
 
-    local px, py, pz = prepareDemoCenter()
-    local offsets = {
+    local px, py = prepareDemoCenter()
+    local patches = {
         {-12, 0, 0.0},
         {12, 0, 0.5},
         {-12, 22, 1.0},
         {12, 22, 2.0},
     }
 
-    for _, entry in ipairs(offsets) do
-        if not addDemoPatch(px + entry[1], py + entry[2], 18, surface, entry[3], string.format("density %.1fx", entry[3])) then
-            destroyDemoElements()
-            warning("Density demo creation failed; try /foliage_probe then pass a working surface")
+    for _, patch in ipairs(patches) do
+        if not addDemoPatch(px + patch[1], py + patch[2], 18, surface, patch[3], string.format("density %.1fx", patch[3])) then
+            clearDemo()
+            warn("Density demo failed; run /foliage_probe and pass a working surface")
             return false
         end
     end
 
     state.demoMode = "density"
-    pushLog("INFO", "Density showcase ready on surface " .. tostring(surface))
+    log("INFO", "Density showcase ready on surface " .. tostring(surface))
     return true
 end
 
 local function startSurfaceDemo()
-    destroyDemoElements()
-    stopCinematic()
-    state.video = false
-    probeWorkingSurfaces(4, true)
-
+    clearDemo()
+    probeSurfaces(4, true)
     if #state.surfaces == 0 then
-        warning("Surface demo could not find any working surface")
+        warn("Surface demo could not find a working surface")
         return false
     end
 
     local px, py = prepareDemoCenter()
-    local offsets = {
-        {-12, 0},
-        {12, 0},
-        {-12, 22},
-        {12, 22},
-    }
-
-    local count = math.min(4, #state.surfaces)
-    for i = 1, count do
+    local offsets = {{-12, 0}, {12, 0}, {-12, 22}, {12, 22}}
+    for i = 1, math.min(4, #state.surfaces) do
         local surface = state.surfaces[i]
         if not addDemoPatch(px + offsets[i][1], py + offsets[i][2], 18, surface, 1.0, "surface " .. tostring(surface)) then
-            warning("Surface " .. tostring(surface) .. " failed while building showcase")
+            warn("Surface " .. tostring(surface) .. " failed while building the showcase")
         end
     end
 
@@ -498,57 +466,68 @@ local function startSurfaceDemo()
     end
 
     state.demoMode = "surfaces"
-    pushLog("INFO", "Surface showcase ready with " .. tostring(#state.demo) .. " variants")
+    log("INFO", "Surface showcase ready with " .. tostring(#state.demo) .. " variants")
     return true
 end
 
 local function startCinematic()
     if #state.demo == 0 or not state.demoCenter then
-        warning("Start /foliage_demo or /foliage_demo_surfaces first")
+        warn("Start /foliage_demo or /foliage_demo_surfaces first")
         return false
     end
-
     state.cinematic = true
     state.cinematicTick = getTickCount()
-    pushLog("INFO", "Cinematic orbit enabled")
+    log("INFO", "Cinematic orbit enabled")
     return true
 end
 
-local function toggleVideo(arg)
-    if state.video then
-        clearDemo()
-        pushLog("INFO", "Video showcase stopped")
+local function toggleDemoDimension()
+    if #state.demo == 0 then
+        warn("No demo foliage exists; start a demo first")
         return
     end
 
-    local mode = tostring(arg or "density")
-    local ok
-    if mode == "surfaces" then
-        ok = startSurfaceDemo()
-    else
-        ok = startDensityDemo(tonumber(arg))
+    local visibleDimension = getElementDimension(localPlayer)
+    local hiddenDimension = visibleDimension == 0 and 1 or 0
+    state.demoHidden = not state.demoHidden
+    local target = state.demoHidden and hiddenDimension or visibleDimension
+
+    local ok = true
+    for _, entry in ipairs(state.demo) do
+        ok = setElementDimension(entry.element, target) and ok
+    end
+    log(ok and "PASS" or "FAIL", state.demoHidden and "Demo moved to another dimension; foliage should disappear" or "Demo restored to player dimension; foliage should reappear")
+end
+
+local function toggleVideo(modeOrSurface)
+    if state.video then
+        clearDemo()
+        log("INFO", "Video showcase stopped")
+        return
     end
 
+    local value = tostring(modeOrSurface or "density")
+    local ok = value == "surfaces" and startSurfaceDemo() or startDensityDemo(tonumber(modeOrSurface))
     if ok and startCinematic() then
         state.video = true
-        pushLog("INFO", "Video mode active - run /foliage_video again to stop")
+        log("INFO", "Video mode active; run /foliage_video again to stop")
     end
 end
 
 local function drawDemo()
     for _, entry in ipairs(state.demo) do
         local v1, v2, v3 = entry.v1, entry.v2, entry.v3
-        local lineColor = tocolor(80, 220, 130, 230)
-        dxDrawLine3D(v1.x, v1.y, v1.z + 0.08, v2.x, v2.y, v2.z + 0.08, lineColor, 2)
-        dxDrawLine3D(v2.x, v2.y, v2.z + 0.08, v3.x, v3.y, v3.z + 0.08, lineColor, 2)
-        dxDrawLine3D(v3.x, v3.y, v3.z + 0.08, v1.x, v1.y, v1.z + 0.08, lineColor, 2)
+        local color = tocolor(80, 220, 130, 230)
+        dxDrawLine3D(v1.x, v1.y, v1.z + 0.08, v2.x, v2.y, v2.z + 0.08, color, 2)
+        dxDrawLine3D(v2.x, v2.y, v2.z + 0.08, v3.x, v3.y, v3.z + 0.08, color, 2)
+        dxDrawLine3D(v3.x, v3.y, v3.z + 0.08, v1.x, v1.y, v1.z + 0.08, color, 2)
 
         local cx = (v1.x + v2.x + v3.x) / 3
         local cy = (v1.y + v2.y + v3.y) / 3
         local cz = (v1.z + v2.z + v3.z) / 3 + 2.2
         local sx, sy = getScreenFromWorldPosition(cx, cy, cz, 0.05)
         if sx and sy then
-            dxDrawText(entry.label, sx - 100, sy - 18, sx + 100, sy + 18, tocolor(255, 255, 255, 245), 1.15, "default-bold", "center", "center", false, false, false, true)
+            dxDrawText(entry.label, sx - 110, sy - 18, sx + 110, sy + 18, tocolor(255, 255, 255, 245), 1.15, "default-bold", "center", "center")
         end
     end
 end
@@ -558,30 +537,22 @@ local function drawOverlay()
         return
     end
 
-    local screenW = guiGetScreenSize()
-    local x, y = 28, 70
-    local width = 560
+    local x, y, width = 28, 70, 560
     local height = state.video and 82 or 260
-
     dxDrawRectangle(x, y, width, height, tocolor(10, 15, 18, 205))
     dxDrawText("CUSTOM FOLIAGE HARNESS", x + 16, y + 10, x + width - 16, y + 34, tocolor(110, 235, 150, 255), 1.25, "default-bold", "left", "center")
-
-    local mode = state.demoMode or "none"
-    local summary = string.format("PASS %d   FAIL %d   WARN %d   |   demo: %s", state.pass, state.fail, state.warn, mode)
-    dxDrawText(summary, x + 16, y + 38, x + width - 16, y + 62, tocolor(235, 235, 235, 255), 1.0, "default", "left", "center")
+    dxDrawText(string.format("PASS %d   FAIL %d   WARN %d   |   demo: %s", state.pass, state.fail, state.warn, state.demoMode or "none"), x + 16, y + 38, x + width - 16, y + 62, tocolor(235, 235, 235, 255), 1.0, "default", "left", "center")
 
     if state.video then
         return
     end
 
-    dxDrawText("surfaces: " .. surfaceListText(), x + 16, y + 62, x + width - 16, y + 84, tocolor(180, 200, 210, 255), 0.95, "default", "left", "center")
-
+    dxDrawText("surfaces: " .. surfaceText(), x + 16, y + 62, x + width - 16, y + 84, tocolor(180, 200, 210, 255), 0.95, "default", "left", "center")
     local logY = y + 90
     for i = math.min(#state.logs, 7), 1, -1 do
         dxDrawText(state.logs[i], x + 16, logY, x + width - 16, logY + 20, tocolor(220, 220, 220, 245), 0.9, "default", "left", "center", true)
         logY = logY + 22
     end
-
     dxDrawText("/foliage_help for commands", x + 16, y + height - 28, x + width - 16, y + height - 8, tocolor(145, 165, 175, 255), 0.9, "default", "left", "center")
 end
 
@@ -591,10 +562,7 @@ addEventHandler("onClientRender", root, function()
         local angle = (elapsed / 14000) * math.pi * 2
         local center = state.demoCenter
         local radius = 38
-        local cameraX = center.x + math.cos(angle) * radius
-        local cameraY = center.y + math.sin(angle) * radius
-        local cameraZ = center.z + 15
-        setCameraMatrix(cameraX, cameraY, cameraZ, center.x, center.y + 7, center.z + 1.0)
+        setCameraMatrix(center.x + math.cos(angle) * radius, center.y + math.sin(angle) * radius, center.z + 15, center.x, center.y + 7, center.z + 1)
     end
 
     if #state.demo > 0 then
@@ -603,100 +571,83 @@ addEventHandler("onClientRender", root, function()
     drawOverlay()
 end)
 
-addCommandHandler("foliage_test", function()
-    runCoreTests()
-end)
-
+addCommandHandler("foliage_test", runCoreTests)
 addCommandHandler("foliage_test_all", function()
     runCoreTests()
     runCapTest()
 end)
-
 addCommandHandler("foliage_probe", function(_, wanted)
-    probeWorkingSurfaces(tonumber(wanted) or 8, false)
+    probeSurfaces(tonumber(wanted) or 8, false)
 end)
-
-addCommandHandler("foliage_captest", function()
-    runCapTest()
-end)
-
+addCommandHandler("foliage_captest", runCapTest)
 addCommandHandler("foliage_stress", function(_, count, cycles)
     runStress(count, cycles)
 end)
-
 addCommandHandler("foliage_demo", function(_, surface)
     startDensityDemo(surface)
 end)
-
-addCommandHandler("foliage_demo_surfaces", function()
-    startSurfaceDemo()
-end)
-
+addCommandHandler("foliage_demo_surfaces", startSurfaceDemo)
+addCommandHandler("foliage_demo_dimension", toggleDemoDimension)
 addCommandHandler("foliage_cinematic", function()
     if state.cinematic then
         stopCinematic()
-        pushLog("INFO", "Cinematic orbit disabled")
+        log("INFO", "Cinematic orbit disabled")
     else
         startCinematic()
     end
 end)
-
 addCommandHandler("foliage_video", function(_, modeOrSurface)
     toggleVideo(modeOrSurface)
 end)
-
 addCommandHandler("foliage_overlay", function()
     state.overlay = not state.overlay
-    pushLog("INFO", "Overlay " .. (state.overlay and "enabled" or "disabled"))
+    log("INFO", "Overlay " .. (state.overlay and "enabled" or "disabled"))
 end)
-
 addCommandHandler("foliage_lifetime", function(_, surfaceArg)
     clearLifetime()
-    probeWorkingSurfaces(1, true)
+    probeSurfaces(1, true)
     local surface = tonumber(surfaceArg) or state.surfaces[1]
-    if not surface then
-        warning("Lifetime test needs a working surface")
+    if surface == nil then
+        warn("Lifetime test needs a working surface")
         return
     end
 
-    local px, py = playerOrigin()
+    local px, py = playerPosition()
     state.lifetime = select(1, createAt(px + 8, py, 24, math.floor(surface), 2.0))
     if isElement(state.lifetime) then
-        pushLog("INFO", "Lifetime patch created. Restart/stop this resource: the patch must disappear with it.")
+        log("INFO", "Lifetime patch created. Restart/stop this resource; the patch must disappear with it.")
     else
-        warning("Lifetime patch creation failed")
+        warn("Lifetime patch creation failed")
     end
 end)
-
 addCommandHandler("foliage_clear", function()
     clearDemo()
     clearLifetime()
-    pushLog("INFO", "Harness-owned persistent foliage cleared")
+    log("INFO", "Harness-owned persistent foliage cleared")
 end)
-
 addCommandHandler("foliage_help", function()
     outputChatBox("--- Custom foliage harness ---", 110, 235, 150)
-    outputChatBox("/foliage_test - functional API/getter/setter/dimension/OOP regression", 230, 230, 230)
+    outputChatBox("/foliage_test - API/getter/setter/position/dimension/OOP regression", 230, 230, 230)
     outputChatBox("/foliage_test_all - core suite + 64 element cap test", 230, 230, 230)
     outputChatBox("/foliage_probe [count] - discover surfaces that actually produce plants", 230, 230, 230)
     outputChatBox("/foliage_stress [count=32] [cycles=5] - repeated create/destroy", 230, 230, 230)
     outputChatBox("/foliage_captest - verify the custom 64 element guard", 230, 230, 230)
-    outputChatBox("/foliage_demo [surface] - 0x / 0.5x / 1x / 2x visual comparison", 230, 230, 230)
-    outputChatBox("/foliage_demo_surfaces - compare up to four working plant surfaces", 230, 230, 230)
-    outputChatBox("/foliage_video [surface|surfaces] - demo + orbit camera for recording", 230, 230, 230)
+    outputChatBox("/foliage_demo [surface] - 0x / 0.5x / 1x / 2x density comparison", 230, 230, 230)
+    outputChatBox("/foliage_demo_surfaces - compare up to four working surfaces", 230, 230, 230)
+    outputChatBox("/foliage_demo_dimension - visually stream demo out/in by dimension", 230, 230, 230)
+    outputChatBox("/foliage_video [surface|surfaces] - showcase + orbit camera", 230, 230, 230)
     outputChatBox("/foliage_cinematic - toggle orbit camera", 230, 230, 230)
     outputChatBox("/foliage_lifetime [surface] - manual resource-stop ownership test", 230, 230, 230)
     outputChatBox("/foliage_overlay - toggle HUD; /foliage_clear - cleanup", 230, 230, 230)
 end)
 
 addEventHandler("onClientResourceStart", resourceRoot, function()
-    pushLog("INFO", "Custom foliage harness loaded. Use /foliage_help or /foliage_test.")
+    log("INFO", "Custom foliage harness loaded. Use /foliage_help or /foliage_test.")
 end)
 
 addEventHandler("onClientResourceStop", resourceRoot, function()
-    -- Do not explicitly destroy foliage here. Resource-owned elements must be
-    -- released by the normal resource ElementGroup teardown; /foliage_lifetime
-    -- exists specifically so that lifetime path can be checked visually.
+    -- Deliberately do not destroy foliage here. /foliage_lifetime verifies that
+    -- resource ElementGroup teardown releases native foliage automatically.
     if state.cinematic then
         setCameraTarget(localPlayer)
     end

--- a/test-resources/foliage-test/client.lua
+++ b/test-resources/foliage-test/client.lua
@@ -1,0 +1,703 @@
+local state = {
+    pass = 0,
+    fail = 0,
+    warn = 0,
+    logs = {},
+    surfaces = {},
+    surfaceSet = {},
+    overlay = true,
+    demo = {},
+    demoMode = nil,
+    demoCenter = nil,
+    cinematic = false,
+    cinematicTick = 0,
+    video = false,
+    lifetime = nil,
+}
+
+local function pushLog(level, text)
+    local line = string.format("[%s] %s", level, text)
+    table.insert(state.logs, 1, line)
+    while #state.logs > 9 do
+        table.remove(state.logs)
+    end
+
+    local r, g, b = 210, 210, 210
+    if level == "PASS" then
+        r, g, b = 90, 220, 120
+    elseif level == "FAIL" then
+        r, g, b = 255, 90, 90
+    elseif level == "WARN" then
+        r, g, b = 255, 190, 80
+    end
+
+    outputDebugString("[foliage-test] " .. line)
+    outputChatBox("[foliage-test] " .. line, r, g, b)
+end
+
+local function check(name, condition, detail)
+    if condition then
+        state.pass = state.pass + 1
+        pushLog("PASS", name)
+        return true
+    end
+
+    state.fail = state.fail + 1
+    pushLog("FAIL", name .. (detail and (" - " .. detail) or ""))
+    return false
+end
+
+local function warning(text)
+    state.warn = state.warn + 1
+    pushLog("WARN", text)
+end
+
+local function nearlyEqual(a, b, epsilon)
+    return type(a) == "number" and type(b) == "number" and math.abs(a - b) <= (epsilon or 0.001)
+end
+
+local function vectorEqual(a, b, epsilon)
+    return a and b and nearlyEqual(a.x, b.x, epsilon) and nearlyEqual(a.y, b.y, epsilon) and nearlyEqual(a.z, b.z, epsilon)
+end
+
+local function surfaceListText()
+    local result = {}
+    for i, surface in ipairs(state.surfaces) do
+        result[i] = tostring(surface)
+    end
+    return #result > 0 and table.concat(result, ", ") or "none"
+end
+
+local function playerOrigin()
+    local x, y, z = getElementPosition(localPlayer)
+    return x, y, z
+end
+
+local function groundZ(x, y, fallbackZ)
+    local z = getGroundPosition(x, y, fallbackZ + 100.0)
+    if type(z) ~= "number" then
+        return fallbackZ
+    end
+    return z + 0.06
+end
+
+local function makeTriangle(cx, cy, size, fallbackZ)
+    local half = size * 0.5
+    local x1, y1 = cx - half, cy - half
+    local x2, y2 = cx + half, cy - half
+    local x3, y3 = cx, cy + half
+
+    return Vector3(x1, y1, groundZ(x1, y1, fallbackZ)),
+           Vector3(x2, y2, groundZ(x2, y2, fallbackZ)),
+           Vector3(x3, y3, groundZ(x3, y3, fallbackZ))
+end
+
+local function destroyList(elements)
+    for i = #elements, 1, -1 do
+        if isElement(elements[i]) then
+            destroyElement(elements[i])
+        end
+        elements[i] = nil
+    end
+end
+
+local function stopCinematic()
+    if state.cinematic then
+        state.cinematic = false
+        setCameraTarget(localPlayer)
+    end
+end
+
+local function clearDemo()
+    destroyList(state.demo)
+    state.demoMode = nil
+    state.demoCenter = nil
+    state.video = false
+    stopCinematic()
+end
+
+local function clearLifetime()
+    if isElement(state.lifetime) then
+        destroyElement(state.lifetime)
+    end
+    state.lifetime = nil
+end
+
+local function createAt(cx, cy, size, surface, density)
+    local _, _, pz = playerOrigin()
+    local v1, v2, v3 = makeTriangle(cx, cy, size, pz)
+    local foliage = createFoliage(v1, v2, v3, surface, density)
+    return foliage, v1, v2, v3
+end
+
+local function probeWorkingSurfaces(wanted, quiet)
+    wanted = math.max(1, math.min(16, tonumber(wanted) or 4))
+
+    if type(createFoliage) ~= "function" then
+        if not quiet then
+            pushLog("FAIL", "createFoliage is not registered")
+        end
+        return state.surfaces
+    end
+
+    if #state.surfaces >= wanted then
+        return state.surfaces
+    end
+
+    local px, py = playerOrigin()
+    local _, _, pz = playerOrigin()
+    local v1, v2, v3 = makeTriangle(px + 4, py + 4, 30, pz)
+
+    for surface = 0, 255 do
+        if not state.surfaceSet[surface] then
+            local foliage = createFoliage(v1, v2, v3, surface, 1.0)
+            if isElement(foliage) then
+                destroyElement(foliage)
+                state.surfaceSet[surface] = true
+                table.insert(state.surfaces, surface)
+                if #state.surfaces >= wanted then
+                    break
+                end
+            end
+        end
+    end
+
+    if not quiet then
+        if #state.surfaces > 0 then
+            pushLog("INFO", "Working foliage surfaces: " .. surfaceListText())
+        else
+            pushLog("WARN", "No working foliage surface found at this test triangle")
+        end
+    end
+
+    return state.surfaces
+end
+
+local function apiAvailable()
+    local names = {
+        "createFoliage",
+        "getFoliageSurface",
+        "setFoliageSurface",
+        "getFoliageVertices",
+        "setFoliageVertices",
+        "getFoliageDensity",
+        "setFoliageDensity",
+    }
+
+    local ok = true
+    for _, name in ipairs(names) do
+        ok = check("API registered: " .. name, type(_G[name]) == "function") and ok
+    end
+    return ok
+end
+
+local function runCoreTests()
+    state.pass, state.fail, state.warn = 0, 0, 0
+    state.logs = {}
+    pushLog("INFO", "Starting custom foliage core regression suite")
+
+    if not apiAvailable() then
+        pushLog("FAIL", "Core suite aborted because one or more foliage functions are missing")
+        return false
+    end
+
+    probeWorkingSurfaces(4, true)
+    if not check("At least one native surface can create foliage", #state.surfaces > 0) then
+        warning("Move to a normal streamed world area and retry /foliage_probe")
+        return false
+    end
+
+    local surface = state.surfaces[1]
+    local px, py, pz = playerOrigin()
+    local v1, v2, v3 = makeTriangle(px + 4, py + 4, 24, pz)
+    local foliage = createFoliage(v1, v2, v3, surface, 1.0)
+
+    if not check("createFoliage returns an element", isElement(foliage)) then
+        return false
+    end
+
+    check("Element type is foliage", getElementType(foliage) == "foliage", tostring(getElementType(foliage)))
+    check("Surface getter round-trip", getFoliageSurface(foliage) == surface)
+    check("Density getter round-trip", nearlyEqual(getFoliageDensity(foliage), 1.0))
+
+    local densities = {0.0, 0.5, 1.0, 2.0, 10.0}
+    for _, density in ipairs(densities) do
+        local setOk = setFoliageDensity(foliage, density)
+        check(string.format("Density setter accepts %.1f", density), setOk == true)
+        check(string.format("Density getter reports %.1f", density), nearlyEqual(getFoliageDensity(foliage), density))
+    end
+
+    check("Density setter rejects negative values", setFoliageDensity(foliage, -0.1) == false)
+    check("Density setter rejects values above 10", setFoliageDensity(foliage, 10.01) == false)
+    setFoliageDensity(foliage, 1.0)
+
+    local rv1, rv2, rv3 = getFoliageVertices(foliage)
+    check("Vertex getter returns three Vector3 values", rv1 and rv2 and rv3 and rv1.x and rv2.x and rv3.x)
+
+    if rv1 and rv2 and rv3 then
+        local moved1 = Vector3(rv1.x + 2.0, rv1.y, rv1.z)
+        local moved2 = Vector3(rv2.x + 2.0, rv2.y, rv2.z)
+        local moved3 = Vector3(rv3.x + 2.0, rv3.y, rv3.z)
+        check("Vertex setter rebuilds native foliage", setFoliageVertices(foliage, moved1, moved2, moved3) == true)
+
+        local gv1, gv2, gv3 = getFoliageVertices(foliage)
+        check("Vertex setter/getter round-trip", vectorEqual(gv1, moved1) and vectorEqual(gv2, moved2) and vectorEqual(gv3, moved3))
+    end
+
+    if #state.surfaces >= 2 then
+        local second = state.surfaces[2]
+        check("Surface setter rebuilds with another valid surface", setFoliageSurface(foliage, second) == true)
+        check("Surface getter reports changed surface", getFoliageSurface(foliage) == second)
+        check("Surface setter restores original surface", setFoliageSurface(foliage, surface) == true)
+    else
+        warning("Only one usable surface found; multi-surface setter test skipped")
+    end
+
+    check("Surface setter rejects -1", setFoliageSurface(foliage, -1) == false)
+    check("Surface setter rejects 256", setFoliageSurface(foliage, 256) == false)
+
+    local originalDimension = getElementDimension(foliage)
+    local hiddenDimension = originalDimension == 0 and 1 or 0
+    check("Element dimension can be changed", setElementDimension(foliage, hiddenDimension) == true)
+    check("Dimension getter reports hidden dimension", getElementDimension(foliage) == hiddenDimension)
+    check("Element dimension can be restored", setElementDimension(foliage, originalDimension) == true)
+    check("Dimension getter reports restored dimension", getElementDimension(foliage) == originalDimension)
+
+    local propertyOk, propertyDensity = pcall(function()
+        foliage.density = 1.25
+        return foliage.density
+    end)
+    check("OOP density property works", propertyOk and nearlyEqual(propertyDensity, 1.25))
+
+    local oopClass = rawget(_G, "Foliage")
+    local oopOk, oopFoliage = pcall(function()
+        if not oopClass or not oopClass.create then
+            return false
+        end
+        return oopClass.create(v1, v2, v3, surface, 1.0)
+    end)
+    check("Foliage OOP class/create is registered", oopOk and isElement(oopFoliage))
+    if isElement(oopFoliage) then
+        destroyElement(oopFoliage)
+    end
+
+    local invalidSurfaceLow = createFoliage(v1, v2, v3, -1, 1.0)
+    local invalidSurfaceHigh = createFoliage(v1, v2, v3, 256, 1.0)
+    check("createFoliage rejects surface -1", invalidSurfaceLow == false)
+    check("createFoliage rejects surface 256", invalidSurfaceHigh == false)
+
+    local invalidDensityLow = createFoliage(v1, v2, v3, surface, -0.1)
+    local invalidDensityHigh = createFoliage(v1, v2, v3, surface, 10.01)
+    check("createFoliage rejects density below 0", invalidDensityLow == false)
+    check("createFoliage rejects density above 10", invalidDensityHigh == false)
+
+    local same = Vector3(px, py, pz)
+    local degenerate = createFoliage(same, same, same, surface, 1.0)
+    check("createFoliage rejects degenerate triangle", degenerate == false)
+
+    for i = 1, math.min(4, #state.surfaces) do
+        local testElement = createFoliage(v1, v2, v3, state.surfaces[i], 1.0)
+        check("Surface " .. tostring(state.surfaces[i]) .. " creates successfully", isElement(testElement))
+        if isElement(testElement) then
+            destroyElement(testElement)
+        end
+    end
+
+    local destroyed = destroyElement(foliage)
+    check("destroyElement succeeds", destroyed == true)
+    check("Destroyed foliage handle becomes invalid", not isElement(foliage))
+
+    pushLog("INFO", string.format("Core suite finished: %d pass, %d fail, %d warn", state.pass, state.fail, state.warn))
+    return state.fail == 0
+end
+
+local function runCapTest()
+    if type(createFoliage) ~= "function" then
+        pushLog("FAIL", "createFoliage is not registered")
+        return false
+    end
+
+    clearDemo()
+    clearLifetime()
+    probeWorkingSurfaces(1, true)
+    if #state.surfaces == 0 then
+        warning("Cap test skipped: no working surface")
+        return false
+    end
+
+    local surface = state.surfaces[1]
+    local px, py, pz = playerOrigin()
+    local created = {}
+
+    for i = 1, 65 do
+        local col = (i - 1) % 8
+        local row = math.floor((i - 1) / 8)
+        local v1, v2, v3 = makeTriangle(px + (col - 3.5) * 3.0, py + (row - 3.5) * 3.0, 24, pz)
+        local foliage = createFoliage(v1, v2, v3, surface, 1.0)
+        if not isElement(foliage) then
+            if i == 65 and #created == 64 then
+                check("Global custom foliage cap rejects element 65", true)
+            else
+                warning(string.format("Creation stopped at %d/%d; native pool or other foliage may already consume capacity", #created, 64))
+            end
+            break
+        end
+        table.insert(created, foliage)
+    end
+
+    if #created == 65 then
+        check("Global custom foliage cap rejects element 65", false, "65 custom foliage elements were created")
+    elseif #created == 64 then
+        pushLog("PASS", "Created 64 custom foliage elements before the cap")
+    end
+
+    destroyList(created)
+    pushLog("INFO", "Cap test cleanup complete")
+    return #created <= 64
+end
+
+local function runStress(count, cycles)
+    count = math.max(1, math.min(64, tonumber(count) or 32))
+    cycles = math.max(1, math.min(20, tonumber(cycles) or 5))
+
+    probeWorkingSurfaces(1, true)
+    if #state.surfaces == 0 then
+        warning("Stress test skipped: no working surface")
+        return
+    end
+
+    local surface = state.surfaces[1]
+    local px, py, pz = playerOrigin()
+    local totalCreated = 0
+
+    for cycle = 1, cycles do
+        local elements = {}
+        for i = 1, count do
+            local col = (i - 1) % 8
+            local row = math.floor((i - 1) / 8)
+            local v1, v2, v3 = makeTriangle(px + (col - 3.5) * 3.0, py + (row - 3.5) * 3.0, 24, pz)
+            local foliage = createFoliage(v1, v2, v3, surface, 1.0 + (i % 4) * 0.25)
+            if not isElement(foliage) then
+                warning(string.format("Stress cycle %d stopped at %d/%d creations", cycle, #elements, count))
+                break
+            end
+            table.insert(elements, foliage)
+            totalCreated = totalCreated + 1
+        end
+        destroyList(elements)
+    end
+
+    pushLog("INFO", string.format("Stress complete: %d create/destroy operations across %d cycles", totalCreated, cycles))
+end
+
+local function addDemoPatch(cx, cy, size, surface, density, label)
+    local foliage, v1, v2, v3 = createAt(cx, cy, size, surface, density)
+    if not isElement(foliage) then
+        return false
+    end
+
+    table.insert(state.demo, {
+        element = foliage,
+        v1 = v1,
+        v2 = v2,
+        v3 = v3,
+        label = label,
+        surface = surface,
+        density = density,
+    })
+    return true
+end
+
+local function destroyDemoElements()
+    for i = #state.demo, 1, -1 do
+        local entry = state.demo[i]
+        if entry and isElement(entry.element) then
+            destroyElement(entry.element)
+        end
+        state.demo[i] = nil
+    end
+end
+
+local function prepareDemoCenter()
+    local px, py, pz = playerOrigin()
+    state.demoCenter = Vector3(px, py + 8.0, groundZ(px, py + 8.0, pz) + 1.0)
+    return px, py, pz
+end
+
+local function startDensityDemo(surfaceArg)
+    destroyDemoElements()
+    stopCinematic()
+    state.video = false
+
+    local requested = tonumber(surfaceArg)
+    if requested then
+        requested = math.floor(requested)
+        if requested < 0 or requested > 255 then
+            warning("Requested surface must be between 0 and 255")
+            requested = nil
+        end
+    end
+
+    probeWorkingSurfaces(1, true)
+    local surface = requested or state.surfaces[1]
+    if surface == nil then
+        warning("Density demo could not find a working surface")
+        return false
+    end
+
+    local px, py, pz = prepareDemoCenter()
+    local offsets = {
+        {-12, 0, 0.0},
+        {12, 0, 0.5},
+        {-12, 22, 1.0},
+        {12, 22, 2.0},
+    }
+
+    for _, entry in ipairs(offsets) do
+        if not addDemoPatch(px + entry[1], py + entry[2], 18, surface, entry[3], string.format("density %.1fx", entry[3])) then
+            destroyDemoElements()
+            warning("Density demo creation failed; try /foliage_probe then pass a working surface")
+            return false
+        end
+    end
+
+    state.demoMode = "density"
+    pushLog("INFO", "Density showcase ready on surface " .. tostring(surface))
+    return true
+end
+
+local function startSurfaceDemo()
+    destroyDemoElements()
+    stopCinematic()
+    state.video = false
+    probeWorkingSurfaces(4, true)
+
+    if #state.surfaces == 0 then
+        warning("Surface demo could not find any working surface")
+        return false
+    end
+
+    local px, py = prepareDemoCenter()
+    local offsets = {
+        {-12, 0},
+        {12, 0},
+        {-12, 22},
+        {12, 22},
+    }
+
+    local count = math.min(4, #state.surfaces)
+    for i = 1, count do
+        local surface = state.surfaces[i]
+        if not addDemoPatch(px + offsets[i][1], py + offsets[i][2], 18, surface, 1.0, "surface " .. tostring(surface)) then
+            warning("Surface " .. tostring(surface) .. " failed while building showcase")
+        end
+    end
+
+    if #state.demo == 0 then
+        return false
+    end
+
+    state.demoMode = "surfaces"
+    pushLog("INFO", "Surface showcase ready with " .. tostring(#state.demo) .. " variants")
+    return true
+end
+
+local function startCinematic()
+    if #state.demo == 0 or not state.demoCenter then
+        warning("Start /foliage_demo or /foliage_demo_surfaces first")
+        return false
+    end
+
+    state.cinematic = true
+    state.cinematicTick = getTickCount()
+    pushLog("INFO", "Cinematic orbit enabled")
+    return true
+end
+
+local function toggleVideo(arg)
+    if state.video then
+        clearDemo()
+        pushLog("INFO", "Video showcase stopped")
+        return
+    end
+
+    local mode = tostring(arg or "density")
+    local ok
+    if mode == "surfaces" then
+        ok = startSurfaceDemo()
+    else
+        ok = startDensityDemo(tonumber(arg))
+    end
+
+    if ok and startCinematic() then
+        state.video = true
+        pushLog("INFO", "Video mode active - run /foliage_video again to stop")
+    end
+end
+
+local function drawDemo()
+    for _, entry in ipairs(state.demo) do
+        local v1, v2, v3 = entry.v1, entry.v2, entry.v3
+        local lineColor = tocolor(80, 220, 130, 230)
+        dxDrawLine3D(v1.x, v1.y, v1.z + 0.08, v2.x, v2.y, v2.z + 0.08, lineColor, 2)
+        dxDrawLine3D(v2.x, v2.y, v2.z + 0.08, v3.x, v3.y, v3.z + 0.08, lineColor, 2)
+        dxDrawLine3D(v3.x, v3.y, v3.z + 0.08, v1.x, v1.y, v1.z + 0.08, lineColor, 2)
+
+        local cx = (v1.x + v2.x + v3.x) / 3
+        local cy = (v1.y + v2.y + v3.y) / 3
+        local cz = (v1.z + v2.z + v3.z) / 3 + 2.2
+        local sx, sy = getScreenFromWorldPosition(cx, cy, cz, 0.05)
+        if sx and sy then
+            dxDrawText(entry.label, sx - 100, sy - 18, sx + 100, sy + 18, tocolor(255, 255, 255, 245), 1.15, "default-bold", "center", "center", false, false, false, true)
+        end
+    end
+end
+
+local function drawOverlay()
+    if not state.overlay then
+        return
+    end
+
+    local screenW = guiGetScreenSize()
+    local x, y = 28, 70
+    local width = 560
+    local height = state.video and 82 or 260
+
+    dxDrawRectangle(x, y, width, height, tocolor(10, 15, 18, 205))
+    dxDrawText("CUSTOM FOLIAGE HARNESS", x + 16, y + 10, x + width - 16, y + 34, tocolor(110, 235, 150, 255), 1.25, "default-bold", "left", "center")
+
+    local mode = state.demoMode or "none"
+    local summary = string.format("PASS %d   FAIL %d   WARN %d   |   demo: %s", state.pass, state.fail, state.warn, mode)
+    dxDrawText(summary, x + 16, y + 38, x + width - 16, y + 62, tocolor(235, 235, 235, 255), 1.0, "default", "left", "center")
+
+    if state.video then
+        return
+    end
+
+    dxDrawText("surfaces: " .. surfaceListText(), x + 16, y + 62, x + width - 16, y + 84, tocolor(180, 200, 210, 255), 0.95, "default", "left", "center")
+
+    local logY = y + 90
+    for i = math.min(#state.logs, 7), 1, -1 do
+        dxDrawText(state.logs[i], x + 16, logY, x + width - 16, logY + 20, tocolor(220, 220, 220, 245), 0.9, "default", "left", "center", true)
+        logY = logY + 22
+    end
+
+    dxDrawText("/foliage_help for commands", x + 16, y + height - 28, x + width - 16, y + height - 8, tocolor(145, 165, 175, 255), 0.9, "default", "left", "center")
+end
+
+addEventHandler("onClientRender", root, function()
+    if state.cinematic and state.demoCenter then
+        local elapsed = getTickCount() - state.cinematicTick
+        local angle = (elapsed / 14000) * math.pi * 2
+        local center = state.demoCenter
+        local radius = 38
+        local cameraX = center.x + math.cos(angle) * radius
+        local cameraY = center.y + math.sin(angle) * radius
+        local cameraZ = center.z + 15
+        setCameraMatrix(cameraX, cameraY, cameraZ, center.x, center.y + 7, center.z + 1.0)
+    end
+
+    if #state.demo > 0 then
+        drawDemo()
+    end
+    drawOverlay()
+end)
+
+addCommandHandler("foliage_test", function()
+    runCoreTests()
+end)
+
+addCommandHandler("foliage_test_all", function()
+    runCoreTests()
+    runCapTest()
+end)
+
+addCommandHandler("foliage_probe", function(_, wanted)
+    probeWorkingSurfaces(tonumber(wanted) or 8, false)
+end)
+
+addCommandHandler("foliage_captest", function()
+    runCapTest()
+end)
+
+addCommandHandler("foliage_stress", function(_, count, cycles)
+    runStress(count, cycles)
+end)
+
+addCommandHandler("foliage_demo", function(_, surface)
+    startDensityDemo(surface)
+end)
+
+addCommandHandler("foliage_demo_surfaces", function()
+    startSurfaceDemo()
+end)
+
+addCommandHandler("foliage_cinematic", function()
+    if state.cinematic then
+        stopCinematic()
+        pushLog("INFO", "Cinematic orbit disabled")
+    else
+        startCinematic()
+    end
+end)
+
+addCommandHandler("foliage_video", function(_, modeOrSurface)
+    toggleVideo(modeOrSurface)
+end)
+
+addCommandHandler("foliage_overlay", function()
+    state.overlay = not state.overlay
+    pushLog("INFO", "Overlay " .. (state.overlay and "enabled" or "disabled"))
+end)
+
+addCommandHandler("foliage_lifetime", function(_, surfaceArg)
+    clearLifetime()
+    probeWorkingSurfaces(1, true)
+    local surface = tonumber(surfaceArg) or state.surfaces[1]
+    if not surface then
+        warning("Lifetime test needs a working surface")
+        return
+    end
+
+    local px, py = playerOrigin()
+    state.lifetime = select(1, createAt(px + 8, py, 24, math.floor(surface), 2.0))
+    if isElement(state.lifetime) then
+        pushLog("INFO", "Lifetime patch created. Restart/stop this resource: the patch must disappear with it.")
+    else
+        warning("Lifetime patch creation failed")
+    end
+end)
+
+addCommandHandler("foliage_clear", function()
+    clearDemo()
+    clearLifetime()
+    pushLog("INFO", "Harness-owned persistent foliage cleared")
+end)
+
+addCommandHandler("foliage_help", function()
+    outputChatBox("--- Custom foliage harness ---", 110, 235, 150)
+    outputChatBox("/foliage_test - functional API/getter/setter/dimension/OOP regression", 230, 230, 230)
+    outputChatBox("/foliage_test_all - core suite + 64 element cap test", 230, 230, 230)
+    outputChatBox("/foliage_probe [count] - discover surfaces that actually produce plants", 230, 230, 230)
+    outputChatBox("/foliage_stress [count=32] [cycles=5] - repeated create/destroy", 230, 230, 230)
+    outputChatBox("/foliage_captest - verify the custom 64 element guard", 230, 230, 230)
+    outputChatBox("/foliage_demo [surface] - 0x / 0.5x / 1x / 2x visual comparison", 230, 230, 230)
+    outputChatBox("/foliage_demo_surfaces - compare up to four working plant surfaces", 230, 230, 230)
+    outputChatBox("/foliage_video [surface|surfaces] - demo + orbit camera for recording", 230, 230, 230)
+    outputChatBox("/foliage_cinematic - toggle orbit camera", 230, 230, 230)
+    outputChatBox("/foliage_lifetime [surface] - manual resource-stop ownership test", 230, 230, 230)
+    outputChatBox("/foliage_overlay - toggle HUD; /foliage_clear - cleanup", 230, 230, 230)
+end)
+
+addEventHandler("onClientResourceStart", resourceRoot, function()
+    pushLog("INFO", "Custom foliage harness loaded. Use /foliage_help or /foliage_test.")
+end)
+
+addEventHandler("onClientResourceStop", resourceRoot, function()
+    -- Do not explicitly destroy foliage here. Resource-owned elements must be
+    -- released by the normal resource ElementGroup teardown; /foliage_lifetime
+    -- exists specifically so that lifetime path can be checked visually.
+    if state.cinematic then
+        setCameraTarget(localPlayer)
+    end
+end)

--- a/test-resources/foliage-test/meta.xml
+++ b/test-resources/foliage-test/meta.xml
@@ -1,4 +1,5 @@
 <meta>
     <info author="MTA Neon" name="Custom foliage test and showcase" type="script" version="1.0.0" />
+    <oop>true</oop>
     <script src="client.lua" type="client" />
 </meta>

--- a/test-resources/foliage-test/meta.xml
+++ b/test-resources/foliage-test/meta.xml
@@ -1,0 +1,4 @@
+<meta>
+    <info author="MTA Neon" name="Custom foliage test and showcase" type="script" version="1.0.0" />
+    <script src="client.lua" type="client" />
+</meta>


### PR DESCRIPTION
## Summary
- expose GTA SA native `CPlantLocTri` patches as client-side `foliage` elements
- add global and OOP Lua APIs for triangle vertices, surface and density
- validate surface properties before native `Add()` to avoid the GTA null dereference path
- reject degenerate/non-finite triangles and clamp V1 density to `0..10`
- use the existing GTA freelist without stealing/overwriting slots, with a global custom foliage cap of 64
- release native triangles on element/resource destruction and on dimension mismatch; recreate on dimension match
- keep procedural objects disabled (`createsObjects=false`)

## Lua API
```lua
createFoliage(v1, v2, v3, surfaceId, density)
getFoliageSurface(foliage)
setFoliageSurface(foliage, surfaceId)
getFoliageVertices(foliage)
setFoliageVertices(foliage, v1, v2, v3)
getFoliageDensity(foliage)
setFoliageDensity(foliage, density)
```

OOP: `Foliage.create`, `foliage.surface`, `foliage.density`, `getVertices` / `setVertices`.

## Native verification
Verified against `gta-reversed-dryxio` and the supplied `GTA_SA.EXE`:
- SHA-256: `72ae59e44c761389e354a50dc6215e964fe771121e2f4b1877273a493ceecc9b`
- PE32 x86, ImageBase `0x00400000`, entry VA `0x00824570`
- foliage entry points contain code at `0x5DC210`, `0x5DC290`, `0x5DB6D0`, `0x5DB8A0`, `0x5DBEF0`, `0x5DCFA0`, `0x5DBAE0`, `0x5DD910`, and surface lookup `0x6F9DE0`
- `CPlantLocTri` layout is asserted as `0x54`; vanilla pool remains 256 entries

## Test harness & visual showcase
Added `test-resources/foliage-test`, an opt-in client resource that uses only the public foliage Lua API.

Regression commands:
```text
/foliage_test
/foliage_test_all
/foliage_probe [count]
/foliage_stress [count] [cycles]
/foliage_captest
/foliage_lifetime [surface]
```

The core suite covers API registration, creation/type, surface and density round-trips, density `0 / 0.5 / 1 / 2 / 10`, invalid inputs, generic position changes, vertex rebuilds, multiple surfaces, dimension changes, OOP registration/properties, degenerate triangles and destruction. The extended suite also exercises the 64-element custom cap. The lifetime command is intentionally left for a resource stop/restart so normal `ElementGroup` teardown is exercised instead of test-side cleanup.

Showcase/recording commands:
```text
/foliage_demo [surface]
/foliage_demo_surfaces
/foliage_demo_dimension
/foliage_video [surface|surfaces]
/foliage_cinematic
/foliage_overlay
```

The density scene renders outlined `0x`, `0.5x`, `1x` and `2x` patches with labels. The surface scene automatically probes up to four native plant surfaces. `/foliage_video` enables a slow orbit camera for PR/demo capture, and `/foliage_demo_dimension` makes the foliage disappear/reappear across dimensions while the triangle guides remain visible. See `test-resources/foliage-test/README.md` for the suggested video shot list and expected limitations.

## V1 scope / limitations
No custom models/textures, no `plants.dat` replacement, no procedural rocks/objects, no polygon helper, no server synchronization and no custom native pool.

## Validation status
Automated Build/CodeQL run on each pushed head. The repository's documented Windows VM runtime workflow is not available in this session, so this PR remains draft pending an actual in-game pass of the included harness. In particular, rendered plant density/count is native GTA state and cannot be proven from Lua getters alone.

Closes #40