### PR TITLE
Add synchronized managed fire elements

### DIFF
--- a/Client/mods/deathmatch/logic/CClientDummy.cpp
+++ b/Client/mods/deathmatch/logic/CClientDummy.cpp
@@ -9,6 +9,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include "CClientFireManager.h"
 
 CClientDummy::CClientDummy(CClientManager* pManager, ElementID ID, const char* szTypeName) : ClassInit(this), CClientEntity(ID)
 {
@@ -23,6 +24,9 @@ CClientDummy::CClientDummy(CClientManager* pManager, ElementID ID, const char* s
         {
             m_pGroups->AddToList(this);
         }
+
+        if (pManager->GetFireManager() && GetTypeName() == "fire")
+            pManager->GetFireManager()->Register(this);
     }
     else
     {
@@ -37,8 +41,12 @@ CClientDummy::~CClientDummy()
 
 void CClientDummy::Unlink()
 {
+    if (m_pManager && m_pManager->GetFireManager() && GetTypeName() == "fire")
+        m_pManager->GetFireManager()->Unregister(this);
+
     if (m_pGroups)
     {
         m_pGroups->RemoveFromList(this);
+        m_pGroups = NULL;
     }
 }

--- a/Client/mods/deathmatch/logic/CClientFireManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientFireManager.cpp
@@ -1,0 +1,309 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  PURPOSE:     Managed fire presentation and gameplay policy
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+#include "CClientFireManager.h"
+#include "CClientDummy.h"
+#include "CClientManager.h"
+#include <game/CFxManager.h>
+#include <game/CFxSystem.h>
+#include <algorithm>
+#include <cmath>
+
+namespace
+{
+constexpr unsigned long long DAMAGE_INTERVAL_MS = 750;
+
+bool GetNumber(CClientEntity* pElement, const char* szKey, double& dValue)
+{
+    if (!pElement)
+        return false;
+
+    CLuaArgument* pArgument = pElement->GetCustomData(szKey, false);
+    if (!pArgument || pArgument->GetType() != LUA_TNUMBER)
+        return false;
+
+    dValue = pArgument->GetNumber();
+    return true;
+}
+
+bool GetBool(CClientEntity* pElement, const char* szKey, bool& bValue)
+{
+    if (!pElement)
+        return false;
+
+    CLuaArgument* pArgument = pElement->GetCustomData(szKey, false);
+    if (!pArgument || pArgument->GetType() != LUA_TBOOLEAN)
+        return false;
+
+    bValue = pArgument->GetBoolean();
+    return true;
+}
+
+CClientEntity* GetElement(CClientEntity* pElement, const char* szKey)
+{
+    if (!pElement)
+        return nullptr;
+
+    CLuaArgument* pArgument = pElement->GetCustomData(szKey, false);
+    if (!pArgument || pArgument->GetType() != LUA_TLIGHTUSERDATA)
+        return nullptr;
+
+    return pArgument->GetElement();
+}
+
+int GetFxTier(float fStrength)
+{
+    if (fStrength <= 1.0f)
+        return 0;
+    if (fStrength <= 2.0f)
+        return 1;
+    return 2;
+}
+
+const char* GetFxName(int iTier)
+{
+    switch (iTier)
+    {
+        case 0:
+            return "fire";
+        case 1:
+            return "fire_med";
+        default:
+            return "fire_large";
+    }
+}
+
+float DistanceSquared(const CVector& a, const CVector& b)
+{
+    const float x = a.fX - b.fX;
+    const float y = a.fY - b.fY;
+    const float z = a.fZ - b.fZ;
+    return x * x + y * y + z * z;
+}
+}  // namespace
+
+CClientFireManager::CClientFireManager(CClientManager* pManager) : m_pManager(pManager)
+{
+    if (g_pClientGame && g_pClientGame->GetEvents())
+        g_pClientGame->GetEvents()->AddEvent("onClientFireDamage", "victim, damage, responsibleElement", nullptr, false);
+}
+
+CClientFireManager::~CClientFireManager()
+{
+    for (auto& fire : m_Fires)
+        DestroyFx(fire);
+    m_Fires.clear();
+}
+
+bool CClientFireManager::IsFireElement(const CClientEntity* pElement)
+{
+    return pElement && pElement->GetType() == CCLIENTDUMMY && const_cast<CClientEntity*>(pElement)->GetTypeName() == "fire";
+}
+
+void CClientFireManager::Register(CClientDummy* pFire)
+{
+    if (!pFire || !IsFireElement(pFire))
+        return;
+
+    const auto found = std::find_if(m_Fires.begin(), m_Fires.end(), [pFire](const SFireEntry& entry) { return entry.pElement == pFire; });
+    if (found != m_Fires.end())
+        return;
+
+    SFireEntry entry;
+    entry.pElement = pFire;
+    m_Fires.push_back(std::move(entry));
+}
+
+void CClientFireManager::Unregister(CClientDummy* pFire)
+{
+    auto found = std::find_if(m_Fires.begin(), m_Fires.end(), [pFire](const SFireEntry& entry) { return entry.pElement == pFire; });
+    if (found == m_Fires.end())
+        return;
+
+    DestroyFx(*found);
+    m_Fires.erase(found);
+}
+
+void CClientFireManager::DestroyFx(SFireEntry& entry)
+{
+    if (entry.pFxSystem)
+    {
+        g_pGame->GetFxManager()->DestroyFxSystem(entry.pFxSystem);
+        entry.pFxSystem = nullptr;
+    }
+    entry.iFxTier = -1;
+}
+
+void CClientFireManager::RecreateFx(SFireEntry& entry, int iTier, const CVector& vecPosition)
+{
+    DestroyFx(entry);
+
+    entry.pFxSystem = g_pGame->GetFxManager()->CreateFxSystem(GetFxName(iTier), vecPosition, nullptr, 0, true);
+    if (entry.pFxSystem)
+    {
+        entry.pFxSystem->PlayAndKill();
+        entry.iFxTier = iTier;
+    }
+}
+
+void CClientFireManager::TryDamage(SFireEntry& entry, CClientEntity* pVictim, const CVector& vecPosition, float fRadiusSq, unsigned char ucMask, float fDamage)
+{
+    if (!pVictim || pVictim == entry.pElement || pVictim->IsBeingDeleted() || pVictim->IsOnFire())
+        return;
+
+    unsigned char targetBit = 0;
+    switch (pVictim->GetType())
+    {
+        case CCLIENTPLAYER:
+            targetBit = DAMAGE_PLAYERS;
+            break;
+        case CCLIENTPED:
+            targetBit = DAMAGE_PEDS;
+            break;
+        case CCLIENTVEHICLE:
+            targetBit = DAMAGE_VEHICLES;
+            break;
+        case CCLIENTOBJECT:
+            targetBit = DAMAGE_OBJECTS;
+            break;
+        default:
+            return;
+    }
+
+    if (!(ucMask & targetBit))
+        return;
+
+    if (pVictim->GetDimension() != entry.pElement->GetDimension() || pVictim->GetInterior() != entry.pElement->GetInterior())
+        return;
+
+    CVector victimPosition;
+    pVictim->GetPosition(victimPosition);
+    if (DistanceSquared(vecPosition, victimPosition) > fRadiusSq)
+        return;
+
+    const unsigned long long now = GetTickCount64_();
+    auto& victimTick = entry.LastVictimPulse[pVictim];
+    if (victimTick && now - victimTick < DAMAGE_INTERVAL_MS)
+        return;
+    victimTick = now;
+
+    CClientEntity* pResponsible = GetElement(entry.pElement, KEY_SOURCE);
+    CLuaArguments arguments;
+    arguments.PushElement(pVictim);
+    arguments.PushNumber(fDamage);
+    arguments.PushElement(pResponsible);
+
+    if (!entry.pElement->CallEvent("onClientFireDamage", arguments, true))
+        return;
+
+    pVictim->SetOnFire(true);
+}
+
+void CClientFireManager::ProcessDamage(SFireEntry& entry, const CVector& vecPosition, float fStrength, unsigned char ucMask)
+{
+    const float radius = std::max(1.2f, 1.0f + fStrength * 0.65f);
+    const float radiusSq = radius * radius;
+    const float damage = std::max(1.0f, fStrength * 10.0f);
+
+    if (ucMask & DAMAGE_PLAYERS)
+    {
+        for (auto iter = m_pManager->GetPlayerManager()->IterBegin(); iter != m_pManager->GetPlayerManager()->IterEnd(); ++iter)
+            TryDamage(entry, *iter, vecPosition, radiusSq, ucMask, damage);
+    }
+
+    if (ucMask & DAMAGE_PEDS)
+    {
+        for (auto iter = m_pManager->GetPedManager()->IterBegin(); iter != m_pManager->GetPedManager()->IterEnd(); ++iter)
+            TryDamage(entry, *iter, vecPosition, radiusSq, ucMask, damage);
+    }
+
+    if (ucMask & DAMAGE_VEHICLES)
+    {
+        for (auto iter = m_pManager->GetVehicleManager()->IterBegin(); iter != m_pManager->GetVehicleManager()->IterEnd(); ++iter)
+            TryDamage(entry, *iter, vecPosition, radiusSq, ucMask, damage);
+    }
+
+    if (ucMask & DAMAGE_OBJECTS)
+    {
+        for (CClientObject* pObject : m_pManager->GetObjectManager()->GetObjects())
+            TryDamage(entry, pObject, vecPosition, radiusSq, ucMask, damage);
+    }
+}
+
+void CClientFireManager::ProcessEntry(SFireEntry& entry, std::vector<CClientDummy*>& expiredLocalFires)
+{
+    CClientDummy* pFire = entry.pElement;
+    if (!pFire || pFire->IsBeingDeleted())
+        return;
+
+    double expiry = 0.0;
+    GetNumber(pFire, KEY_EXPIRY, expiry);
+    if (expiry > 0.0)
+    {
+        const double now = static_cast<double>(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+        if (now >= expiry)
+        {
+            DestroyFx(entry);
+            if (pFire->IsLocalEntity())
+                expiredLocalFires.push_back(pFire);
+            return;
+        }
+    }
+
+    CClientPlayer* pLocalPlayer = m_pManager->GetPlayerManager()->GetLocalPlayer();
+    if (!pLocalPlayer || pLocalPlayer->GetDimension() != pFire->GetDimension() || pLocalPlayer->GetInterior() != pFire->GetInterior())
+    {
+        DestroyFx(entry);
+        return;
+    }
+
+    CVector position;
+    pFire->GetPosition(position);
+
+    CClientEntity* pTarget = GetElement(pFire, KEY_TARGET);
+    if (pTarget && !pTarget->IsBeingDeleted() && pTarget->GetDimension() == pFire->GetDimension() && pTarget->GetInterior() == pFire->GetInterior())
+        pTarget->GetPosition(position);
+
+    double strengthValue = 1.0;
+    GetNumber(pFire, KEY_STRENGTH, strengthValue);
+    const float strength = std::max(0.1f, static_cast<float>(strengthValue));
+    const int tier = GetFxTier(strength);
+
+    if (!entry.pFxSystem || entry.iFxTier != tier)
+        RecreateFx(entry, tier, position);
+    else
+        entry.pFxSystem->SetPosition(position);
+
+    bool damageEnabled = true;
+    GetBool(pFire, KEY_DAMAGE, damageEnabled);
+    if (!damageEnabled)
+        return;
+
+    double maskValue = DAMAGE_ALL;
+    GetNumber(pFire, KEY_DAMAGE_MASK, maskValue);
+    const unsigned char mask = static_cast<unsigned char>(static_cast<unsigned int>(maskValue)) & DAMAGE_ALL;
+    if (!mask)
+        return;
+
+    ProcessDamage(entry, position, strength, mask);
+}
+
+void CClientFireManager::DoPulse()
+{
+    std::vector<CClientDummy*> expiredLocalFires;
+
+    for (auto& fire : m_Fires)
+        ProcessEntry(fire, expiredLocalFires);
+
+    for (CClientDummy* pFire : expiredLocalFires)
+    {
+        if (pFire && !pFire->IsBeingDeleted())
+            CStaticFunctionDefinitions::DestroyElement(*pFire);
+    }
+}

--- a/Client/mods/deathmatch/logic/CClientFireManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientFireManager.cpp
@@ -13,6 +13,7 @@
 #include <game/CFxManager.h>
 #include <game/CFxSystem.h>
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 
 namespace
@@ -51,10 +52,7 @@ CClientEntity* GetElement(CClientEntity* pElement, const char* szKey)
         return nullptr;
 
     CLuaArgument* pArgument = pElement->GetCustomData(szKey, false);
-    if (!pArgument || pArgument->GetType() != LUA_TLIGHTUSERDATA)
-        return nullptr;
-
-    return pArgument->GetElement();
+    return pArgument ? pArgument->GetElement() : nullptr;
 }
 
 int GetFxTier(float fStrength)
@@ -199,6 +197,8 @@ void CClientFireManager::TryDamage(SFireEntry& entry, CClientEntity* pVictim, co
     arguments.PushNumber(fDamage);
     arguments.PushElement(pResponsible);
 
+    // CallEvent returns false when a handler cancels the event. Only ignite the victim
+    // after script policy has had a chance to veto the interaction.
     if (!entry.pElement->CallEvent("onClientFireDamage", arguments, true))
         return;
 

--- a/Client/mods/deathmatch/logic/CClientFireManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientFireManager.cpp
@@ -13,7 +13,6 @@
 #include <game/CFxManager.h>
 #include <game/CFxSystem.h>
 #include <algorithm>
-#include <chrono>
 #include <cmath>
 
 namespace
@@ -31,6 +30,13 @@ bool GetNumber(CClientEntity* pElement, const char* szKey, double& dValue)
 
     dValue = pArgument->GetNumber();
     return true;
+}
+
+void SetLocalNumber(CClientEntity* pElement, const char* szKey, double dValue)
+{
+    CLuaArgument argument;
+    argument.ReadNumber(dValue);
+    pElement->SetCustomData(szKey, argument, false);
 }
 
 bool GetBool(CClientEntity* pElement, const char* szKey, bool& bValue)
@@ -115,6 +121,7 @@ void CClientFireManager::Register(CClientDummy* pFire)
 
     SFireEntry entry;
     entry.pElement = pFire;
+    entry.ullLastPulse = GetTickCount64_();
     m_Fires.push_back(std::move(entry));
 }
 
@@ -197,8 +204,6 @@ void CClientFireManager::TryDamage(SFireEntry& entry, CClientEntity* pVictim, co
     arguments.PushNumber(fDamage);
     arguments.PushElement(pResponsible);
 
-    // CallEvent returns false when a handler cancels the event. Only ignite the victim
-    // after script policy has had a chance to veto the interaction.
     if (!entry.pElement->CallEvent("onClientFireDamage", arguments, true))
         return;
 
@@ -242,12 +247,23 @@ void CClientFireManager::ProcessEntry(SFireEntry& entry, std::vector<CClientDumm
     if (!pFire || pFire->IsBeingDeleted())
         return;
 
-    double expiry = 0.0;
-    GetNumber(pFire, KEY_EXPIRY, expiry);
-    if (expiry > 0.0)
+    const unsigned long long now = GetTickCount64_();
+    const unsigned long long elapsed = entry.ullLastPulse ? now - entry.ullLastPulse : 0;
+    entry.ullLastPulse = now;
+
+    double duration = 0.0;
+    double remaining = 0.0;
+    GetNumber(pFire, KEY_DURATION, duration);
+    GetNumber(pFire, KEY_REMAINING, remaining);
+    if (duration > 0.0)
     {
-        const double now = static_cast<double>(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
-        if (now >= expiry)
+        if (remaining > 0.0 && elapsed > 0)
+        {
+            remaining = std::max(0.0, remaining - static_cast<double>(elapsed));
+            SetLocalNumber(pFire, KEY_REMAINING, remaining);
+        }
+
+        if (remaining <= 0.0)
         {
             DestroyFx(entry);
             if (pFire->IsLocalEntity())

--- a/Client/mods/deathmatch/logic/CClientFireManager.h
+++ b/Client/mods/deathmatch/logic/CClientFireManager.h
@@ -14,6 +14,7 @@ class CClientDummy;
 class CClientEntity;
 class CClientManager;
 class CFxSystem;
+class CVector;
 
 class CClientFireManager
 {
@@ -53,7 +54,6 @@ private:
         CClientDummy* pElement{};
         CFxSystem*    pFxSystem{};
         int           iFxTier{-1};
-        unsigned long long ullLastDamagePulse{};
         std::unordered_map<CClientEntity*, unsigned long long> LastVictimPulse;
     };
 
@@ -63,6 +63,6 @@ private:
     void ProcessDamage(SFireEntry& entry, const CVector& vecPosition, float fStrength, unsigned char ucMask);
     void TryDamage(SFireEntry& entry, CClientEntity* pVictim, const CVector& vecPosition, float fRadiusSq, unsigned char ucMask, float fDamage);
 
-    CClientManager*                         m_pManager{};
-    std::vector<SFireEntry>                 m_Fires;
+    CClientManager*         m_pManager{};
+    std::vector<SFireEntry> m_Fires;
 };

--- a/Client/mods/deathmatch/logic/CClientFireManager.h
+++ b/Client/mods/deathmatch/logic/CClientFireManager.h
@@ -38,7 +38,7 @@ public:
     static bool IsFireElement(const CClientEntity* pElement);
 
     static constexpr const char* KEY_DURATION = "__neon_fire_duration";
-    static constexpr const char* KEY_EXPIRY = "__neon_fire_expiry";
+    static constexpr const char* KEY_REMAINING = "__neon_fire_remaining";
     static constexpr const char* KEY_STRENGTH = "__neon_fire_strength";
     static constexpr const char* KEY_DAMAGE = "__neon_fire_damage";
     static constexpr const char* KEY_DAMAGE_MASK = "__neon_fire_damage_mask";
@@ -54,6 +54,7 @@ private:
         CClientDummy* pElement{};
         CFxSystem*    pFxSystem{};
         int           iFxTier{-1};
+        unsigned long long ullLastPulse{};
         std::unordered_map<CClientEntity*, unsigned long long> LastVictimPulse;
     };
 

--- a/Client/mods/deathmatch/logic/CClientFireManager.h
+++ b/Client/mods/deathmatch/logic/CClientFireManager.h
@@ -1,0 +1,68 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  PURPOSE:     Managed fire presentation and gameplay policy
+ *
+ *****************************************************************************/
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+
+class CClientDummy;
+class CClientEntity;
+class CClientManager;
+class CFxSystem;
+
+class CClientFireManager
+{
+public:
+    enum eDamageTarget : unsigned char
+    {
+        DAMAGE_PLAYERS = 1 << 0,
+        DAMAGE_PEDS = 1 << 1,
+        DAMAGE_VEHICLES = 1 << 2,
+        DAMAGE_OBJECTS = 1 << 3,
+        DAMAGE_ALL = DAMAGE_PLAYERS | DAMAGE_PEDS | DAMAGE_VEHICLES | DAMAGE_OBJECTS,
+    };
+
+    explicit CClientFireManager(CClientManager* pManager);
+    ~CClientFireManager();
+
+    void Register(CClientDummy* pFire);
+    void Unregister(CClientDummy* pFire);
+    void DoPulse();
+
+    static bool IsFireElement(const CClientEntity* pElement);
+
+    static constexpr const char* KEY_DURATION = "__neon_fire_duration";
+    static constexpr const char* KEY_EXPIRY = "__neon_fire_expiry";
+    static constexpr const char* KEY_STRENGTH = "__neon_fire_strength";
+    static constexpr const char* KEY_DAMAGE = "__neon_fire_damage";
+    static constexpr const char* KEY_DAMAGE_MASK = "__neon_fire_damage_mask";
+    static constexpr const char* KEY_SPREAD = "__neon_fire_spread";
+    static constexpr const char* KEY_MAX_GENERATIONS = "__neon_fire_max_generations";
+    static constexpr const char* KEY_GENERATION = "__neon_fire_generation";
+    static constexpr const char* KEY_SOURCE = "__neon_fire_source";
+    static constexpr const char* KEY_TARGET = "__neon_fire_target";
+
+private:
+    struct SFireEntry
+    {
+        CClientDummy* pElement{};
+        CFxSystem*    pFxSystem{};
+        int           iFxTier{-1};
+        unsigned long long ullLastDamagePulse{};
+        std::unordered_map<CClientEntity*, unsigned long long> LastVictimPulse;
+    };
+
+    void ProcessEntry(SFireEntry& entry, std::vector<CClientDummy*>& expiredLocalFires);
+    void RecreateFx(SFireEntry& entry, int iTier, const CVector& vecPosition);
+    void DestroyFx(SFireEntry& entry);
+    void ProcessDamage(SFireEntry& entry, const CVector& vecPosition, float fStrength, unsigned char ucMask);
+    void TryDamage(SFireEntry& entry, CClientEntity* pVictim, const CVector& vecPosition, float fRadiusSq, unsigned char ucMask, float fDamage);
+
+    CClientManager*                         m_pManager{};
+    std::vector<SFireEntry>                 m_Fires;
+};

--- a/Client/mods/deathmatch/logic/CClientManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientManager.cpp
@@ -9,6 +9,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include "CClientFireManager.h"
 
 using SharedUtil::CalcMTASAPath;
 
@@ -43,6 +44,7 @@ CClientManager::CClientManager()
     m_pResourceManager = new CResourceManager;
     m_pColManager = new CClientColManager;
     m_pGroups = new CClientGroups;
+    m_pFireManager = new CClientFireManager(this);
     m_pProjectileManager = new CClientProjectileManager(this);
     m_pDFFManager = new CClientDFFManager(this);
     m_pColModelManager = new CClientColModelManager(this);
@@ -99,6 +101,9 @@ CClientManager::~CClientManager()
 
     delete m_pProjectileManager;
     m_pProjectileManager = NULL;
+
+    delete m_pFireManager;
+    m_pFireManager = NULL;
 
     delete m_pGroups;
     m_pGroups = NULL;
@@ -228,6 +233,7 @@ void CClientManager::DoPulse(bool bDoStandardPulses, bool bDoVehicleManagerPulse
             m_pPedManager->DoPulse(true);
             TIMING_CHECKPOINT("-MTA_PedManager");
             m_pProjectileManager->DoPulse();
+            m_pFireManager->DoPulse();
             m_pSoundManager->DoPulse();
             TIMING_CHECKPOINT("+MTA_PlayerManager");
             m_pPlayerManager->DoPulse();

--- a/Client/mods/deathmatch/logic/CClientManager.h
+++ b/Client/mods/deathmatch/logic/CClientManager.h
@@ -48,6 +48,7 @@ class CClientManager;
 
 class CClientProjectileManager;
 class CClientExplosionManager;
+class CClientFireManager;
 
 class CClientManager
 {
@@ -92,6 +93,7 @@ public:
     CClientGroups*               GetGroups() { return m_pGroups; }
     CClientProjectileManager*    GetProjectileManager() { return m_pProjectileManager; }
     CClientExplosionManager*     GetExplosionManager() { return m_pExplosionManager; }
+    CClientFireManager*          GetFireManager() { return m_pFireManager; }
     CClientPacketRecorder*       GetPacketRecorder() { return m_pPacketRecorder; }
     CClientWaterManager*         GetWaterManager() { return m_pWaterManager; }
     CClientWeaponManager*        GetWeaponManager() { return m_pWeaponManager; }
@@ -149,6 +151,7 @@ private:
     CClientGroups*               m_pGroups;
     CClientProjectileManager*    m_pProjectileManager;
     CClientExplosionManager*     m_pExplosionManager;
+    CClientFireManager*          m_pFireManager;
     CClientWeaponManager*        m_pWeaponManager;
     CClientEffectManager*        m_pEffectManager;
     CClientPointLightsManager*   m_pPointLightsManager;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
@@ -9,49 +9,256 @@
  *****************************************************************************/
 #include "StdInc.h"
 #include "CLuaFireDefs.h"
+#include "../CClientFireManager.h"
+#include <chrono>
+
+namespace
+{
+using FireManager = CClientFireManager;
+
+long long NowMs()
+{
+    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+}
+
+bool IsFire(CClientEntity* pElement)
+{
+    return FireManager::IsFireElement(pElement);
+}
+
+void SetNumber(CClientEntity* pFire, const char* key, double value)
+{
+    CLuaArgument argument;
+    argument.ReadNumber(value);
+    pFire->SetCustomData(key, argument, false);
+}
+
+void SetBool(CClientEntity* pFire, const char* key, bool value)
+{
+    CLuaArgument argument;
+    argument.ReadBool(value);
+    pFire->SetCustomData(key, argument, false);
+}
+
+void SetElement(CClientEntity* pFire, const char* key, CClientEntity* pValue)
+{
+    if (!pValue)
+    {
+        pFire->DeleteCustomData(key);
+        return;
+    }
+
+    CLuaArgument argument;
+    argument.ReadElement(pValue);
+    pFire->SetCustomData(key, argument, false);
+}
+
+bool GetNumber(CClientEntity* pFire, const char* key, double& value)
+{
+    CLuaArgument* argument = pFire ? pFire->GetCustomData(key, false) : nullptr;
+    if (!argument || argument->GetType() != LUA_TNUMBER)
+        return false;
+    value = argument->GetNumber();
+    return true;
+}
+
+bool GetBool(CClientEntity* pFire, const char* key, bool& value)
+{
+    CLuaArgument* argument = pFire ? pFire->GetCustomData(key, false) : nullptr;
+    if (!argument || argument->GetType() != LUA_TBOOLEAN)
+        return false;
+    value = argument->GetBoolean();
+    return true;
+}
+
+CClientEntity* GetElement(CClientEntity* pFire, const char* key)
+{
+    CLuaArgument* argument = pFire ? pFire->GetCustomData(key, false) : nullptr;
+    return argument ? argument->GetElement() : nullptr;
+}
+
+bool ReadTableBool(lua_State* luaVM, int tableIndex, const char* key, bool defaultValue)
+{
+    lua_getfield(luaVM, tableIndex, key);
+    const bool value = lua_isboolean(luaVM, -1) ? lua_toboolean(luaVM, -1) != 0 : defaultValue;
+    lua_pop(luaVM, 1);
+    return value;
+}
+
+double ReadTableNumber(lua_State* luaVM, int tableIndex, const char* key, double defaultValue)
+{
+    lua_getfield(luaVM, tableIndex, key);
+    const double value = lua_isnumber(luaVM, -1) ? lua_tonumber(luaVM, -1) : defaultValue;
+    lua_pop(luaVM, 1);
+    return value;
+}
+
+CClientEntity* ReadTableElement(lua_State* luaVM, int tableIndex, const char* key)
+{
+    lua_getfield(luaVM, tableIndex, key);
+    CClientEntity* value = lua_toelement(luaVM, -1);
+    lua_pop(luaVM, 1);
+    return value;
+}
+
+unsigned char ReadDamageMask(lua_State* luaVM, int optionsIndex)
+{
+    unsigned char mask = FireManager::DAMAGE_ALL;
+    lua_getfield(luaVM, optionsIndex, "damageTargets");
+    if (lua_istable(luaVM, -1))
+    {
+        const int table = lua_gettop(luaVM);
+        mask = 0;
+        if (ReadTableBool(luaVM, table, "players", true))
+            mask |= FireManager::DAMAGE_PLAYERS;
+        if (ReadTableBool(luaVM, table, "peds", true))
+            mask |= FireManager::DAMAGE_PEDS;
+        if (ReadTableBool(luaVM, table, "vehicles", true))
+            mask |= FireManager::DAMAGE_VEHICLES;
+        if (ReadTableBool(luaVM, table, "objects", true))
+            mask |= FireManager::DAMAGE_OBJECTS;
+    }
+    lua_pop(luaVM, 1);
+    return mask;
+}
+
+void PushDamageMask(lua_State* luaVM, unsigned char mask)
+{
+    lua_createtable(luaVM, 0, 4);
+    lua_pushboolean(luaVM, (mask & FireManager::DAMAGE_PLAYERS) != 0);
+    lua_setfield(luaVM, -2, "players");
+    lua_pushboolean(luaVM, (mask & FireManager::DAMAGE_PEDS) != 0);
+    lua_setfield(luaVM, -2, "peds");
+    lua_pushboolean(luaVM, (mask & FireManager::DAMAGE_VEHICLES) != 0);
+    lua_setfield(luaVM, -2, "vehicles");
+    lua_pushboolean(luaVM, (mask & FireManager::DAMAGE_OBJECTS) != 0);
+    lua_setfield(luaVM, -2, "objects");
+}
+
+bool ReadFire(lua_State* luaVM, CClientEntity*& pFire)
+{
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pFire);
+    return !argStream.HasErrors() && IsFire(pFire);
+}
+
+bool CanMutate(CClientEntity* pFire)
+{
+    return pFire && pFire->IsLocalEntity();
+}
+}  // namespace
 
 void CLuaFireDefs::LoadFunctions()
 {
     constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"createFire", CreateFire},
         {"extinguishFire", ExtinguishFire},
+        {"getFireDuration", GetFireDuration},
+        {"setFireDuration", SetFireDuration},
+        {"getFireRemainingTime", GetFireRemainingTime},
+        {"setFireRemainingTime", SetFireRemainingTime},
+        {"getFireStrength", GetFireStrength},
+        {"setFireStrength", SetFireStrength},
+        {"isFireDamageEnabled", IsFireDamageEnabled},
+        {"setFireDamageEnabled", SetFireDamageEnabled},
+        {"getFireDamageTargets", GetFireDamageTargets},
+        {"setFireDamageTargets", SetFireDamageTargets},
+        {"isFireSpreadEnabled", IsFireSpreadEnabled},
+        {"setFireSpreadEnabled", SetFireSpreadEnabled},
+        {"getFireMaxGenerations", GetFireMaxGenerations},
+        {"setFireMaxGenerations", SetFireMaxGenerations},
+        {"getFireSource", GetFireSource},
+        {"setFireSource", SetFireSource},
+        {"getFireTarget", GetFireTarget},
+        {"setFireTarget", SetFireTarget},
     };
 
-    // Add functions
     for (const auto& [name, func] : functions)
         CLuaCFunctions::AddFunction(name, func);
 }
 
 int CLuaFireDefs::CreateFire(lua_State* luaVM)
 {
-    // bool createFire ( float x, float y, float z [, float size = 1.8 ] )
     CVector vecPosition;
-    float   fSize;
-
     CScriptArgReader argStream(luaVM);
     argStream.ReadVector3D(vecPosition);
-    argStream.ReadNumber(fSize, 1.8f);
 
-    if (!argStream.HasErrors())
+    if (argStream.HasErrors())
     {
-        if (CStaticFunctionDefinitions::CreateFire(vecPosition, fSize))
-        {
-            lua_pushboolean(luaVM, true);
-            return 1;
-        }
-    }
-    else
         m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+        lua_pushboolean(luaVM, false);
+        return 1;
+    }
 
-    lua_pushboolean(luaVM, false);
+    // Keep the historical numeric form byte-for-byte compatible: it creates a native,
+    // unmanaged GTA fire and returns a boolean. The options-table form creates a managed
+    // fire element with stable lifetime and control state.
+    if (!lua_istable(luaVM, 4))
+    {
+        float size = 1.8f;
+        if (!lua_isnoneornil(luaVM, 4))
+        {
+            if (!lua_isnumber(luaVM, 4))
+            {
+                lua_pushboolean(luaVM, false);
+                return 1;
+            }
+            size = static_cast<float>(lua_tonumber(luaVM, 4));
+        }
+        lua_pushboolean(luaVM, CStaticFunctionDefinitions::CreateFire(vecPosition, size));
+        return 1;
+    }
+
+    const int options = 4;
+    const double duration = std::max(0.0, ReadTableNumber(luaVM, options, "duration", 5000.0));
+    const double strength = std::max(0.1, ReadTableNumber(luaVM, options, "strength", 1.0));
+    const bool damage = ReadTableBool(luaVM, options, "damage", true);
+    const bool spread = ReadTableBool(luaVM, options, "spread", false);
+    const double maxGenerations = std::max(0.0, ReadTableNumber(luaVM, options, "maxGenerations", 0.0));
+    const unsigned char damageMask = ReadDamageMask(luaVM, options);
+    CClientEntity* source = ReadTableElement(luaVM, options, "source");
+    CClientEntity* target = ReadTableElement(luaVM, options, "target");
+
+    CResource& resource = lua_getownerresource(luaVM);
+    CClientDummy* fire = CStaticFunctionDefinitions::CreateElement(resource, "fire", "");
+    if (!fire)
+    {
+        lua_pushboolean(luaVM, false);
+        return 1;
+    }
+
+    fire->SetPosition(vecPosition);
+    SetNumber(fire, FireManager::KEY_DURATION, duration);
+    SetNumber(fire, FireManager::KEY_EXPIRY, duration > 0.0 ? static_cast<double>(NowMs()) + duration : 0.0);
+    SetNumber(fire, FireManager::KEY_STRENGTH, strength);
+    SetBool(fire, FireManager::KEY_DAMAGE, damage);
+    SetNumber(fire, FireManager::KEY_DAMAGE_MASK, damageMask);
+    SetBool(fire, FireManager::KEY_SPREAD, spread);
+    SetNumber(fire, FireManager::KEY_MAX_GENERATIONS, maxGenerations);
+    SetNumber(fire, FireManager::KEY_GENERATION, 0.0);
+    SetElement(fire, FireManager::KEY_SOURCE, source);
+    SetElement(fire, FireManager::KEY_TARGET, target);
+
+    if (resource.GetElementGroup())
+        resource.GetElementGroup()->Add(fire);
+
+    lua_pushelement(luaVM, fire);
     return 1;
 }
 
 int CLuaFireDefs::ExtinguishFire(lua_State* luaVM)
 {
-    // bool extinguishFire ( [ float x, float y, float z [, float radius = 1.0 ] ] )
-    CScriptArgReader argStream(luaVM);
+    if (lua_type(luaVM, 1) == LUA_TLIGHTUSERDATA)
+    {
+        CClientEntity* fire = lua_toelement(luaVM, 1);
+        if (IsFire(fire) && CanMutate(fire))
+        {
+            lua_pushboolean(luaVM, CStaticFunctionDefinitions::DestroyElement(*fire));
+            return 1;
+        }
+    }
 
+    CScriptArgReader argStream(luaVM);
     if (argStream.NextIsNone())
     {
         lua_pushboolean(luaVM, CStaticFunctionDefinitions::ExtinguishAllFires());
@@ -59,22 +266,284 @@ int CLuaFireDefs::ExtinguishFire(lua_State* luaVM)
     }
 
     CVector vecPosition;
-    float   fRadius;
-
+    float fRadius;
     argStream.ReadVector3D(vecPosition);
     argStream.ReadNumber(fRadius, 1.0f);
-
     if (!argStream.HasErrors())
     {
-        if (CStaticFunctionDefinitions::ExtinguishFireInRadius(vecPosition, fRadius))
-        {
-            lua_pushboolean(luaVM, true);
-            return 1;
-        }
+        lua_pushboolean(luaVM, CStaticFunctionDefinitions::ExtinguishFireInRadius(vecPosition, fRadius));
+        return 1;
     }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
 
+    m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::GetFireDuration(lua_State* luaVM)
+{
+    CClientEntity* fire = nullptr;
+    double value = 0.0;
+    if (ReadFire(luaVM, fire) && GetNumber(fire, FireManager::KEY_DURATION, value))
+        lua_pushnumber(luaVM, value);
+    else
+        lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::SetFireDuration(lua_State* luaVM)
+{
+    CClientEntity* fire = nullptr;
+    double duration = 0.0;
+    CScriptArgReader args(luaVM);
+    args.ReadUserData(fire);
+    args.ReadNumber(duration);
+    if (!args.HasErrors() && IsFire(fire) && CanMutate(fire) && duration >= 0.0)
+    {
+        SetNumber(fire, FireManager::KEY_DURATION, duration);
+        SetNumber(fire, FireManager::KEY_EXPIRY, duration > 0.0 ? static_cast<double>(NowMs()) + duration : 0.0);
+        lua_pushboolean(luaVM, true);
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::GetFireRemainingTime(lua_State* luaVM)
+{
+    CClientEntity* fire = nullptr;
+    double expiry = 0.0;
+    if (ReadFire(luaVM, fire) && GetNumber(fire, FireManager::KEY_EXPIRY, expiry))
+    {
+        lua_pushnumber(luaVM, expiry <= 0.0 ? 0.0 : std::max(0.0, expiry - static_cast<double>(NowMs())));
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::SetFireRemainingTime(lua_State* luaVM)
+{
+    CClientEntity* fire = nullptr;
+    double remaining = 0.0;
+    CScriptArgReader args(luaVM);
+    args.ReadUserData(fire);
+    args.ReadNumber(remaining);
+    if (!args.HasErrors() && IsFire(fire) && CanMutate(fire) && remaining >= 0.0)
+    {
+        SetNumber(fire, FireManager::KEY_EXPIRY, remaining > 0.0 ? static_cast<double>(NowMs()) + remaining : static_cast<double>(NowMs()));
+        lua_pushboolean(luaVM, true);
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::GetFireStrength(lua_State* luaVM)
+{
+    CClientEntity* fire = nullptr;
+    double value = 0.0;
+    if (ReadFire(luaVM, fire) && GetNumber(fire, FireManager::KEY_STRENGTH, value))
+        lua_pushnumber(luaVM, value);
+    else
+        lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::SetFireStrength(lua_State* luaVM)
+{
+    CClientEntity* fire = nullptr;
+    double strength = 0.0;
+    CScriptArgReader args(luaVM);
+    args.ReadUserData(fire);
+    args.ReadNumber(strength);
+    if (!args.HasErrors() && IsFire(fire) && CanMutate(fire) && strength > 0.0)
+    {
+        SetNumber(fire, FireManager::KEY_STRENGTH, strength);
+        lua_pushboolean(luaVM, true);
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::IsFireDamageEnabled(lua_State* luaVM)
+{
+    CClientEntity* fire = nullptr;
+    bool value = false;
+    if (ReadFire(luaVM, fire) && GetBool(fire, FireManager::KEY_DAMAGE, value))
+        lua_pushboolean(luaVM, value);
+    else
+        lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::SetFireDamageEnabled(lua_State* luaVM)
+{
+    CClientEntity* fire = nullptr;
+    bool enabled = false;
+    CScriptArgReader args(luaVM);
+    args.ReadUserData(fire);
+    args.ReadBool(enabled);
+    if (!args.HasErrors() && IsFire(fire) && CanMutate(fire))
+    {
+        SetBool(fire, FireManager::KEY_DAMAGE, enabled);
+        lua_pushboolean(luaVM, true);
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::GetFireDamageTargets(lua_State* luaVM)
+{
+    CClientEntity* fire = nullptr;
+    double value = FireManager::DAMAGE_ALL;
+    if (ReadFire(luaVM, fire))
+    {
+        GetNumber(fire, FireManager::KEY_DAMAGE_MASK, value);
+        PushDamageMask(luaVM, static_cast<unsigned char>(static_cast<unsigned int>(value)) & FireManager::DAMAGE_ALL);
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::SetFireDamageTargets(lua_State* luaVM)
+{
+    CClientEntity* fire = lua_toelement(luaVM, 1);
+    if (!IsFire(fire) || !CanMutate(fire) || !lua_istable(luaVM, 2))
+    {
+        lua_pushboolean(luaVM, false);
+        return 1;
+    }
+
+    unsigned char mask = 0;
+    if (ReadTableBool(luaVM, 2, "players", true))
+        mask |= FireManager::DAMAGE_PLAYERS;
+    if (ReadTableBool(luaVM, 2, "peds", true))
+        mask |= FireManager::DAMAGE_PEDS;
+    if (ReadTableBool(luaVM, 2, "vehicles", true))
+        mask |= FireManager::DAMAGE_VEHICLES;
+    if (ReadTableBool(luaVM, 2, "objects", true))
+        mask |= FireManager::DAMAGE_OBJECTS;
+    SetNumber(fire, FireManager::KEY_DAMAGE_MASK, mask);
+    lua_pushboolean(luaVM, true);
+    return 1;
+}
+
+int CLuaFireDefs::IsFireSpreadEnabled(lua_State* luaVM)
+{
+    CClientEntity* fire = nullptr;
+    bool value = false;
+    if (ReadFire(luaVM, fire) && GetBool(fire, FireManager::KEY_SPREAD, value))
+        lua_pushboolean(luaVM, value);
+    else
+        lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::SetFireSpreadEnabled(lua_State* luaVM)
+{
+    CClientEntity* fire = nullptr;
+    bool enabled = false;
+    CScriptArgReader args(luaVM);
+    args.ReadUserData(fire);
+    args.ReadBool(enabled);
+    if (!args.HasErrors() && IsFire(fire) && CanMutate(fire))
+    {
+        SetBool(fire, FireManager::KEY_SPREAD, enabled);
+        lua_pushboolean(luaVM, true);
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::GetFireMaxGenerations(lua_State* luaVM)
+{
+    CClientEntity* fire = nullptr;
+    double value = 0.0;
+    if (ReadFire(luaVM, fire) && GetNumber(fire, FireManager::KEY_MAX_GENERATIONS, value))
+        lua_pushnumber(luaVM, value);
+    else
+        lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::SetFireMaxGenerations(lua_State* luaVM)
+{
+    CClientEntity* fire = nullptr;
+    unsigned int generations = 0;
+    CScriptArgReader args(luaVM);
+    args.ReadUserData(fire);
+    args.ReadNumber(generations);
+    if (!args.HasErrors() && IsFire(fire) && CanMutate(fire) && generations <= 255)
+    {
+        SetNumber(fire, FireManager::KEY_MAX_GENERATIONS, generations);
+        lua_pushboolean(luaVM, true);
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::GetFireSource(lua_State* luaVM)
+{
+    CClientEntity* fire = nullptr;
+    if (ReadFire(luaVM, fire))
+    {
+        CClientEntity* value = GetElement(fire, FireManager::KEY_SOURCE);
+        if (value)
+            lua_pushelement(luaVM, value);
+        else
+            lua_pushboolean(luaVM, false);
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::SetFireSource(lua_State* luaVM)
+{
+    CClientEntity* fire = lua_toelement(luaVM, 1);
+    CClientEntity* value = lua_isnoneornil(luaVM, 2) ? nullptr : lua_toelement(luaVM, 2);
+    if (IsFire(fire) && CanMutate(fire) && (lua_isnoneornil(luaVM, 2) || value))
+    {
+        SetElement(fire, FireManager::KEY_SOURCE, value);
+        lua_pushboolean(luaVM, true);
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::GetFireTarget(lua_State* luaVM)
+{
+    CClientEntity* fire = nullptr;
+    if (ReadFire(luaVM, fire))
+    {
+        CClientEntity* value = GetElement(fire, FireManager::KEY_TARGET);
+        if (value)
+            lua_pushelement(luaVM, value);
+        else
+            lua_pushboolean(luaVM, false);
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::SetFireTarget(lua_State* luaVM)
+{
+    CClientEntity* fire = lua_toelement(luaVM, 1);
+    CClientEntity* value = lua_isnoneornil(luaVM, 2) ? nullptr : lua_toelement(luaVM, 2);
+    if (IsFire(fire) && CanMutate(fire) && (lua_isnoneornil(luaVM, 2) || value))
+    {
+        SetElement(fire, FireManager::KEY_TARGET, value);
+        lua_pushboolean(luaVM, true);
+        return 1;
+    }
     lua_pushboolean(luaVM, false);
     return 1;
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
@@ -10,16 +10,11 @@
 #include "StdInc.h"
 #include "CLuaFireDefs.h"
 #include "../CClientFireManager.h"
-#include <chrono>
+#include <algorithm>
 
 namespace
 {
 using FireManager = CClientFireManager;
-
-long long NowMs()
-{
-    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-}
 
 bool IsFire(CClientEntity* pElement)
 {
@@ -190,9 +185,8 @@ int CLuaFireDefs::CreateFire(lua_State* luaVM)
         return 1;
     }
 
-    // Keep the historical numeric form byte-for-byte compatible: it creates a native,
-    // unmanaged GTA fire and returns a boolean. The options-table form creates a managed
-    // fire element with stable lifetime and control state.
+    // Keep the historical numeric form compatible. The options-table form creates
+    // a managed element; the numeric form keeps the original native GTA fire path.
     if (!lua_istable(luaVM, 4))
     {
         float size = 1.8f;
@@ -229,7 +223,7 @@ int CLuaFireDefs::CreateFire(lua_State* luaVM)
 
     fire->SetPosition(vecPosition);
     SetNumber(fire, FireManager::KEY_DURATION, duration);
-    SetNumber(fire, FireManager::KEY_EXPIRY, duration > 0.0 ? static_cast<double>(NowMs()) + duration : 0.0);
+    SetNumber(fire, FireManager::KEY_REMAINING, duration);
     SetNumber(fire, FireManager::KEY_STRENGTH, strength);
     SetBool(fire, FireManager::KEY_DAMAGE, damage);
     SetNumber(fire, FireManager::KEY_DAMAGE_MASK, damageMask);
@@ -248,14 +242,11 @@ int CLuaFireDefs::CreateFire(lua_State* luaVM)
 
 int CLuaFireDefs::ExtinguishFire(lua_State* luaVM)
 {
-    if (lua_type(luaVM, 1) == LUA_TLIGHTUSERDATA)
+    CClientEntity* managed = lua_toelement(luaVM, 1);
+    if (IsFire(managed))
     {
-        CClientEntity* fire = lua_toelement(luaVM, 1);
-        if (IsFire(fire) && CanMutate(fire))
-        {
-            lua_pushboolean(luaVM, CStaticFunctionDefinitions::DestroyElement(*fire));
-            return 1;
-        }
+        lua_pushboolean(luaVM, CanMutate(managed) && CStaticFunctionDefinitions::DestroyElement(*managed));
+        return 1;
     }
 
     CScriptArgReader argStream(luaVM);
@@ -301,7 +292,7 @@ int CLuaFireDefs::SetFireDuration(lua_State* luaVM)
     if (!args.HasErrors() && IsFire(fire) && CanMutate(fire) && duration >= 0.0)
     {
         SetNumber(fire, FireManager::KEY_DURATION, duration);
-        SetNumber(fire, FireManager::KEY_EXPIRY, duration > 0.0 ? static_cast<double>(NowMs()) + duration : 0.0);
+        SetNumber(fire, FireManager::KEY_REMAINING, duration);
         lua_pushboolean(luaVM, true);
         return 1;
     }
@@ -312,13 +303,11 @@ int CLuaFireDefs::SetFireDuration(lua_State* luaVM)
 int CLuaFireDefs::GetFireRemainingTime(lua_State* luaVM)
 {
     CClientEntity* fire = nullptr;
-    double expiry = 0.0;
-    if (ReadFire(luaVM, fire) && GetNumber(fire, FireManager::KEY_EXPIRY, expiry))
-    {
-        lua_pushnumber(luaVM, expiry <= 0.0 ? 0.0 : std::max(0.0, expiry - static_cast<double>(NowMs())));
-        return 1;
-    }
-    lua_pushboolean(luaVM, false);
+    double remaining = 0.0;
+    if (ReadFire(luaVM, fire) && GetNumber(fire, FireManager::KEY_REMAINING, remaining))
+        lua_pushnumber(luaVM, std::max(0.0, remaining));
+    else
+        lua_pushboolean(luaVM, false);
     return 1;
 }
 
@@ -331,7 +320,11 @@ int CLuaFireDefs::SetFireRemainingTime(lua_State* luaVM)
     args.ReadNumber(remaining);
     if (!args.HasErrors() && IsFire(fire) && CanMutate(fire) && remaining >= 0.0)
     {
-        SetNumber(fire, FireManager::KEY_EXPIRY, remaining > 0.0 ? static_cast<double>(NowMs()) + remaining : static_cast<double>(NowMs()));
+        double duration = 0.0;
+        GetNumber(fire, FireManager::KEY_DURATION, duration);
+        if (duration <= 0.0 && remaining > 0.0)
+            SetNumber(fire, FireManager::KEY_DURATION, remaining);
+        SetNumber(fire, FireManager::KEY_REMAINING, remaining);
         lua_pushboolean(luaVM, true);
         return 1;
     }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaFireDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaFireDefs.h
@@ -18,4 +18,22 @@ public:
 
     LUA_DECLARE(CreateFire);
     LUA_DECLARE(ExtinguishFire);
+    LUA_DECLARE(GetFireDuration);
+    LUA_DECLARE(SetFireDuration);
+    LUA_DECLARE(GetFireRemainingTime);
+    LUA_DECLARE(SetFireRemainingTime);
+    LUA_DECLARE(GetFireStrength);
+    LUA_DECLARE(SetFireStrength);
+    LUA_DECLARE(IsFireDamageEnabled);
+    LUA_DECLARE(SetFireDamageEnabled);
+    LUA_DECLARE(GetFireDamageTargets);
+    LUA_DECLARE(SetFireDamageTargets);
+    LUA_DECLARE(IsFireSpreadEnabled);
+    LUA_DECLARE(SetFireSpreadEnabled);
+    LUA_DECLARE(GetFireMaxGenerations);
+    LUA_DECLARE(SetFireMaxGenerations);
+    LUA_DECLARE(GetFireSource);
+    LUA_DECLARE(SetFireSource);
+    LUA_DECLARE(GetFireTarget);
+    LUA_DECLARE(SetFireTarget);
 };

--- a/Server/mods/deathmatch/logic/CDummy.cpp
+++ b/Server/mods/deathmatch/logic/CDummy.cpp
@@ -13,6 +13,7 @@
 #include "CDummy.h"
 #include "CGroups.h"
 #include "CGame.h"
+#include "luadefs/CLuaFireDefs.h"
 
 CDummy::CDummy(CGroups* pGroups, CElement* pParent) : CElement(pParent)
 {
@@ -30,6 +31,9 @@ CDummy::CDummy(CGroups* pGroups, CElement* pParent) : CElement(pParent)
 
 CDummy::~CDummy()
 {
+    if (GetTypeName() == "fire")
+        CLuaFireDefs::OnFireDestroyed(this);
+
     // Unlink from manager
     Unlink();
 }

--- a/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -18,6 +18,7 @@
 #include "luadefs/CLuaHTTPDefs.h"
 #include "luadefs/CLuaUtilDefs.h"
 #include "luadefs/CLuaElementDefs.h"
+#include "luadefs/CLuaFireDefs.h"
 #include "luadefs/CLuaAccountDefs.h"
 #include "luadefs/CLuaACLDefs.h"
 #include "luadefs/CLuaBanDefs.h"
@@ -134,6 +135,7 @@ void CLuaManager::DoPulse()
         (*iter)->DoPulse();
     }
     m_pLuaModuleManager->DoPulse();
+    CLuaFireDefs::DoPulse();
 }
 
 CLuaMain* CLuaManager::GetVirtualMachine(lua_State* luaVM)
@@ -220,6 +222,7 @@ void CLuaManager::LoadCFunctions()
     CLuaColShapeDefs::LoadFunctions();
     CLuaDatabaseDefs::LoadFunctions();
     CLuaElementDefs::LoadFunctions();
+    CLuaFireDefs::LoadFunctions();
     CLuaHandlingDefs::LoadFunctions();
     CLuaMarkerDefs::LoadFunctions();
     CLuaModelDefs::LoadFunctions();

--- a/Server/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
@@ -94,27 +94,27 @@ void SetNumber(CElement* pFire, const char* key, double value)
 {
     CLuaArgument argument;
     argument.ReadNumber(value);
-    pFire->SetCustomData(key, argument, ESyncType::BROADCAST, nullptr, false);
+    CStaticFunctionDefinitions::SetElementData(pFire, key, argument, ESyncType::BROADCAST, std::nullopt);
 }
 
 void SetBool(CElement* pFire, const char* key, bool value)
 {
     CLuaArgument argument;
     argument.ReadBool(value);
-    pFire->SetCustomData(key, argument, ESyncType::BROADCAST, nullptr, false);
+    CStaticFunctionDefinitions::SetElementData(pFire, key, argument, ESyncType::BROADCAST, std::nullopt);
 }
 
 void SetElement(CElement* pFire, const char* key, CElement* value)
 {
     if (!value)
     {
-        pFire->DeleteCustomData(key);
+        CStaticFunctionDefinitions::RemoveElementData(pFire, key);
         return;
     }
 
     CLuaArgument argument;
     argument.ReadElement(value);
-    pFire->SetCustomData(key, argument, ESyncType::BROADCAST, nullptr, false);
+    CStaticFunctionDefinitions::SetElementData(pFire, key, argument, ESyncType::BROADCAST, std::nullopt);
 }
 
 bool GetNumber(CElement* pFire, const char* key, double& value)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
@@ -28,7 +28,8 @@ constexpr unsigned char DAMAGE_OBJECTS = 1 << 3;
 constexpr unsigned char DAMAGE_ALL = DAMAGE_PLAYERS | DAMAGE_PEDS | DAMAGE_VEHICLES | DAMAGE_OBJECTS;
 
 constexpr const char* KEY_DURATION = "__neon_fire_duration";
-constexpr const char* KEY_EXPIRY = "__neon_fire_expiry";
+constexpr const char* KEY_REMAINING = "__neon_fire_remaining";
+constexpr const char* KEY_EXPIRY = "__neon_fire_expiry";  // Server-local only; never sent to clients.
 constexpr const char* KEY_STRENGTH = "__neon_fire_strength";
 constexpr const char* KEY_DAMAGE = "__neon_fire_damage";
 constexpr const char* KEY_DAMAGE_MASK = "__neon_fire_damage_mask";
@@ -58,11 +59,16 @@ bool IsFire(CElement* pElement)
     return pElement && pElement->GetType() == CElement::DUMMY && pElement->GetTypeName() == "fire";
 }
 
-void SetInitialNumber(CElement* pFire, const char* key, double value)
+void StoreNumber(CElement* pFire, const char* key, double value, ESyncType syncType)
 {
     CLuaArgument argument;
     argument.ReadNumber(value);
-    pFire->GetCustomDataManager().Set(key, argument, ESyncType::BROADCAST);
+    pFire->GetCustomDataManager().Set(key, argument, syncType);
+}
+
+void SetInitialNumber(CElement* pFire, const char* key, double value)
+{
+    StoreNumber(pFire, key, value, ESyncType::BROADCAST);
 }
 
 void SetInitialBool(CElement* pFire, const char* key, bool value)
@@ -206,10 +212,12 @@ CDummy* CreateFireElement(CResource* pResource, const CVector& position, double 
     fire->SetDimension(dimension);
     fire->SetInterior(interior);
 
-    // Seed synchronized state before CEntityAddPacket is sent so a joining client can
-    // construct the fire in one pass without seeing a transient default configuration.
+    // Seed all synchronized values before EntityAdd. The absolute expiry remains local
+    // to the server; clients only receive a relative remaining duration so their wall
+    // clocks never need to agree with the server clock.
     SetInitialNumber(fire, KEY_DURATION, duration);
-    SetInitialNumber(fire, KEY_EXPIRY, duration > 0.0 ? NowMs() + duration : 0.0);
+    SetInitialNumber(fire, KEY_REMAINING, duration);
+    StoreNumber(fire, KEY_EXPIRY, duration > 0.0 ? NowMs() + duration : 0.0, ESyncType::LOCAL);
     SetInitialNumber(fire, KEY_STRENGTH, strength);
     SetInitialBool(fire, KEY_DAMAGE, damage);
     SetInitialNumber(fire, KEY_DAMAGE_MASK, mask);
@@ -299,12 +307,22 @@ void CLuaFireDefs::DoPulse()
         if (!fire || fire->IsBeingDeleted())
             continue;
 
+        double duration = 0.0;
         double expiry = 0.0;
+        GetNumber(fire, KEY_DURATION, duration);
         GetNumber(fire, KEY_EXPIRY, expiry);
-        if (expiry > 0.0 && now >= expiry)
+        if (duration > 0.0)
         {
-            expired.push_back(fire);
-            continue;
+            const double remaining = expiry > 0.0 ? std::max(0.0, expiry - now) : 0.0;
+            // This updates the authoritative stored value without emitting a packet every
+            // pulse. Existing clients count down locally; a late join gets this fresh value
+            // in its EntityAdd custom-data snapshot.
+            StoreNumber(fire, KEY_REMAINING, remaining, ESyncType::BROADCAST);
+            if (remaining <= 0.0)
+            {
+                expired.push_back(fire);
+                continue;
+            }
         }
 
         bool spread = false;
@@ -478,7 +496,8 @@ int CLuaFireDefs::SetFireDuration(lua_State* luaVM)
     if (!args.HasErrors() && IsFire(fire) && duration >= 0.0)
     {
         SetNumber(fire, KEY_DURATION, duration);
-        SetNumber(fire, KEY_EXPIRY, duration > 0.0 ? NowMs() + duration : 0.0);
+        SetNumber(fire, KEY_REMAINING, duration);
+        StoreNumber(fire, KEY_EXPIRY, duration > 0.0 ? NowMs() + duration : 0.0, ESyncType::LOCAL);
         lua_pushboolean(luaVM, true);
         return 1;
     }
@@ -489,10 +508,11 @@ int CLuaFireDefs::SetFireDuration(lua_State* luaVM)
 int CLuaFireDefs::GetFireRemainingTime(lua_State* luaVM)
 {
     CElement* fire = lua_toelement(luaVM, 1);
+    double duration = 0.0;
     double expiry = 0.0;
-    if (IsFire(fire) && GetNumber(fire, KEY_EXPIRY, expiry))
+    if (IsFire(fire) && GetNumber(fire, KEY_DURATION, duration) && GetNumber(fire, KEY_EXPIRY, expiry))
     {
-        lua_pushnumber(luaVM, expiry <= 0.0 ? 0.0 : std::max(0.0, expiry - NowMs()));
+        lua_pushnumber(luaVM, duration <= 0.0 ? 0.0 : std::max(0.0, expiry - NowMs()));
         return 1;
     }
     lua_pushboolean(luaVM, false);
@@ -508,7 +528,15 @@ int CLuaFireDefs::SetFireRemainingTime(lua_State* luaVM)
     args.ReadNumber(remaining);
     if (!args.HasErrors() && IsFire(fire) && remaining >= 0.0)
     {
-        SetNumber(fire, KEY_EXPIRY, remaining > 0.0 ? NowMs() + remaining : NowMs());
+        double duration = 0.0;
+        GetNumber(fire, KEY_DURATION, duration);
+        if (duration <= 0.0 && remaining > 0.0)
+        {
+            duration = remaining;
+            SetNumber(fire, KEY_DURATION, duration);
+        }
+        SetNumber(fire, KEY_REMAINING, remaining);
+        StoreNumber(fire, KEY_EXPIRY, remaining > 0.0 ? NowMs() + remaining : (duration > 0.0 ? NowMs() : 0.0), ESyncType::LOCAL);
         lua_pushboolean(luaVM, true);
         return 1;
     }

--- a/Server/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
@@ -1,0 +1,721 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  PURPOSE:     Managed fire Lua definitions
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+#include "CLuaFireDefs.h"
+#include "../CDummy.h"
+#include "../CElementGroup.h"
+#include "../CResource.h"
+#include "../packets/CEntityAddPacket.h"
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <unordered_map>
+#include <vector>
+
+namespace
+{
+constexpr unsigned char DAMAGE_PLAYERS = 1 << 0;
+constexpr unsigned char DAMAGE_PEDS = 1 << 1;
+constexpr unsigned char DAMAGE_VEHICLES = 1 << 2;
+constexpr unsigned char DAMAGE_OBJECTS = 1 << 3;
+constexpr unsigned char DAMAGE_ALL = DAMAGE_PLAYERS | DAMAGE_PEDS | DAMAGE_VEHICLES | DAMAGE_OBJECTS;
+
+constexpr const char* KEY_DURATION = "__neon_fire_duration";
+constexpr const char* KEY_EXPIRY = "__neon_fire_expiry";
+constexpr const char* KEY_STRENGTH = "__neon_fire_strength";
+constexpr const char* KEY_DAMAGE = "__neon_fire_damage";
+constexpr const char* KEY_DAMAGE_MASK = "__neon_fire_damage_mask";
+constexpr const char* KEY_SPREAD = "__neon_fire_spread";
+constexpr const char* KEY_MAX_GENERATIONS = "__neon_fire_max_generations";
+constexpr const char* KEY_GENERATION = "__neon_fire_generation";
+constexpr const char* KEY_SOURCE = "__neon_fire_source";
+constexpr const char* KEY_TARGET = "__neon_fire_target";
+
+struct SFireRecord
+{
+    CDummy*    pFire{};
+    CResource* pResource{};
+    double     dNextSpread{};
+    bool       bDidSpread{};
+};
+
+std::unordered_map<CDummy*, SFireRecord> g_Fires;
+
+double NowMs()
+{
+    return static_cast<double>(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+}
+
+bool IsFire(CElement* pElement)
+{
+    return pElement && pElement->GetType() == CElement::DUMMY && pElement->GetTypeName() == "fire";
+}
+
+void SetInitialNumber(CElement* pFire, const char* key, double value)
+{
+    CLuaArgument argument;
+    argument.ReadNumber(value);
+    pFire->GetCustomDataManager().Set(key, argument, ESyncType::BROADCAST);
+}
+
+void SetInitialBool(CElement* pFire, const char* key, bool value)
+{
+    CLuaArgument argument;
+    argument.ReadBool(value);
+    pFire->GetCustomDataManager().Set(key, argument, ESyncType::BROADCAST);
+}
+
+void SetInitialElement(CElement* pFire, const char* key, CElement* value)
+{
+    if (!value)
+        return;
+    CLuaArgument argument;
+    argument.ReadElement(value);
+    pFire->GetCustomDataManager().Set(key, argument, ESyncType::BROADCAST);
+}
+
+void SetNumber(CElement* pFire, const char* key, double value)
+{
+    CLuaArgument argument;
+    argument.ReadNumber(value);
+    pFire->SetCustomData(key, argument, ESyncType::BROADCAST, nullptr, false);
+}
+
+void SetBool(CElement* pFire, const char* key, bool value)
+{
+    CLuaArgument argument;
+    argument.ReadBool(value);
+    pFire->SetCustomData(key, argument, ESyncType::BROADCAST, nullptr, false);
+}
+
+void SetElement(CElement* pFire, const char* key, CElement* value)
+{
+    if (!value)
+    {
+        pFire->DeleteCustomData(key);
+        return;
+    }
+    CLuaArgument argument;
+    argument.ReadElement(value);
+    pFire->SetCustomData(key, argument, ESyncType::BROADCAST, nullptr, false);
+}
+
+bool GetNumber(CElement* pFire, const char* key, double& value)
+{
+    CLuaArgument* argument = pFire ? pFire->GetCustomData(key, false) : nullptr;
+    if (!argument || argument->GetType() != LUA_TNUMBER)
+        return false;
+    value = argument->GetNumber();
+    return true;
+}
+
+bool GetBool(CElement* pFire, const char* key, bool& value)
+{
+    CLuaArgument* argument = pFire ? pFire->GetCustomData(key, false) : nullptr;
+    if (!argument || argument->GetType() != LUA_TBOOLEAN)
+        return false;
+    value = argument->GetBoolean();
+    return true;
+}
+
+CElement* GetElement(CElement* pFire, const char* key)
+{
+    CLuaArgument* argument = pFire ? pFire->GetCustomData(key, false) : nullptr;
+    return argument ? argument->GetElement() : nullptr;
+}
+
+bool ReadTableBool(lua_State* luaVM, int tableIndex, const char* key, bool defaultValue)
+{
+    lua_getfield(luaVM, tableIndex, key);
+    const bool value = lua_isboolean(luaVM, -1) ? lua_toboolean(luaVM, -1) != 0 : defaultValue;
+    lua_pop(luaVM, 1);
+    return value;
+}
+
+double ReadTableNumber(lua_State* luaVM, int tableIndex, const char* key, double defaultValue)
+{
+    lua_getfield(luaVM, tableIndex, key);
+    const double value = lua_isnumber(luaVM, -1) ? lua_tonumber(luaVM, -1) : defaultValue;
+    lua_pop(luaVM, 1);
+    return value;
+}
+
+CElement* ReadTableElement(lua_State* luaVM, int tableIndex, const char* key)
+{
+    lua_getfield(luaVM, tableIndex, key);
+    CElement* value = lua_toelement(luaVM, -1);
+    lua_pop(luaVM, 1);
+    return value;
+}
+
+unsigned char ReadDamageMask(lua_State* luaVM, int optionsIndex)
+{
+    unsigned char mask = DAMAGE_ALL;
+    lua_getfield(luaVM, optionsIndex, "damageTargets");
+    if (lua_istable(luaVM, -1))
+    {
+        const int table = lua_gettop(luaVM);
+        mask = 0;
+        if (ReadTableBool(luaVM, table, "players", true))
+            mask |= DAMAGE_PLAYERS;
+        if (ReadTableBool(luaVM, table, "peds", true))
+            mask |= DAMAGE_PEDS;
+        if (ReadTableBool(luaVM, table, "vehicles", true))
+            mask |= DAMAGE_VEHICLES;
+        if (ReadTableBool(luaVM, table, "objects", true))
+            mask |= DAMAGE_OBJECTS;
+    }
+    lua_pop(luaVM, 1);
+    return mask;
+}
+
+void PushDamageMask(lua_State* luaVM, unsigned char mask)
+{
+    lua_createtable(luaVM, 0, 4);
+    lua_pushboolean(luaVM, (mask & DAMAGE_PLAYERS) != 0);
+    lua_setfield(luaVM, -2, "players");
+    lua_pushboolean(luaVM, (mask & DAMAGE_PEDS) != 0);
+    lua_setfield(luaVM, -2, "peds");
+    lua_pushboolean(luaVM, (mask & DAMAGE_VEHICLES) != 0);
+    lua_setfield(luaVM, -2, "vehicles");
+    lua_pushboolean(luaVM, (mask & DAMAGE_OBJECTS) != 0);
+    lua_setfield(luaVM, -2, "objects");
+}
+
+CDummy* CreateFireElement(CResource* pResource, const CVector& position, double duration, double strength, bool damage, unsigned char mask, bool spread,
+                          unsigned int maxGenerations, unsigned int generation, CElement* source, CElement* target)
+{
+    if (!pResource)
+        return nullptr;
+
+    CDummy* fire = new CDummy(g_pGame->GetGroups(), pResource->GetDynamicElementRoot());
+    fire->SetTypeName("fire");
+    fire->SetPosition(position);
+
+    SetInitialNumber(fire, KEY_DURATION, duration);
+    SetInitialNumber(fire, KEY_EXPIRY, duration > 0.0 ? NowMs() + duration : 0.0);
+    SetInitialNumber(fire, KEY_STRENGTH, strength);
+    SetInitialBool(fire, KEY_DAMAGE, damage);
+    SetInitialNumber(fire, KEY_DAMAGE_MASK, mask);
+    SetInitialBool(fire, KEY_SPREAD, spread);
+    SetInitialNumber(fire, KEY_MAX_GENERATIONS, maxGenerations);
+    SetInitialNumber(fire, KEY_GENERATION, generation);
+    SetInitialElement(fire, KEY_SOURCE, source);
+    SetInitialElement(fire, KEY_TARGET, target);
+
+    if (CElementGroup* group = pResource->GetElementGroup())
+        group->Add(fire);
+
+    g_Fires.emplace(fire, SFireRecord{fire, pResource, NowMs() + 1500.0, false});
+
+    if (pResource->IsClientSynced())
+    {
+        CEntityAddPacket packet;
+        packet.Add(fire);
+        g_pGame->GetPlayerManager()->BroadcastOnlyJoined(packet);
+    }
+
+    return fire;
+}
+
+bool DestroyManagedFire(CDummy* fire)
+{
+    if (!fire || !IsFire(fire))
+        return false;
+    g_Fires.erase(fire);
+    return CStaticFunctionDefinitions::DestroyElement(fire);
+}
+
+void UpdateSpreadReset(CElement* fire)
+{
+    auto iter = g_Fires.find(static_cast<CDummy*>(fire));
+    if (iter != g_Fires.end())
+    {
+        iter->second.bDidSpread = false;
+        iter->second.dNextSpread = NowMs() + 1500.0;
+    }
+}
+}  // namespace
+
+void CLuaFireDefs::LoadFunctions()
+{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
+        {"createFire", CreateFire},
+        {"extinguishFire", ExtinguishFire},
+        {"getFireDuration", GetFireDuration},
+        {"setFireDuration", SetFireDuration},
+        {"getFireRemainingTime", GetFireRemainingTime},
+        {"setFireRemainingTime", SetFireRemainingTime},
+        {"getFireStrength", GetFireStrength},
+        {"setFireStrength", SetFireStrength},
+        {"isFireDamageEnabled", IsFireDamageEnabled},
+        {"setFireDamageEnabled", SetFireDamageEnabled},
+        {"getFireDamageTargets", GetFireDamageTargets},
+        {"setFireDamageTargets", SetFireDamageTargets},
+        {"isFireSpreadEnabled", IsFireSpreadEnabled},
+        {"setFireSpreadEnabled", SetFireSpreadEnabled},
+        {"getFireMaxGenerations", GetFireMaxGenerations},
+        {"setFireMaxGenerations", SetFireMaxGenerations},
+        {"getFireSource", GetFireSource},
+        {"setFireSource", SetFireSource},
+        {"getFireTarget", GetFireTarget},
+        {"setFireTarget", SetFireTarget},
+    };
+
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
+}
+
+void CLuaFireDefs::OnFireDestroyed(CDummy* pFire)
+{
+    g_Fires.erase(pFire);
+}
+
+void CLuaFireDefs::DoPulse()
+{
+    const double now = NowMs();
+    std::vector<CDummy*> expired;
+    std::vector<SFireRecord> spreadCandidates;
+
+    for (auto& [fire, record] : g_Fires)
+    {
+        if (!fire || fire->IsBeingDeleted())
+            continue;
+
+        double expiry = 0.0;
+        GetNumber(fire, KEY_EXPIRY, expiry);
+        if (expiry > 0.0 && now >= expiry)
+        {
+            expired.push_back(fire);
+            continue;
+        }
+
+        bool spread = false;
+        double generation = 0.0;
+        double maxGenerations = 0.0;
+        GetBool(fire, KEY_SPREAD, spread);
+        GetNumber(fire, KEY_GENERATION, generation);
+        GetNumber(fire, KEY_MAX_GENERATIONS, maxGenerations);
+        if (spread && !record.bDidSpread && generation < maxGenerations && now >= record.dNextSpread)
+        {
+            record.bDidSpread = true;
+            spreadCandidates.push_back(record);
+        }
+    }
+
+    for (CDummy* fire : expired)
+        DestroyManagedFire(fire);
+
+    for (const SFireRecord& record : spreadCandidates)
+    {
+        CDummy* parent = record.pFire;
+        if (!parent || parent->IsBeingDeleted() || !record.pResource)
+            continue;
+
+        double generation = 0.0;
+        double maxGenerations = 0.0;
+        double strength = 1.0;
+        double mask = DAMAGE_ALL;
+        bool damage = true;
+        bool spread = true;
+        GetNumber(parent, KEY_GENERATION, generation);
+        GetNumber(parent, KEY_MAX_GENERATIONS, maxGenerations);
+        GetNumber(parent, KEY_STRENGTH, strength);
+        GetNumber(parent, KEY_DAMAGE_MASK, mask);
+        GetBool(parent, KEY_DAMAGE, damage);
+        GetBool(parent, KEY_SPREAD, spread);
+
+        const double angle = (static_cast<double>(std::rand() % 6284) / 1000.0);
+        const double distance = 2.0 + static_cast<double>(std::rand() % 1000) / 1000.0;
+        CVector position;
+        parent->GetPosition(position);
+        position.fX += static_cast<float>(std::cos(angle) * distance);
+        position.fY += static_cast<float>(std::sin(angle) * distance);
+
+        CDummy* child = CreateFireElement(record.pResource, position, 20000.0, std::max(0.8, strength * 0.8), damage,
+                                          static_cast<unsigned char>(static_cast<unsigned int>(mask)) & DAMAGE_ALL, spread,
+                                          static_cast<unsigned int>(maxGenerations), static_cast<unsigned int>(generation) + 1, GetElement(parent, KEY_SOURCE), nullptr);
+        if (child)
+        {
+            child->SetDimension(parent->GetDimension());
+            child->SetInterior(parent->GetInterior());
+        }
+    }
+}
+
+int CLuaFireDefs::CreateFire(lua_State* luaVM)
+{
+    CVector position;
+    CScriptArgReader args(luaVM);
+    args.ReadVector3D(position);
+    if (args.HasErrors())
+    {
+        m_pScriptDebugging->LogCustom(luaVM, args.GetFullErrorMessage());
+        lua_pushboolean(luaVM, false);
+        return 1;
+    }
+
+    double duration = 5000.0;
+    double strength = 1.0;
+    bool damage = true;
+    bool spread = false;
+    unsigned int maxGenerations = 0;
+    unsigned char damageMask = DAMAGE_ALL;
+    CElement* source = nullptr;
+    CElement* target = nullptr;
+
+    if (lua_istable(luaVM, 4))
+    {
+        duration = std::max(0.0, ReadTableNumber(luaVM, 4, "duration", duration));
+        strength = std::max(0.1, ReadTableNumber(luaVM, 4, "strength", strength));
+        damage = ReadTableBool(luaVM, 4, "damage", damage);
+        spread = ReadTableBool(luaVM, 4, "spread", spread);
+        maxGenerations = static_cast<unsigned int>(std::clamp(ReadTableNumber(luaVM, 4, "maxGenerations", 0.0), 0.0, 255.0));
+        damageMask = ReadDamageMask(luaVM, 4);
+        source = ReadTableElement(luaVM, 4, "source");
+        target = ReadTableElement(luaVM, 4, "target");
+    }
+    else if (!lua_isnoneornil(luaVM, 4))
+    {
+        if (!lua_isnumber(luaVM, 4))
+        {
+            lua_pushboolean(luaVM, false);
+            return 1;
+        }
+        strength = std::max(0.1, static_cast<double>(lua_tonumber(luaVM, 4)));
+    }
+
+    CLuaMain* luaMain = m_pLuaManager->GetVirtualMachine(luaVM);
+    CResource* resource = luaMain ? luaMain->GetResource() : nullptr;
+    CDummy* fire = CreateFireElement(resource, position, duration, strength, damage, damageMask, spread, maxGenerations, 0, source, target);
+    if (fire)
+        lua_pushelement(luaVM, fire);
+    else
+        lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::ExtinguishFire(lua_State* luaVM)
+{
+    if (lua_type(luaVM, 1) == LUA_TLIGHTUSERDATA)
+    {
+        CElement* element = lua_toelement(luaVM, 1);
+        lua_pushboolean(luaVM, IsFire(element) && DestroyManagedFire(static_cast<CDummy*>(element)));
+        return 1;
+    }
+
+    if (lua_gettop(luaVM) == 0)
+    {
+        std::vector<CDummy*> fires;
+        fires.reserve(g_Fires.size());
+        for (const auto& [fire, record] : g_Fires)
+            fires.push_back(fire);
+        for (CDummy* fire : fires)
+            DestroyManagedFire(fire);
+        lua_pushboolean(luaVM, true);
+        return 1;
+    }
+
+    CVector position;
+    float radius = 1.0f;
+    CScriptArgReader args(luaVM);
+    args.ReadVector3D(position);
+    args.ReadNumber(radius, 1.0f);
+    if (args.HasErrors())
+    {
+        lua_pushboolean(luaVM, false);
+        return 1;
+    }
+
+    const float radiusSq = radius * radius;
+    std::vector<CDummy*> fires;
+    for (const auto& [fire, record] : g_Fires)
+    {
+        CVector firePosition;
+        fire->GetPosition(firePosition);
+        const CVector delta = firePosition - position;
+        if (delta.DotProduct(&delta) <= radiusSq)
+            fires.push_back(fire);
+    }
+    for (CDummy* fire : fires)
+        DestroyManagedFire(fire);
+    lua_pushboolean(luaVM, true);
+    return 1;
+}
+
+int CLuaFireDefs::GetFireDuration(lua_State* luaVM)
+{
+    CElement* fire = lua_toelement(luaVM, 1);
+    double value = 0.0;
+    if (IsFire(fire) && GetNumber(fire, KEY_DURATION, value))
+        lua_pushnumber(luaVM, value);
+    else
+        lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::SetFireDuration(lua_State* luaVM)
+{
+    CElement* fire = nullptr;
+    double duration = 0.0;
+    CScriptArgReader args(luaVM);
+    args.ReadUserData(fire);
+    args.ReadNumber(duration);
+    if (!args.HasErrors() && IsFire(fire) && duration >= 0.0)
+    {
+        SetNumber(fire, KEY_DURATION, duration);
+        SetNumber(fire, KEY_EXPIRY, duration > 0.0 ? NowMs() + duration : 0.0);
+        lua_pushboolean(luaVM, true);
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::GetFireRemainingTime(lua_State* luaVM)
+{
+    CElement* fire = lua_toelement(luaVM, 1);
+    double expiry = 0.0;
+    if (IsFire(fire) && GetNumber(fire, KEY_EXPIRY, expiry))
+    {
+        lua_pushnumber(luaVM, expiry <= 0.0 ? 0.0 : std::max(0.0, expiry - NowMs()));
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::SetFireRemainingTime(lua_State* luaVM)
+{
+    CElement* fire = nullptr;
+    double remaining = 0.0;
+    CScriptArgReader args(luaVM);
+    args.ReadUserData(fire);
+    args.ReadNumber(remaining);
+    if (!args.HasErrors() && IsFire(fire) && remaining >= 0.0)
+    {
+        SetNumber(fire, KEY_EXPIRY, remaining > 0.0 ? NowMs() + remaining : NowMs());
+        lua_pushboolean(luaVM, true);
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::GetFireStrength(lua_State* luaVM)
+{
+    CElement* fire = lua_toelement(luaVM, 1);
+    double value = 0.0;
+    if (IsFire(fire) && GetNumber(fire, KEY_STRENGTH, value))
+        lua_pushnumber(luaVM, value);
+    else
+        lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::SetFireStrength(lua_State* luaVM)
+{
+    CElement* fire = nullptr;
+    double strength = 0.0;
+    CScriptArgReader args(luaVM);
+    args.ReadUserData(fire);
+    args.ReadNumber(strength);
+    if (!args.HasErrors() && IsFire(fire) && strength > 0.0)
+    {
+        SetNumber(fire, KEY_STRENGTH, strength);
+        lua_pushboolean(luaVM, true);
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::IsFireDamageEnabled(lua_State* luaVM)
+{
+    CElement* fire = lua_toelement(luaVM, 1);
+    bool value = false;
+    if (IsFire(fire) && GetBool(fire, KEY_DAMAGE, value))
+        lua_pushboolean(luaVM, value);
+    else
+        lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::SetFireDamageEnabled(lua_State* luaVM)
+{
+    CElement* fire = nullptr;
+    bool enabled = false;
+    CScriptArgReader args(luaVM);
+    args.ReadUserData(fire);
+    args.ReadBool(enabled);
+    if (!args.HasErrors() && IsFire(fire))
+    {
+        SetBool(fire, KEY_DAMAGE, enabled);
+        lua_pushboolean(luaVM, true);
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::GetFireDamageTargets(lua_State* luaVM)
+{
+    CElement* fire = lua_toelement(luaVM, 1);
+    double value = DAMAGE_ALL;
+    if (IsFire(fire))
+    {
+        GetNumber(fire, KEY_DAMAGE_MASK, value);
+        PushDamageMask(luaVM, static_cast<unsigned char>(static_cast<unsigned int>(value)) & DAMAGE_ALL);
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::SetFireDamageTargets(lua_State* luaVM)
+{
+    CElement* fire = lua_toelement(luaVM, 1);
+    if (!IsFire(fire) || !lua_istable(luaVM, 2))
+    {
+        lua_pushboolean(luaVM, false);
+        return 1;
+    }
+
+    unsigned char mask = 0;
+    if (ReadTableBool(luaVM, 2, "players", true))
+        mask |= DAMAGE_PLAYERS;
+    if (ReadTableBool(luaVM, 2, "peds", true))
+        mask |= DAMAGE_PEDS;
+    if (ReadTableBool(luaVM, 2, "vehicles", true))
+        mask |= DAMAGE_VEHICLES;
+    if (ReadTableBool(luaVM, 2, "objects", true))
+        mask |= DAMAGE_OBJECTS;
+    SetNumber(fire, KEY_DAMAGE_MASK, mask);
+    lua_pushboolean(luaVM, true);
+    return 1;
+}
+
+int CLuaFireDefs::IsFireSpreadEnabled(lua_State* luaVM)
+{
+    CElement* fire = lua_toelement(luaVM, 1);
+    bool value = false;
+    if (IsFire(fire) && GetBool(fire, KEY_SPREAD, value))
+        lua_pushboolean(luaVM, value);
+    else
+        lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::SetFireSpreadEnabled(lua_State* luaVM)
+{
+    CElement* fire = nullptr;
+    bool enabled = false;
+    CScriptArgReader args(luaVM);
+    args.ReadUserData(fire);
+    args.ReadBool(enabled);
+    if (!args.HasErrors() && IsFire(fire))
+    {
+        SetBool(fire, KEY_SPREAD, enabled);
+        UpdateSpreadReset(fire);
+        lua_pushboolean(luaVM, true);
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::GetFireMaxGenerations(lua_State* luaVM)
+{
+    CElement* fire = lua_toelement(luaVM, 1);
+    double value = 0.0;
+    if (IsFire(fire) && GetNumber(fire, KEY_MAX_GENERATIONS, value))
+        lua_pushnumber(luaVM, value);
+    else
+        lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::SetFireMaxGenerations(lua_State* luaVM)
+{
+    CElement* fire = nullptr;
+    unsigned int generations = 0;
+    CScriptArgReader args(luaVM);
+    args.ReadUserData(fire);
+    args.ReadNumber(generations);
+    if (!args.HasErrors() && IsFire(fire) && generations <= 255)
+    {
+        SetNumber(fire, KEY_MAX_GENERATIONS, generations);
+        UpdateSpreadReset(fire);
+        lua_pushboolean(luaVM, true);
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::GetFireSource(lua_State* luaVM)
+{
+    CElement* fire = lua_toelement(luaVM, 1);
+    if (IsFire(fire))
+    {
+        CElement* value = GetElement(fire, KEY_SOURCE);
+        if (value)
+            lua_pushelement(luaVM, value);
+        else
+            lua_pushboolean(luaVM, false);
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::SetFireSource(lua_State* luaVM)
+{
+    CElement* fire = lua_toelement(luaVM, 1);
+    CElement* value = lua_isnoneornil(luaVM, 2) ? nullptr : lua_toelement(luaVM, 2);
+    if (IsFire(fire) && (lua_isnoneornil(luaVM, 2) || value))
+    {
+        SetElement(fire, KEY_SOURCE, value);
+        lua_pushboolean(luaVM, true);
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::GetFireTarget(lua_State* luaVM)
+{
+    CElement* fire = lua_toelement(luaVM, 1);
+    if (IsFire(fire))
+    {
+        CElement* value = GetElement(fire, KEY_TARGET);
+        if (value)
+            lua_pushelement(luaVM, value);
+        else
+            lua_pushboolean(luaVM, false);
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFireDefs::SetFireTarget(lua_State* luaVM)
+{
+    CElement* fire = lua_toelement(luaVM, 1);
+    CElement* value = lua_isnoneornil(luaVM, 2) ? nullptr : lua_toelement(luaVM, 2);
+    if (IsFire(fire) && (lua_isnoneornil(luaVM, 2) || value))
+    {
+        SetElement(fire, KEY_TARGET, value);
+        lua_pushboolean(luaVM, true);
+        return 1;
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}

--- a/Server/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
@@ -12,6 +12,8 @@
 #include "../CElementGroup.h"
 #include "../CResource.h"
 #include "../packets/CEntityAddPacket.h"
+#include "../CStaticFunctionDefinitions.h"
+#include <CScriptArgReader.h>
 #include <algorithm>
 #include <chrono>
 #include <cmath>

--- a/Server/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
@@ -76,6 +76,7 @@ void SetInitialElement(CElement* pFire, const char* key, CElement* value)
 {
     if (!value)
         return;
+
     CLuaArgument argument;
     argument.ReadElement(value);
     pFire->GetCustomDataManager().Set(key, argument, ESyncType::BROADCAST);
@@ -102,6 +103,7 @@ void SetElement(CElement* pFire, const char* key, CElement* value)
         pFire->DeleteCustomData(key);
         return;
     }
+
     CLuaArgument argument;
     argument.ReadElement(value);
     pFire->SetCustomData(key, argument, ESyncType::BROADCAST, nullptr, false);
@@ -112,6 +114,7 @@ bool GetNumber(CElement* pFire, const char* key, double& value)
     CLuaArgument* argument = pFire ? pFire->GetCustomData(key, false) : nullptr;
     if (!argument || argument->GetType() != LUA_TNUMBER)
         return false;
+
     value = argument->GetNumber();
     return true;
 }
@@ -121,6 +124,7 @@ bool GetBool(CElement* pFire, const char* key, bool& value)
     CLuaArgument* argument = pFire ? pFire->GetCustomData(key, false) : nullptr;
     if (!argument || argument->GetType() != LUA_TBOOLEAN)
         return false;
+
     value = argument->GetBoolean();
     return true;
 }
@@ -190,7 +194,8 @@ void PushDamageMask(lua_State* luaVM, unsigned char mask)
 }
 
 CDummy* CreateFireElement(CResource* pResource, const CVector& position, double duration, double strength, bool damage, unsigned char mask, bool spread,
-                          unsigned int maxGenerations, unsigned int generation, CElement* source, CElement* target)
+                          unsigned int maxGenerations, unsigned int generation, CElement* source, CElement* target, unsigned short dimension = 0,
+                          unsigned char interior = 0)
 {
     if (!pResource)
         return nullptr;
@@ -198,7 +203,11 @@ CDummy* CreateFireElement(CResource* pResource, const CVector& position, double 
     CDummy* fire = new CDummy(g_pGame->GetGroups(), pResource->GetDynamicElementRoot());
     fire->SetTypeName("fire");
     fire->SetPosition(position);
+    fire->SetDimension(dimension);
+    fire->SetInterior(interior);
 
+    // Seed synchronized state before CEntityAddPacket is sent so a joining client can
+    // construct the fire in one pass without seeing a transient default configuration.
     SetInitialNumber(fire, KEY_DURATION, duration);
     SetInitialNumber(fire, KEY_EXPIRY, duration > 0.0 ? NowMs() + duration : 0.0);
     SetInitialNumber(fire, KEY_STRENGTH, strength);
@@ -229,6 +238,7 @@ bool DestroyManagedFire(CDummy* fire)
 {
     if (!fire || !IsFire(fire))
         return false;
+
     g_Fires.erase(fire);
     return CStaticFunctionDefinitions::DestroyElement(fire);
 }
@@ -332,21 +342,16 @@ void CLuaFireDefs::DoPulse()
         GetBool(parent, KEY_DAMAGE, damage);
         GetBool(parent, KEY_SPREAD, spread);
 
-        const double angle = (static_cast<double>(std::rand() % 6284) / 1000.0);
+        const double angle = static_cast<double>(std::rand() % 6284) / 1000.0;
         const double distance = 2.0 + static_cast<double>(std::rand() % 1000) / 1000.0;
-        CVector position;
-        parent->GetPosition(position);
+        CVector position = parent->GetPosition();
         position.fX += static_cast<float>(std::cos(angle) * distance);
         position.fY += static_cast<float>(std::sin(angle) * distance);
 
-        CDummy* child = CreateFireElement(record.pResource, position, 20000.0, std::max(0.8, strength * 0.8), damage,
-                                          static_cast<unsigned char>(static_cast<unsigned int>(mask)) & DAMAGE_ALL, spread,
-                                          static_cast<unsigned int>(maxGenerations), static_cast<unsigned int>(generation) + 1, GetElement(parent, KEY_SOURCE), nullptr);
-        if (child)
-        {
-            child->SetDimension(parent->GetDimension());
-            child->SetInterior(parent->GetInterior());
-        }
+        CreateFireElement(record.pResource, position, 20000.0, std::max(0.8, strength * 0.8), damage,
+                          static_cast<unsigned char>(static_cast<unsigned int>(mask)) & DAMAGE_ALL, spread,
+                          static_cast<unsigned int>(maxGenerations), static_cast<unsigned int>(generation) + 1, GetElement(parent, KEY_SOURCE), nullptr,
+                          parent->GetDimension(), parent->GetInterior());
     }
 }
 
@@ -404,10 +409,10 @@ int CLuaFireDefs::CreateFire(lua_State* luaVM)
 
 int CLuaFireDefs::ExtinguishFire(lua_State* luaVM)
 {
-    if (lua_type(luaVM, 1) == LUA_TLIGHTUSERDATA)
+    CElement* firstElement = lua_toelement(luaVM, 1);
+    if (IsFire(firstElement))
     {
-        CElement* element = lua_toelement(luaVM, 1);
-        lua_pushboolean(luaVM, IsFire(element) && DestroyManagedFire(static_cast<CDummy*>(element)));
+        lua_pushboolean(luaVM, DestroyManagedFire(static_cast<CDummy*>(firstElement)));
         return 1;
     }
 
@@ -430,6 +435,7 @@ int CLuaFireDefs::ExtinguishFire(lua_State* luaVM)
     args.ReadNumber(radius, 1.0f);
     if (args.HasErrors())
     {
+        m_pScriptDebugging->LogCustom(luaVM, args.GetFullErrorMessage());
         lua_pushboolean(luaVM, false);
         return 1;
     }
@@ -438,10 +444,11 @@ int CLuaFireDefs::ExtinguishFire(lua_State* luaVM)
     std::vector<CDummy*> fires;
     for (const auto& [fire, record] : g_Fires)
     {
-        CVector firePosition;
-        fire->GetPosition(firePosition);
-        const CVector delta = firePosition - position;
-        if (delta.DotProduct(&delta) <= radiusSq)
+        const CVector& firePosition = fire->GetPosition();
+        const float dx = firePosition.fX - position.fX;
+        const float dy = firePosition.fY - position.fY;
+        const float dz = firePosition.fZ - position.fZ;
+        if (dx * dx + dy * dy + dz * dz <= radiusSq)
             fires.push_back(fire);
     }
     for (CDummy* fire : fires)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaFireDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaFireDefs.h
@@ -1,0 +1,41 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  PURPOSE:     Managed fire Lua definitions
+ *
+ *****************************************************************************/
+#pragma once
+
+#include "CLuaDefs.h"
+
+class CDummy;
+
+class CLuaFireDefs : public CLuaDefs
+{
+public:
+    static void LoadFunctions();
+    static void DoPulse();
+    static void OnFireDestroyed(CDummy* pFire);
+
+    LUA_DECLARE(CreateFire);
+    LUA_DECLARE(ExtinguishFire);
+    LUA_DECLARE(GetFireDuration);
+    LUA_DECLARE(SetFireDuration);
+    LUA_DECLARE(GetFireRemainingTime);
+    LUA_DECLARE(SetFireRemainingTime);
+    LUA_DECLARE(GetFireStrength);
+    LUA_DECLARE(SetFireStrength);
+    LUA_DECLARE(IsFireDamageEnabled);
+    LUA_DECLARE(SetFireDamageEnabled);
+    LUA_DECLARE(GetFireDamageTargets);
+    LUA_DECLARE(SetFireDamageTargets);
+    LUA_DECLARE(IsFireSpreadEnabled);
+    LUA_DECLARE(SetFireSpreadEnabled);
+    LUA_DECLARE(GetFireMaxGenerations);
+    LUA_DECLARE(SetFireMaxGenerations);
+    LUA_DECLARE(GetFireSource);
+    LUA_DECLARE(SetFireSource);
+    LUA_DECLARE(GetFireTarget);
+    LUA_DECLARE(SetFireTarget);
+};

--- a/test-resources/fire-showcase/README.md
+++ b/test-resources/fire-showcase/README.md
@@ -1,0 +1,29 @@
+# Managed fire showcase
+
+A short cinematic demo resource for the managed fire element API.
+
+## Run
+
+```text
+start fire-showcase
+/fireshow
+```
+
+Use `/fireshow stop` to abort and clean everything immediately.
+
+The sequence is automatic and lasts about 27 seconds:
+
+1. 68 managed fires form a vertical **NEON** sign, exceeding GTA's native 60-fire pool.
+2. A synchronized strength wave travels across the sign.
+3. One existing fire is highlighted, physically leaves the `O`, and moves toward an Infernus.
+4. The exact same fire switches to `setFireTarget(vehicle)` and follows the moving car.
+5. The camera pulls back for the final managed-fire capability card.
+
+The resource temporarily stages the player in an isolated dimension at Verdant Meadows, hides/freezes the player during the cinematic, then restores position, rotation, dimension, interior, alpha and frozen state on completion or `/fireshow stop`.
+
+## Recording notes
+
+- Record at 16:9 if possible; captions are positioned for a standard widescreen frame.
+- The resource deliberately uses no custom assets, shaders or textures: the visual is entirely managed fires + the normal GTA vehicle.
+- For Discord, a 27-second capture works as-is. Trim the first/last second if you want a tighter clip.
+- The important visual claim is not simply that MTA can create fire. The demo shows that a created fire has persistent identity and can be individually mutated and targeted without extinguishing/recreating it.

--- a/test-resources/fire-showcase/client.lua
+++ b/test-resources/fire-showcase/client.lua
@@ -78,22 +78,22 @@ local function renderShow()
     local elapsed = getTickCount() - show.startedAt
     local cx, cy, cz = show.centerX, show.centerY, show.centerZ
 
-    -- Give the managed fire FX plenty of time to stream in and settle. The camera
-    -- eases into the logo for the first few seconds, then stays almost completely
-    -- still so the full NEON word remains readable on video.
+    -- Stay close enough for every fire FX to be clearly rendered from the first
+    -- recorded frame. Use a wider FOV instead of moving the camera far away just
+    -- to fit the whole word in shot.
     if elapsed < 14000 then
-        local reveal = smoothstep(elapsed / 3000)
+        local t = smoothstep(elapsed / 14000)
         cameraLerp(
-            cx + 23, cy - 42, cz + 13,
+            cx, cy - 22.0, cz + 3.2,
             cx, cy, cz,
-            cx, cy - 34, cz + 5,
+            cx, cy - 19.5, cz + 2.2,
             cx, cy, cz,
-            reveal,
-            76, 62
+            t,
+            90, 84
         )
 
-    -- Move in on the selected fire only after the complete logo has been visible
-    -- for a long uninterrupted shot.
+    -- After the long clean logo shot, move much closer to the selected fire as it
+    -- leaves the O.
     elseif elapsed < 19000 then
         local t = (elapsed - 14000) / 5000
         local lookX, lookY, lookZ = cx + 5, cy, cz
@@ -105,12 +105,12 @@ local function renderShow()
         end
 
         cameraLerp(
-            cx, cy - 34, cz + 5,
+            cx, cy - 19.5, cz + 2.2,
             cx, cy, cz,
-            cx + 8, cy - 21, cz + 2,
+            cx + 6, cy - 13.5, cz + 1.5,
             lookX, lookY, lookZ,
             t,
-            62, 55
+            84, 68
         )
 
     -- Follow the car while the very same fire element is targeting it.
@@ -119,10 +119,10 @@ local function renderShow()
         if camX then
             setCameraMatrix(camX, camY, camZ, lookX, lookY, lookZ, 0, 62)
         else
-            setCameraMatrix(cx + 8, cy - 21, cz + 2, cx, cy, cz, 0, 60)
+            setCameraMatrix(cx + 6, cy - 13.5, cz + 1.5, cx, cy, cz, 0, 68)
         end
 
-    -- Finish on a clean wide gameplay shot with both the logo and car area visible.
+    -- Finish close enough that the remaining logo fires are still clearly visible.
     else
         local vehicleX, vehicleY, vehicleZ = cx + 16, cy - 13, 16.6
         if isElement(show.vehicle) then
@@ -135,7 +135,7 @@ local function renderShow()
         local targetX = (cx + vehicleX) * 0.5
         local targetY = (cy + vehicleY) * 0.5
         local targetZ = math.max(cz, vehicleZ + 2)
-        setCameraMatrix(cx + 27, cy - 43, cz + 15, targetX, targetY, targetZ, 0, 74)
+        setCameraMatrix(cx + 18, cy - 24, cz + 9, targetX, targetY, targetZ, 0, 82)
     end
 end
 

--- a/test-resources/fire-showcase/client.lua
+++ b/test-resources/fire-showcase/client.lua
@@ -1,5 +1,3 @@
-local screenW, screenH = guiGetScreenSize()
-
 local show = {
     active = false,
     startedAt = 0,
@@ -8,8 +6,6 @@ local show = {
     centerZ = 0,
     vehicle = nil,
     heroFire = nil,
-    fireCount = 0,
-    duration = 0,
 }
 
 local function clamp(value, minimum, maximum)
@@ -69,24 +65,9 @@ local function getVehicleCamera()
         z + 1.0
 end
 
-local function drawCaption(title, subtitle, accent)
-    local left = screenW * 0.065
-    local bottom = screenH * 0.90
-    local width = screenW * 0.64
-    local titleHeight = screenH * 0.055
-
-    dxDrawRectangle(left - 18, bottom - 92, width, 82, tocolor(0, 0, 0, 150), false)
-    dxDrawRectangle(left - 18, bottom - 92, 5, 82, accent or tocolor(255, 140, 40, 240), false)
-    dxDrawText(title, left, bottom - 87, left + width, bottom - 87 + titleHeight,
-        tocolor(255, 255, 255, 255), 1.7, "default-bold", "left", "top", false, false, false)
-    dxDrawText(subtitle, left, bottom - 48, left + width, bottom,
-        tocolor(220, 220, 220, 245), 1.0, "default", "left", "top", false, false, false)
-end
-
-local function drawCinematicBars()
-    local barHeight = screenH * 0.045
-    dxDrawRectangle(0, 0, screenW, barHeight, tocolor(0, 0, 0, 235), false)
-    dxDrawRectangle(0, screenH - barHeight, screenW, barHeight, tocolor(0, 0, 0, 235), false)
+local function setPresentationUI(visible)
+    showPlayerHudComponent("all", visible)
+    showChat(visible)
 end
 
 local function renderShow()
@@ -97,9 +78,11 @@ local function renderShow()
     local elapsed = getTickCount() - show.startedAt
     local cx, cy, cz = show.centerX, show.centerY, show.centerZ
 
-    -- 0-7s: reveal the full vertical NEON logo from a clean, readable angle.
-    if elapsed < 7000 then
-        local reveal = smoothstep(elapsed / 1600)
+    -- Give the managed fire FX plenty of time to stream in and settle. The camera
+    -- eases into the logo for the first few seconds, then stays almost completely
+    -- still so the full NEON word remains readable on video.
+    if elapsed < 14000 then
+        local reveal = smoothstep(elapsed / 3000)
         cameraLerp(
             cx + 23, cy - 42, cz + 13,
             cx, cy, cz,
@@ -109,9 +92,10 @@ local function renderShow()
             76, 62
         )
 
-    -- 7-11s: push toward the selected flame as it brightens and leaves the O.
-    elseif elapsed < 11000 then
-        local t = (elapsed - 7000) / 4000
+    -- Move in on the selected fire only after the complete logo has been visible
+    -- for a long uninterrupted shot.
+    elseif elapsed < 19000 then
+        local t = (elapsed - 14000) / 5000
         local lookX, lookY, lookZ = cx + 5, cy, cz
         if isElement(show.heroFire) then
             local fireX, fireY, fireZ = getElementPosition(show.heroFire)
@@ -129,8 +113,8 @@ local function renderShow()
             62, 55
         )
 
-    -- 11-21s: chase the vehicle. The same managed fire now follows it as a target.
-    elseif elapsed < 21000 then
+    -- Follow the car while the very same fire element is targeting it.
+    elseif elapsed < 31000 then
         local camX, camY, camZ, lookX, lookY, lookZ = getVehicleCamera()
         if camX then
             setCameraMatrix(camX, camY, camZ, lookX, lookY, lookZ, 0, 62)
@@ -138,7 +122,7 @@ local function renderShow()
             setCameraMatrix(cx + 8, cy - 21, cz + 2, cx, cy, cz, 0, 60)
         end
 
-    -- 21s-end: pull back enough to retain the fiery logo while the car rests in frame.
+    -- Finish on a clean wide gameplay shot with both the logo and car area visible.
     else
         local vehicleX, vehicleY, vehicleZ = cx + 16, cy - 13, 16.6
         if isElement(show.vehicle) then
@@ -153,37 +137,6 @@ local function renderShow()
         local targetZ = math.max(cz, vehicleZ + 2)
         setCameraMatrix(cx + 27, cy - 43, cz + 15, targetX, targetY, targetZ, 0, 74)
     end
-
-    drawCinematicBars()
-
-    if elapsed < 7000 then
-        drawCaption(
-            ("%d MANAGED FIRES"):format(show.fireCount),
-            "One synchronized NEON sign — already beyond GTA's native 60-fire pool."
-        )
-    elseif elapsed < 11000 then
-        drawCaption(
-            "EVERY FLAME IS AN ELEMENT",
-            "The selected fire changes strength and position live — no extinguish/recreate workaround."
-        )
-    elseif elapsed < 21000 then
-        drawCaption(
-            "SAME FIRE. NEW TARGET.",
-            "One existing fire leaves the logo, targets a moving vehicle, and follows it."
-        )
-    else
-        drawCaption(
-            "SYNCED • SCRIPTABLE • TARGETABLE",
-            "Managed fire elements: lifetime, strength, source/target, damage policy and propagation."
-        )
-    end
-
-    -- Tiny implementation hint for scripters without turning the video into documentation.
-    dxDrawText(
-        "createFire(...) → element",
-        screenW * 0.74, screenH * 0.065, screenW * 0.95, screenH * 0.11,
-        tocolor(235, 235, 235, 210), 1.0, "default-bold", "right", "top", false, false, false
-    )
 end
 
 local function stopShow()
@@ -194,13 +147,14 @@ local function stopShow()
     show.active = false
     removeEventHandler("onClientRender", root, renderShow)
     setCameraTarget(localPlayer)
+    setPresentationUI(true)
 
     show.vehicle = nil
     show.heroFire = nil
 end
 
 addEvent("fireShowcase:start", true)
-addEventHandler("fireShowcase:start", resourceRoot, function(centerX, centerY, centerZ, vehicle, heroFire, fireCount, duration)
+addEventHandler("fireShowcase:start", resourceRoot, function(centerX, centerY, centerZ, vehicle, heroFire)
     stopShow()
 
     show.active = true
@@ -210,9 +164,8 @@ addEventHandler("fireShowcase:start", resourceRoot, function(centerX, centerY, c
     show.centerZ = centerZ
     show.vehicle = vehicle
     show.heroFire = heroFire
-    show.fireCount = fireCount
-    show.duration = duration
 
+    setPresentationUI(false)
     addEventHandler("onClientRender", root, renderShow)
 end)
 

--- a/test-resources/fire-showcase/client.lua
+++ b/test-resources/fire-showcase/client.lua
@@ -45,9 +45,16 @@ local function getVehicleCamera()
     end
 
     local x, y, z = getElementPosition(show.vehicle)
-    local vx, vy = getElementVelocity(show.vehicle)
-    local speed = math.sqrt(vx * vx + vy * vy)
+    if type(x) ~= "number" or type(y) ~= "number" or type(z) ~= "number" then
+        return nil
+    end
 
+    local vx, vy = getElementVelocity(show.vehicle)
+    if type(vx) ~= "number" or type(vy) ~= "number" then
+        vx, vy = 1, 0
+    end
+
+    local speed = math.sqrt(vx * vx + vy * vy)
     local dirX, dirY = 1, 0
     if speed > 0.005 then
         dirX, dirY = vx / speed, vy / speed
@@ -107,7 +114,10 @@ local function renderShow()
         local t = (elapsed - 7000) / 4000
         local lookX, lookY, lookZ = cx + 5, cy, cz
         if isElement(show.heroFire) then
-            lookX, lookY, lookZ = getElementPosition(show.heroFire)
+            local fireX, fireY, fireZ = getElementPosition(show.heroFire)
+            if type(fireX) == "number" and type(fireY) == "number" and type(fireZ) == "number" then
+                lookX, lookY, lookZ = fireX, fireY, fireZ
+            end
         end
 
         cameraLerp(
@@ -132,7 +142,10 @@ local function renderShow()
     else
         local vehicleX, vehicleY, vehicleZ = cx + 16, cy - 13, 16.6
         if isElement(show.vehicle) then
-            vehicleX, vehicleY, vehicleZ = getElementPosition(show.vehicle)
+            local x, y, z = getElementPosition(show.vehicle)
+            if type(x) == "number" and type(y) == "number" and type(z) == "number" then
+                vehicleX, vehicleY, vehicleZ = x, y, z
+            end
         end
 
         local targetX = (cx + vehicleX) * 0.5

--- a/test-resources/fire-showcase/client.lua
+++ b/test-resources/fire-showcase/client.lua
@@ -1,0 +1,209 @@
+local screenW, screenH = guiGetScreenSize()
+
+local show = {
+    active = false,
+    startedAt = 0,
+    centerX = 0,
+    centerY = 0,
+    centerZ = 0,
+    vehicle = nil,
+    heroFire = nil,
+    fireCount = 0,
+    duration = 0,
+}
+
+local function clamp(value, minimum, maximum)
+    return math.max(minimum, math.min(maximum, value))
+end
+
+local function smoothstep(value)
+    value = clamp(value, 0, 1)
+    return value * value * (3 - 2 * value)
+end
+
+local function lerp(a, b, t)
+    return a + (b - a) * t
+end
+
+local function cameraLerp(ax, ay, az, alx, aly, alz, bx, by, bz, blx, bly, blz, t, fovA, fovB)
+    t = smoothstep(t)
+    setCameraMatrix(
+        lerp(ax, bx, t),
+        lerp(ay, by, t),
+        lerp(az, bz, t),
+        lerp(alx, blx, t),
+        lerp(aly, bly, t),
+        lerp(alz, blz, t),
+        0,
+        lerp(fovA or 65, fovB or 65, t)
+    )
+end
+
+local function getVehicleCamera()
+    if not isElement(show.vehicle) then
+        return nil
+    end
+
+    local x, y, z = getElementPosition(show.vehicle)
+    local vx, vy = getElementVelocity(show.vehicle)
+    local speed = math.sqrt(vx * vx + vy * vy)
+
+    local dirX, dirY = 1, 0
+    if speed > 0.005 then
+        dirX, dirY = vx / speed, vy / speed
+    end
+
+    return
+        x - dirX * 11.0 - dirY * 3.5,
+        y - dirY * 11.0 + dirX * 3.5,
+        z + 5.0,
+        x + dirX * 2.5,
+        y + dirY * 2.5,
+        z + 1.0
+end
+
+local function drawCaption(title, subtitle, accent)
+    local left = screenW * 0.065
+    local bottom = screenH * 0.90
+    local width = screenW * 0.64
+    local titleHeight = screenH * 0.055
+
+    dxDrawRectangle(left - 18, bottom - 92, width, 82, tocolor(0, 0, 0, 150), false)
+    dxDrawRectangle(left - 18, bottom - 92, 5, 82, accent or tocolor(255, 140, 40, 240), false)
+    dxDrawText(title, left, bottom - 87, left + width, bottom - 87 + titleHeight,
+        tocolor(255, 255, 255, 255), 1.7, "default-bold", "left", "top", false, false, false)
+    dxDrawText(subtitle, left, bottom - 48, left + width, bottom,
+        tocolor(220, 220, 220, 245), 1.0, "default", "left", "top", false, false, false)
+end
+
+local function drawCinematicBars()
+    local barHeight = screenH * 0.045
+    dxDrawRectangle(0, 0, screenW, barHeight, tocolor(0, 0, 0, 235), false)
+    dxDrawRectangle(0, screenH - barHeight, screenW, barHeight, tocolor(0, 0, 0, 235), false)
+end
+
+local function renderShow()
+    if not show.active then
+        return
+    end
+
+    local elapsed = getTickCount() - show.startedAt
+    local cx, cy, cz = show.centerX, show.centerY, show.centerZ
+
+    -- 0-7s: reveal the full vertical NEON logo from a clean, readable angle.
+    if elapsed < 7000 then
+        local reveal = smoothstep(elapsed / 1600)
+        cameraLerp(
+            cx + 23, cy - 42, cz + 13,
+            cx, cy, cz,
+            cx, cy - 34, cz + 5,
+            cx, cy, cz,
+            reveal,
+            76, 62
+        )
+
+    -- 7-11s: push toward the selected flame as it brightens and leaves the O.
+    elseif elapsed < 11000 then
+        local t = (elapsed - 7000) / 4000
+        local lookX, lookY, lookZ = cx + 5, cy, cz
+        if isElement(show.heroFire) then
+            lookX, lookY, lookZ = getElementPosition(show.heroFire)
+        end
+
+        cameraLerp(
+            cx, cy - 34, cz + 5,
+            cx, cy, cz,
+            cx + 8, cy - 21, cz + 2,
+            lookX, lookY, lookZ,
+            t,
+            62, 55
+        )
+
+    -- 11-21s: chase the vehicle. The same managed fire now follows it as a target.
+    elseif elapsed < 21000 then
+        local camX, camY, camZ, lookX, lookY, lookZ = getVehicleCamera()
+        if camX then
+            setCameraMatrix(camX, camY, camZ, lookX, lookY, lookZ, 0, 62)
+        else
+            setCameraMatrix(cx + 8, cy - 21, cz + 2, cx, cy, cz, 0, 60)
+        end
+
+    -- 21s-end: pull back enough to retain the fiery logo while the car rests in frame.
+    else
+        local vehicleX, vehicleY, vehicleZ = cx + 16, cy - 13, 16.6
+        if isElement(show.vehicle) then
+            vehicleX, vehicleY, vehicleZ = getElementPosition(show.vehicle)
+        end
+
+        local targetX = (cx + vehicleX) * 0.5
+        local targetY = (cy + vehicleY) * 0.5
+        local targetZ = math.max(cz, vehicleZ + 2)
+        setCameraMatrix(cx + 27, cy - 43, cz + 15, targetX, targetY, targetZ, 0, 74)
+    end
+
+    drawCinematicBars()
+
+    if elapsed < 7000 then
+        drawCaption(
+            ("%d MANAGED FIRES"):format(show.fireCount),
+            "One synchronized NEON sign — already beyond GTA's native 60-fire pool."
+        )
+    elseif elapsed < 11000 then
+        drawCaption(
+            "EVERY FLAME IS AN ELEMENT",
+            "The selected fire changes strength and position live — no extinguish/recreate workaround."
+        )
+    elseif elapsed < 21000 then
+        drawCaption(
+            "SAME FIRE. NEW TARGET.",
+            "One existing fire leaves the logo, targets a moving vehicle, and follows it."
+        )
+    else
+        drawCaption(
+            "SYNCED • SCRIPTABLE • TARGETABLE",
+            "Managed fire elements: lifetime, strength, source/target, damage policy and propagation."
+        )
+    end
+
+    -- Tiny implementation hint for scripters without turning the video into documentation.
+    dxDrawText(
+        "createFire(...) → element",
+        screenW * 0.74, screenH * 0.065, screenW * 0.95, screenH * 0.11,
+        tocolor(235, 235, 235, 210), 1.0, "default-bold", "right", "top", false, false, false
+    )
+end
+
+local function stopShow()
+    if not show.active then
+        return
+    end
+
+    show.active = false
+    removeEventHandler("onClientRender", root, renderShow)
+    setCameraTarget(localPlayer)
+
+    show.vehicle = nil
+    show.heroFire = nil
+end
+
+addEvent("fireShowcase:start", true)
+addEventHandler("fireShowcase:start", resourceRoot, function(centerX, centerY, centerZ, vehicle, heroFire, fireCount, duration)
+    stopShow()
+
+    show.active = true
+    show.startedAt = getTickCount()
+    show.centerX = centerX
+    show.centerY = centerY
+    show.centerZ = centerZ
+    show.vehicle = vehicle
+    show.heroFire = heroFire
+    show.fireCount = fireCount
+    show.duration = duration
+
+    addEventHandler("onClientRender", root, renderShow)
+end)
+
+addEvent("fireShowcase:stop", true)
+addEventHandler("fireShowcase:stop", resourceRoot, stopShow)
+
+addEventHandler("onClientResourceStop", resourceRoot, stopShow)

--- a/test-resources/fire-showcase/meta.xml
+++ b/test-resources/fire-showcase/meta.xml
@@ -1,0 +1,5 @@
+<meta>
+    <info author="Neon" name="Managed fire showcase" version="0.1.0" type="script" />
+    <script src="server.lua" type="server" />
+    <script src="client.lua" type="client" cache="false" />
+</meta>

--- a/test-resources/fire-showcase/server.lua
+++ b/test-resources/fire-showcase/server.lua
@@ -1,5 +1,5 @@
 local SHOW_DIMENSION = 64990
-local SHOW_DURATION = 27000
+local SHOW_DURATION = 36000
 
 local LOGO_CENTER_X = 405.0
 local LOGO_Y = 2535.0
@@ -132,7 +132,6 @@ local function cleanup(notifyClient)
         triggerClientEvent(state.player, "fireShowcase:stop", resourceRoot)
     end
 
-    -- Destroy fires before the target vehicle so element references disappear cleanly.
     for _, fire in ipairs(state.fires) do
         destroyElementSafe(fire)
     end
@@ -177,7 +176,6 @@ local function buildLogo(player)
     local firstX = LOGO_CENTER_X - ((totalColumns - 1) * LOGO_STEP * 0.5)
     local created = 0
     local hero = nil
-    local minColumn = math.huge
 
     for letterIndex, pattern in ipairs(patterns) do
         local columnBase = (letterIndex - 1) * (letterWidth + LETTER_GAP)
@@ -200,9 +198,7 @@ local function buildLogo(player)
                         setElementInterior(fire, 0)
                         state.fires[#state.fires + 1] = fire
                         created = created + 1
-                        minColumn = math.min(minColumn, globalColumn)
 
-                        -- Right side of the O: easy to see leaving the middle of the word.
                         if letterIndex == 3 and rowIndex == 4 and columnIndex == 5 then
                             hero = fire
                         end
@@ -212,7 +208,7 @@ local function buildLogo(player)
         end
     end
 
-    return created, hero, firstX, minColumn
+    return created, hero, firstX
 end
 
 local function animateStrengthWave(firstX)
@@ -220,7 +216,7 @@ local function animateStrengthWave(firstX)
         if isElement(fire) then
             local x = select(1, getElementPosition(fire))
             local column = math.floor(((x - firstX) / LOGO_STEP) + 0.5)
-            local delay = 1800 + column * 105
+            local delay = 6000 + column * 120
 
             later(delay, function()
                 if isElement(fire) then
@@ -228,7 +224,7 @@ local function animateStrengthWave(firstX)
                 end
             end)
 
-            later(delay + 420, function()
+            later(delay + 500, function()
                 if isElement(fire) and fire ~= state.heroFire then
                     setFireStrength(fire, 1.0)
                 end
@@ -248,7 +244,7 @@ local function animateHeroToVehicle()
     setFireStrength(hero, 3.2)
 
     local startX, startY, startZ = getElementPosition(hero)
-    local steps = 24
+    local steps = 28
     local currentStep = 0
     local serial = state.serial
     local timer
@@ -322,8 +318,7 @@ local function startShow(player)
 
     animateStrengthWave(firstX)
 
-    -- Make the selected flame stand out before it physically leaves the O.
-    later(8200, function()
+    later(14500, function()
         if isElement(state.heroFire) then
             setFireStrength(state.heroFire, 3.2)
         end
@@ -332,26 +327,25 @@ local function startShow(player)
         end
     end)
 
-    later(9300, animateHeroToVehicle)
+    later(16000, animateHeroToVehicle)
 
-    -- Keep the car in the useful camera area rather than letting physics run forever.
-    later(19000, function()
+    later(30000, function()
         if isElement(state.vehicle) then
             setElementVelocity(state.vehicle, 0, 0, 0)
         end
     end)
 
-    triggerClientEvent(player, "fireShowcase:start", resourceRoot,
-        LOGO_CENTER_X, LOGO_Y, LOGO_BASE_Z + 4.05, vehicle, hero, count, SHOW_DURATION)
-
-    chat(player, ("Started: %d managed fires. Recording sequence is automatic."):format(count), 120, 255, 120)
+    -- Wait briefly before switching to the showcase camera so EntityAdd packets and
+    -- their FX can start arriving before the first recorded frame.
+    later(900, function()
+        if isElement(state.player) then
+            triggerClientEvent(state.player, "fireShowcase:start", resourceRoot,
+                LOGO_CENTER_X, LOGO_Y, LOGO_BASE_Z + 4.05, state.vehicle, state.heroFire)
+        end
+    end)
 
     later(SHOW_DURATION, function()
-        local owner = state.player
         cleanup(true)
-        if isElement(owner) then
-            chat(owner, "Showcase complete. /fireshow to replay.", 120, 255, 120)
-        end
     end)
 end
 
@@ -364,7 +358,6 @@ addCommandHandler("fireshow", function(player, _, action)
             return
         end
         cleanup(true)
-        chat(player, "Showcase stopped and cleaned up.", 255, 200, 80)
         return
     end
 

--- a/test-resources/fire-showcase/server.lua
+++ b/test-resources/fire-showcase/server.lua
@@ -1,0 +1,387 @@
+local SHOW_DIMENSION = 64990
+local SHOW_DURATION = 27000
+
+local LOGO_CENTER_X = 405.0
+local LOGO_Y = 2535.0
+local LOGO_BASE_Z = 18.5
+local LOGO_STEP = 1.35
+local LETTER_GAP = 2
+
+local patterns = {
+    {
+        name = "N",
+        rows = {
+            "10001",
+            "11001",
+            "10101",
+            "10011",
+            "10001",
+            "10001",
+            "10001",
+        },
+    },
+    {
+        name = "E",
+        rows = {
+            "11111",
+            "10000",
+            "10000",
+            "11110",
+            "10000",
+            "10000",
+            "11111",
+        },
+    },
+    {
+        name = "O",
+        rows = {
+            "01110",
+            "10001",
+            "10001",
+            "10001",
+            "10001",
+            "10001",
+            "01110",
+        },
+    },
+    {
+        name = "N",
+        rows = {
+            "10001",
+            "11001",
+            "10101",
+            "10011",
+            "10001",
+            "10001",
+            "10001",
+        },
+    },
+}
+
+local state = {
+    running = false,
+    serial = 0,
+    player = nil,
+    fires = {},
+    timers = {},
+    vehicle = nil,
+    heroFire = nil,
+    savedPlayer = nil,
+}
+
+local function chat(player, message, r, g, b)
+    if isElement(player) then
+        outputChatBox("[FIRE SHOWCASE] " .. message, player, r or 255, g or 180, b or 70)
+    end
+end
+
+local function rememberTimer(timer)
+    state.timers[#state.timers + 1] = timer
+    return timer
+end
+
+local function later(delay, callback)
+    local serial = state.serial
+    return rememberTimer(setTimer(function()
+        if state.running and serial == state.serial then
+            callback()
+        end
+    end, delay, 1))
+end
+
+local function clearTimers()
+    for _, timer in ipairs(state.timers) do
+        if isTimer(timer) then
+            killTimer(timer)
+        end
+    end
+    state.timers = {}
+end
+
+local function destroyElementSafe(element)
+    if isElement(element) then
+        destroyElement(element)
+    end
+end
+
+local function restorePlayer()
+    local player = state.player
+    local saved = state.savedPlayer
+    if not isElement(player) or not saved then
+        return
+    end
+
+    setElementInterior(player, saved.interior)
+    setElementDimension(player, saved.dimension)
+    setElementPosition(player, saved.x, saved.y, saved.z)
+    setElementRotation(player, saved.rx, saved.ry, saved.rz)
+    setElementAlpha(player, saved.alpha)
+    setElementFrozen(player, saved.frozen)
+end
+
+local function cleanup(notifyClient)
+    if not state.running and #state.fires == 0 and not isElement(state.vehicle) then
+        return
+    end
+
+    state.running = false
+    state.serial = state.serial + 1
+    clearTimers()
+
+    if notifyClient ~= false and isElement(state.player) then
+        triggerClientEvent(state.player, "fireShowcase:stop", resourceRoot)
+    end
+
+    -- Destroy fires before the target vehicle so element references disappear cleanly.
+    for _, fire in ipairs(state.fires) do
+        destroyElementSafe(fire)
+    end
+    state.fires = {}
+    state.heroFire = nil
+
+    destroyElementSafe(state.vehicle)
+    state.vehicle = nil
+
+    restorePlayer()
+    state.savedPlayer = nil
+    state.player = nil
+end
+
+local function saveAndStagePlayer(player)
+    local x, y, z = getElementPosition(player)
+    local rx, ry, rz = getElementRotation(player)
+    state.savedPlayer = {
+        x = x,
+        y = y,
+        z = z,
+        rx = rx,
+        ry = ry,
+        rz = rz,
+        dimension = getElementDimension(player),
+        interior = getElementInterior(player),
+        alpha = getElementAlpha(player),
+        frozen = isElementFrozen(player),
+    }
+
+    setElementInterior(player, 0)
+    setElementDimension(player, SHOW_DIMENSION)
+    setElementPosition(player, LOGO_CENTER_X, LOGO_Y - 42.0, 16.8)
+    setElementRotation(player, 0, 0, 0)
+    setElementAlpha(player, 0)
+    setElementFrozen(player, true)
+end
+
+local function buildLogo(player)
+    local letterWidth = 5
+    local totalColumns = (#patterns * letterWidth) + ((#patterns - 1) * LETTER_GAP)
+    local firstX = LOGO_CENTER_X - ((totalColumns - 1) * LOGO_STEP * 0.5)
+    local created = 0
+    local hero = nil
+    local minColumn = math.huge
+
+    for letterIndex, pattern in ipairs(patterns) do
+        local columnBase = (letterIndex - 1) * (letterWidth + LETTER_GAP)
+        for rowIndex, row in ipairs(pattern.rows) do
+            for columnIndex = 1, #row do
+                if row:sub(columnIndex, columnIndex) == "1" then
+                    local globalColumn = columnBase + (columnIndex - 1)
+                    local x = firstX + globalColumn * LOGO_STEP
+                    local z = LOGO_BASE_Z + (#pattern.rows - rowIndex) * LOGO_STEP
+                    local fire = createFire(x, LOGO_Y, z, {
+                        duration = SHOW_DURATION + 5000,
+                        strength = 1.0,
+                        damage = false,
+                        spread = false,
+                        source = player,
+                    })
+
+                    if isElement(fire) then
+                        setElementDimension(fire, SHOW_DIMENSION)
+                        setElementInterior(fire, 0)
+                        state.fires[#state.fires + 1] = fire
+                        created = created + 1
+                        minColumn = math.min(minColumn, globalColumn)
+
+                        -- Right side of the O: easy to see leaving the middle of the word.
+                        if letterIndex == 3 and rowIndex == 4 and columnIndex == 5 then
+                            hero = fire
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    return created, hero, firstX, minColumn
+end
+
+local function animateStrengthWave(firstX)
+    for _, fire in ipairs(state.fires) do
+        if isElement(fire) then
+            local x = select(1, getElementPosition(fire))
+            local column = math.floor(((x - firstX) / LOGO_STEP) + 0.5)
+            local delay = 1800 + column * 105
+
+            later(delay, function()
+                if isElement(fire) then
+                    setFireStrength(fire, 2.8)
+                end
+            end)
+
+            later(delay + 420, function()
+                if isElement(fire) and fire ~= state.heroFire then
+                    setFireStrength(fire, 1.0)
+                end
+            end)
+        end
+    end
+end
+
+local function animateHeroToVehicle()
+    local hero = state.heroFire
+    local vehicle = state.vehicle
+    if not isElement(hero) or not isElement(vehicle) then
+        return
+    end
+
+    setFireTarget(hero, nil)
+    setFireStrength(hero, 3.2)
+
+    local startX, startY, startZ = getElementPosition(hero)
+    local steps = 24
+    local currentStep = 0
+    local serial = state.serial
+    local timer
+
+    timer = setTimer(function()
+        if not state.running or serial ~= state.serial or not isElement(hero) or not isElement(vehicle) then
+            if isTimer(timer) then
+                killTimer(timer)
+            end
+            return
+        end
+
+        currentStep = currentStep + 1
+        local vehicleX, vehicleY, vehicleZ = getElementPosition(vehicle)
+        local t = currentStep / steps
+        local eased = t * t * (3 - 2 * t)
+        local arc = math.sin(t * math.pi) * 2.2
+
+        setElementPosition(
+            hero,
+            startX + (vehicleX - startX) * eased,
+            startY + (vehicleY - startY) * eased,
+            startZ + ((vehicleZ + 1.1) - startZ) * eased + arc
+        )
+
+        if currentStep >= steps then
+            setFireTarget(hero, vehicle)
+            setElementVelocity(vehicle, 0.18, 0.0, 0.0)
+        end
+    end, 50, steps)
+
+    rememberTimer(timer)
+end
+
+local function startShow(player)
+    if state.running then
+        chat(player, "A showcase is already running. Use /fireshow stop first.", 255, 90, 90)
+        return
+    end
+
+    state.running = true
+    state.serial = state.serial + 1
+    state.player = player
+    state.fires = {}
+    state.timers = {}
+    state.vehicle = nil
+    state.heroFire = nil
+
+    saveAndStagePlayer(player)
+
+    local vehicle = createVehicle(411, LOGO_CENTER_X - 20.0, LOGO_Y - 13.0, 16.6, 0, 0, 90)
+    if not isElement(vehicle) then
+        chat(player, "Could not create showcase vehicle.", 255, 90, 90)
+        cleanup(true)
+        return
+    end
+
+    state.vehicle = vehicle
+    setElementDimension(vehicle, SHOW_DIMENSION)
+    setElementInterior(vehicle, 0)
+    setElementFrozen(vehicle, true)
+
+    local count, hero, firstX = buildLogo(player)
+    state.heroFire = hero
+
+    if count <= 60 or not isElement(hero) then
+        chat(player, ("Showcase setup failed (fires=%d, hero=%s)."):format(count, tostring(isElement(hero))), 255, 90, 90)
+        cleanup(true)
+        return
+    end
+
+    animateStrengthWave(firstX)
+
+    -- Make the selected flame stand out before it physically leaves the O.
+    later(8200, function()
+        if isElement(state.heroFire) then
+            setFireStrength(state.heroFire, 3.2)
+        end
+        if isElement(state.vehicle) then
+            setElementFrozen(state.vehicle, false)
+        end
+    end)
+
+    later(9300, animateHeroToVehicle)
+
+    -- Keep the car in the useful camera area rather than letting physics run forever.
+    later(19000, function()
+        if isElement(state.vehicle) then
+            setElementVelocity(state.vehicle, 0, 0, 0)
+        end
+    end)
+
+    triggerClientEvent(player, "fireShowcase:start", resourceRoot,
+        LOGO_CENTER_X, LOGO_Y, LOGO_BASE_Z + 4.05, vehicle, hero, count, SHOW_DURATION)
+
+    chat(player, ("Started: %d managed fires. Recording sequence is automatic."):format(count), 120, 255, 120)
+
+    later(SHOW_DURATION, function()
+        local owner = state.player
+        cleanup(true)
+        if isElement(owner) then
+            chat(owner, "Showcase complete. /fireshow to replay.", 120, 255, 120)
+        end
+    end)
+end
+
+addCommandHandler("fireshow", function(player, _, action)
+    action = action and action:lower() or "start"
+
+    if action == "stop" or action == "reset" then
+        if state.running and state.player ~= player then
+            chat(player, "Another player owns the active showcase.", 255, 90, 90)
+            return
+        end
+        cleanup(true)
+        chat(player, "Showcase stopped and cleaned up.", 255, 200, 80)
+        return
+    end
+
+    if action ~= "start" then
+        chat(player, "Usage: /fireshow [start|stop]", 255, 200, 80)
+        return
+    end
+
+    startShow(player)
+end)
+
+addEventHandler("onPlayerQuit", root, function()
+    if source == state.player then
+        cleanup(false)
+    end
+end)
+
+addEventHandler("onResourceStop", resourceRoot, function()
+    cleanup(true)
+end)

--- a/test-resources/fire-test/README.md
+++ b/test-resources/fire-test/README.md
@@ -1,0 +1,66 @@
+# Managed fire test harness
+
+This resource exercises the managed fire runtime without depending on a gameplay resource.
+
+## Automated run
+
+Start `fire-test`, join the server, then run:
+
+```text
+/firetest all
+```
+
+The server and client print explicit lines such as:
+
+```text
+[FIRETEST] PASS duration.get: 5000
+[FIRETEST] PASS client.sync.element: fire element received
+[FIRETEST] FAIL damage.cancel-event: true
+```
+
+The automated run covers managed element creation, duration/remaining time, live strength changes, damage target masks, source/target setters, client synchronization, server expiry, one-generation spread, more than 60 simultaneous managed fires, local damage-mask behavior and cancellable `onClientFireDamage` behavior.
+
+Other commands:
+
+```text
+/firetest basic
+/firetest late
+/firetest status
+/firetest reset
+```
+
+`/firetest late` creates a 30-second synchronized fire for manual late-join/stream validation. Join with another client while it is active and verify the second client receives the same `fire` element with a reduced remaining lifetime rather than a restarted lifetime.
+
+## API shape exercised
+
+Server and managed client-local fires use the options-table form:
+
+```lua
+local fire = createFire(x, y, z, {
+    duration = 10000,
+    strength = 1.5,
+    damage = true,
+    damageTargets = {
+        players = true,
+        peds = true,
+        vehicles = false,
+        objects = false,
+    },
+    spread = false,
+    maxGenerations = 0,
+    source = localPlayer,
+    target = nil,
+})
+```
+
+The legacy client call `createFire(x, y, z [, size])` remains the native GTA fire path and still returns a boolean.
+
+## Manual checks
+
+After `/firetest all`, additionally verify:
+
+- `strength` values around `1`, `2` and `3` visibly select small, medium and large GTA fire FX.
+- moving a target element makes a targeted managed fire follow it.
+- moving the local player to another dimension/interior hides a managed fire until the contexts match again.
+- normal GTA/Molotov fires still use the native fire runtime and are unaffected by managed-fire settings.
+- stopping `fire-test` removes every fire owned by the resource and leaves no visible FX behind.

--- a/test-resources/fire-test/client.lua
+++ b/test-resources/fire-test/client.lua
@@ -1,0 +1,98 @@
+local activeSerial = 0
+local cancelDamage = false
+
+local function send(serial, name, ok, detail)
+    triggerServerEvent("firetest:clientResult", resourceRoot, serial, name, ok == true, tostring(detail or ""))
+end
+
+addEvent("firetest:inspect", true)
+addEventHandler("firetest:inspect", resourceRoot, function(fire, serial)
+    activeSerial = serial
+    local ok = isElement(fire) and getElementType(fire) == "fire"
+    send(serial, "sync.element", ok, ok and "fire element received" or "missing/invalid fire")
+    if not ok then return end
+
+    local strength = getFireStrength(fire)
+    local remaining = getFireRemainingTime(fire)
+    local mask = getFireDamageTargets(fire)
+    send(serial, "sync.strength", type(strength) == "number" and math.abs(strength - 2.5) < 0.01, strength)
+    send(serial, "sync.remaining", type(remaining) == "number" and remaining > 2500 and remaining <= 4500, remaining)
+    send(serial, "sync.damage-mask", type(mask) == "table" and mask.players and not mask.peds and mask.vehicles and not mask.objects,
+        type(mask) == "table" and ("p=%s ped=%s v=%s o=%s"):format(tostring(mask.players), tostring(mask.peds), tostring(mask.vehicles), tostring(mask.objects)) or tostring(mask))
+end)
+
+addEventHandler("onClientFireDamage", root, function(victim, damage, responsibleElement)
+    if cancelDamage then
+        cancelEvent()
+    end
+end)
+
+local function destroyIfElement(element)
+    if isElement(element) then
+        destroyElement(element)
+    end
+end
+
+addEvent("firetest:localPolicy", true)
+addEventHandler("firetest:localPolicy", resourceRoot, function(serial)
+    activeSerial = serial
+    local px, py, pz = getElementPosition(localPlayer)
+    local ped = createPed(7, px + 4, py, pz)
+    if not isElement(ped) then
+        send(serial, "local.ped-create", false, "createPed failed")
+        return
+    end
+
+    setElementDimension(ped, getElementDimension(localPlayer))
+    setElementInterior(ped, getElementInterior(localPlayer))
+
+    local fire = createFire(px + 4, py, pz, {
+        duration = 4500,
+        strength = 1.0,
+        damage = true,
+        damageTargets = {players = false, peds = false, vehicles = false, objects = false},
+        source = localPlayer,
+    })
+
+    if not isElement(fire) then
+        send(serial, "local.fire-create", false, "managed local createFire failed")
+        destroyIfElement(ped)
+        return
+    end
+
+    setElementDimension(fire, getElementDimension(localPlayer))
+    setElementInterior(fire, getElementInterior(localPlayer))
+    send(serial, "local.create", getElementType(fire) == "fire", getElementType(fire))
+
+    setTimer(function()
+        if serial ~= activeSerial then
+            destroyIfElement(fire)
+            destroyIfElement(ped)
+            return
+        end
+
+        send(serial, "damage.mask-block", not isElementOnFire(ped), tostring(isElementOnFire(ped)))
+        setFireDamageTargets(fire, {players = false, peds = true, vehicles = false, objects = false})
+        cancelDamage = true
+        setElementOnFire(ped, false)
+
+        setTimer(function()
+            if serial ~= activeSerial then return end
+            send(serial, "damage.cancel-event", not isElementOnFire(ped), tostring(isElementOnFire(ped)))
+            cancelDamage = false
+            setElementOnFire(ped, false)
+
+            setTimer(function()
+                if serial ~= activeSerial then return end
+                send(serial, "damage.allowed", isElementOnFire(ped), tostring(isElementOnFire(ped)))
+                destroyIfElement(fire)
+                destroyIfElement(ped)
+            end, 1000, 1)
+        end, 1000, 1)
+    end, 1000, 1)
+end)
+
+addEventHandler("onClientResourceStop", resourceRoot, function()
+    cancelDamage = false
+    activeSerial = activeSerial + 1
+end)

--- a/test-resources/fire-test/meta.xml
+++ b/test-resources/fire-test/meta.xml
@@ -1,0 +1,5 @@
+<meta>
+    <info author="Dryxio" name="Managed fire test harness" type="script" />
+    <script src="server.lua" type="server" />
+    <script src="client.lua" type="client" cache="false" />
+</meta>

--- a/test-resources/fire-test/server.lua
+++ b/test-resources/fire-test/server.lua
@@ -1,9 +1,22 @@
 local tracked = {}
 local runSerial = 0
+local runPlayer = false
+
+local function emit(message, debugLevel, r, g, b)
+    outputDebugString(message, debugLevel or 3)
+    if isElement(runPlayer) and getElementType(runPlayer) == "player" then
+        outputChatBox(message, runPlayer, r or 255, g or 255, b or 255)
+    end
+end
 
 local function log(kind, name, detail)
     local suffix = detail and (": " .. tostring(detail)) or ""
-    outputDebugString(("[FIRETEST] %s %s%s"):format(kind, name, suffix), kind == "FAIL" and 1 or 3)
+    local message = ("[FIRETEST] %s %s%s"):format(kind, name, suffix)
+    if kind == "FAIL" then
+        emit(message, 1, 255, 80, 80)
+    else
+        emit(message, 3, 100, 255, 100)
+    end
 end
 
 local function pass(name, detail)
@@ -158,7 +171,7 @@ local function runAll(player)
     runSerial = runSerial + 1
     local serial = runSerial
     reset()
-    outputDebugString(("[FIRETEST] RUN serial=%d player=%s"):format(serial, getPlayerName(player)), 3)
+    emit(("[FIRETEST] RUN serial=%d player=%s"):format(serial, getPlayerName(player)), 3, 255, 200, 80)
 
     if not runImmediate(player) then
         fail("run", "basic creation failed; dependent tests skipped")
@@ -171,7 +184,7 @@ local function runAll(player)
 
     setTimer(function()
         if serial == runSerial then
-            outputDebugString(("[FIRETEST] DONE serial=%d -- inspect PASS/FAIL lines above"):format(serial), 3)
+            emit(("[FIRETEST] DONE serial=%d -- inspect PASS/FAIL lines above"):format(serial), 3, 255, 200, 80)
         end
     end, 5000, 1)
 end
@@ -185,6 +198,11 @@ addEventHandler("firetest:clientResult", resourceRoot, function(serial, name, ok
 end)
 
 addCommandHandler("firetest", function(player, _, caseName)
+    if not isElement(player) or getElementType(player) ~= "player" then
+        return
+    end
+
+    runPlayer = player
     caseName = caseName or "all"
     if caseName == "all" then
         runAll(player)
@@ -216,6 +234,13 @@ addCommandHandler("firetest", function(player, _, caseName)
     end
 end)
 
+addEventHandler("onPlayerQuit", root, function()
+    if source == runPlayer then
+        runPlayer = false
+    end
+end)
+
 addEventHandler("onResourceStop", resourceRoot, function()
     reset()
+    runPlayer = false
 end)

--- a/test-resources/fire-test/server.lua
+++ b/test-resources/fire-test/server.lua
@@ -91,6 +91,11 @@ local function runImmediate(player)
     check("target.set", setFireTarget(fire, player) and getFireTarget(fire) == player, tostring(getFireTarget(fire)))
     check("target.clear", setFireTarget(fire, nil) and getFireTarget(fire) == false, tostring(getFireTarget(fire)))
 
+    -- Keep this control fire stable after testing the live setters so the dedicated
+    -- spread scenario owns all propagation assertions.
+    setFireSpreadEnabled(fire, false)
+    setFireMaxGenerations(fire, 0)
+
     triggerClientEvent(player, "firetest:inspect", resourceRoot, fire, runSerial)
     return true
 end
@@ -173,7 +178,7 @@ end
 
 addEvent("firetest:clientResult", true)
 addEventHandler("firetest:clientResult", resourceRoot, function(serial, name, ok, detail)
-    if client ~= source or serial ~= runSerial then
+    if not client or serial ~= runSerial then
         return
     end
     check("client." .. tostring(name), ok == true, detail)

--- a/test-resources/fire-test/server.lua
+++ b/test-resources/fire-test/server.lua
@@ -1,0 +1,216 @@
+local tracked = {}
+local runSerial = 0
+
+local function log(kind, name, detail)
+    local suffix = detail and (": " .. tostring(detail)) or ""
+    outputDebugString(("[FIRETEST] %s %s%s"):format(kind, name, suffix), kind == "FAIL" and 1 or 3)
+end
+
+local function pass(name, detail)
+    log("PASS", name, detail)
+end
+
+local function fail(name, detail)
+    log("FAIL", name, detail)
+end
+
+local function check(name, condition, detail)
+    if condition then
+        pass(name, detail)
+    else
+        fail(name, detail)
+    end
+    return condition
+end
+
+local function track(element)
+    if isElement(element) then
+        tracked[element] = true
+    end
+    return element
+end
+
+local function reset()
+    for element in pairs(tracked) do
+        if isElement(element) then
+            destroyElement(element)
+        end
+    end
+    tracked = {}
+end
+
+local function spawnPosition(player, offset)
+    local x, y, z = getElementPosition(player)
+    return x + (offset or 3), y, z
+end
+
+local function countManagedFires()
+    local count = 0
+    for _, element in ipairs(getElementsByType("fire")) do
+        if isElement(element) then
+            count = count + 1
+        end
+    end
+    return count
+end
+
+local function runImmediate(player)
+    local x, y, z = spawnPosition(player, 3)
+    local fire = track(createFire(x, y, z, {
+        duration = 5000,
+        strength = 1.0,
+        damage = false,
+        spread = false,
+        source = player,
+    }))
+
+    check("basic.create", isElement(fire), tostring(fire))
+    if not isElement(fire) then
+        return false
+    end
+
+    check("basic.type", getElementType(fire) == "fire", getElementType(fire))
+    check("duration.get", math.abs((getFireDuration(fire) or -1) - 5000) < 1, getFireDuration(fire))
+    check("remaining.initial", (getFireRemainingTime(fire) or -1) > 4500, getFireRemainingTime(fire))
+    check("strength.get", math.abs((getFireStrength(fire) or -1) - 1.0) < 0.01, getFireStrength(fire))
+    check("damage.disabled", isFireDamageEnabled(fire) == false, tostring(isFireDamageEnabled(fire)))
+    check("source.get", getFireSource(fire) == player, tostring(getFireSource(fire)))
+
+    check("strength.set", setFireStrength(fire, 2.5) and math.abs((getFireStrength(fire) or 0) - 2.5) < 0.01, getFireStrength(fire))
+    check("duration.set", setFireDuration(fire, 8000) and math.abs((getFireDuration(fire) or 0) - 8000) < 1, getFireDuration(fire))
+    check("remaining.set", setFireRemainingTime(fire, 4000) and (getFireRemainingTime(fire) or 0) > 3500, getFireRemainingTime(fire))
+
+    local mask = {players = true, peds = false, vehicles = true, objects = false}
+    setFireDamageTargets(fire, mask)
+    local got = getFireDamageTargets(fire)
+    check("damage.mask", got and got.players and not got.peds and got.vehicles and not got.objects,
+        got and ("p=%s ped=%s v=%s o=%s"):format(tostring(got.players), tostring(got.peds), tostring(got.vehicles), tostring(got.objects)) or "false")
+
+    check("spread.set", setFireSpreadEnabled(fire, true) and isFireSpreadEnabled(fire), tostring(isFireSpreadEnabled(fire)))
+    check("generations.set", setFireMaxGenerations(fire, 2) and getFireMaxGenerations(fire) == 2, getFireMaxGenerations(fire))
+    check("target.set", setFireTarget(fire, player) and getFireTarget(fire) == player, tostring(getFireTarget(fire)))
+    check("target.clear", setFireTarget(fire, nil) and getFireTarget(fire) == false, tostring(getFireTarget(fire)))
+
+    triggerClientEvent(player, "firetest:inspect", resourceRoot, fire, runSerial)
+    return true
+end
+
+local function runExpiry(player, serial)
+    local x, y, z = spawnPosition(player, 5)
+    local fire = track(createFire(x, y, z, {duration = 850, damage = false}))
+    check("expiry.created", isElement(fire))
+    setTimer(function()
+        if serial ~= runSerial then return end
+        check("expiry.destroyed", not isElement(fire), isElement(fire) and "still alive" or "expired")
+        tracked[fire] = nil
+    end, 1400, 1)
+end
+
+local function runSpread(player, serial)
+    local before = countManagedFires()
+    local x, y, z = spawnPosition(player, 7)
+    local parent = track(createFire(x, y, z, {
+        duration = 7000,
+        strength = 1.5,
+        damage = false,
+        spread = true,
+        maxGenerations = 1,
+    }))
+    check("spread.created", isElement(parent))
+
+    setTimer(function()
+        if serial ~= runSerial then return end
+        local after = countManagedFires()
+        check("spread.child", after >= before + 2, ("before=%d after=%d"):format(before, after))
+    end, 2400, 1)
+end
+
+local function runBulk(player, serial)
+    local x, y, z = spawnPosition(player, 100)
+    local fires = {}
+    for i = 1, 65 do
+        local fire = createFire(x + (i % 10), y + math.floor(i / 10), z, {duration = 3500, damage = false})
+        if isElement(fire) then
+            setElementDimension(fire, 65000)
+            fires[#fires + 1] = fire
+            tracked[fire] = true
+        end
+    end
+    check("bulk.over-native-pool", #fires == 65, ("created=%d"):format(#fires))
+
+    setTimer(function()
+        if serial ~= runSerial then return end
+        local alive = 0
+        for _, fire in ipairs(fires) do
+            if isElement(fire) then alive = alive + 1 end
+        end
+        check("bulk.expiry", alive == 0, ("alive=%d"):format(alive))
+        for _, fire in ipairs(fires) do tracked[fire] = nil end
+    end, 4300, 1)
+end
+
+local function runAll(player)
+    runSerial = runSerial + 1
+    local serial = runSerial
+    reset()
+    outputDebugString(("[FIRETEST] RUN serial=%d player=%s"):format(serial, getPlayerName(player)), 3)
+
+    if not runImmediate(player) then
+        fail("run", "basic creation failed; dependent tests skipped")
+        return
+    end
+    runExpiry(player, serial)
+    runSpread(player, serial)
+    runBulk(player, serial)
+    triggerClientEvent(player, "firetest:localPolicy", resourceRoot, serial)
+
+    setTimer(function()
+        if serial == runSerial then
+            outputDebugString(("[FIRETEST] DONE serial=%d -- inspect PASS/FAIL lines above"):format(serial), 3)
+        end
+    end, 5000, 1)
+end
+
+addEvent("firetest:clientResult", true)
+addEventHandler("firetest:clientResult", resourceRoot, function(serial, name, ok, detail)
+    if client ~= source or serial ~= runSerial then
+        return
+    end
+    check("client." .. tostring(name), ok == true, detail)
+end)
+
+addCommandHandler("firetest", function(player, _, caseName)
+    caseName = caseName or "all"
+    if caseName == "all" then
+        runAll(player)
+    elseif caseName == "reset" then
+        runSerial = runSerial + 1
+        reset()
+        pass("reset")
+    elseif caseName == "status" then
+        outputChatBox(("[FIRETEST] tracked=%d worldFires=%d serial=%d"):format(
+            (function() local n = 0 for element in pairs(tracked) do if isElement(element) then n = n + 1 end end return n end)(),
+            countManagedFires(), runSerial), player, 255, 200, 80)
+    elseif caseName == "basic" then
+        runSerial = runSerial + 1
+        reset()
+        runImmediate(player)
+    elseif caseName == "late" then
+        runSerial = runSerial + 1
+        reset()
+        local x, y, z = spawnPosition(player, 6)
+        local fire = track(createFire(x, y, z, {duration = 30000, strength = 1.5, damage = false}))
+        if isElement(fire) then
+            outputChatBox("[FIRETEST] late-join fire created for 30s; join/stream another client and run /firetest status", player, 255, 200, 80)
+            pass("late.setup", ("remaining=%.0f"):format(getFireRemainingTime(fire) or -1))
+        else
+            fail("late.setup", "createFire returned false")
+        end
+    else
+        outputChatBox("[FIRETEST] cases: all, basic, late, status, reset", player, 255, 200, 80)
+    end
+end)
+
+addEventHandler("onResourceStop", resourceRoot, function()
+    reset()
+end)


### PR DESCRIPTION
## Summary
- add synchronized managed `fire` elements with duration/remaining time, strength, source/target, damage masks and server-owned propagation state
- render managed fires through GTA fire FX while preserving the legacy native client fire path
- add cancellable `onClientFireDamage` policy handling and a dedicated `fire-test` runtime harness
- keep remaining lifetime clock-independent so late-join snapshots resume from server-maintained remaining time

## Compatibility
- `createFire(x, y, z [, size])` on the client keeps the existing native GTA behavior and boolean result
- the options-table form creates a managed fire element
- normal GTA/Molotov fires remain on the native fire runtime

## Validation
- `test-resources/fire-test` provides `/firetest all`, `/firetest basic`, `/firetest late`, `/firetest status` and `/firetest reset`
- the harness emits explicit `[FIRETEST] PASS` / `[FIRETEST] FAIL` lines for lifecycle, setters, synchronization, expiry, propagation, damage policy and >60 simultaneous managed fires