### PR TITLE
Add player replay prototype harness

### DIFF
--- a/test-resources/replay-prototype/README.md
+++ b/test-resources/replay-prototype/README.md
@@ -1,0 +1,56 @@
+# Player replay prototype
+
+Client-side harness for validating an FPS-independent player replay before moving the recorder/playback path into native code.
+
+## Scope
+
+- Local player, on foot only.
+- Keeps up to the last 60 seconds in memory.
+- Samples at roughly 60 Hz using timestamps rather than playback frame numbers.
+- Records transform, velocity, camera, aim endpoint, weapon state and key control states.
+- Replays controls on a local ghost ped.
+- Uses 500 ms transform keyframes to measure/correct simulation drift.
+- Includes pause, resume, seek and a small debug overlay.
+
+No network upload, persistence, vehicles, surrounding entities or anti-cheat scoring are included in this prototype.
+
+## Test flow
+
+Start the resource, then run:
+
+```text
+/replayrec
+```
+
+Run around, sprint, jump, crouch, aim and fire for 20-60 seconds while staying on foot.
+
+Stop recording:
+
+```text
+/replaystop
+```
+
+Play it:
+
+```text
+/replayplay
+```
+
+Optional controls:
+
+```text
+/replaypause
+/replayresume
+/replayseek 15
+/replayplay 15
+/replaydebug
+/replayclear
+```
+
+The ghost is semi-transparent so the recorded path is easy to distinguish from the local player.
+
+## What to watch
+
+The overlay reports the buffered duration, sample count, soft corrections and hard resyncs. A useful first validation is to repeat the same recording while changing the client FPS limit before playback and compare the ghost trajectory and correction counts.
+
+The prototype intentionally keeps recording/playback logic isolated in a test resource. If the control-driven path proves stable enough, the next step is moving frame capture and the circular buffer into the client C++ layer, then exposing only replay handles/commands to Lua.

--- a/test-resources/replay-prototype/client.lua
+++ b/test-resources/replay-prototype/client.lua
@@ -1,54 +1,58 @@
 local BUFFER_DURATION_MS = 60000
 local SAMPLE_INTERVAL_MS = 16
-local KEYFRAME_INTERVAL_MS = 500
-
--- Control-driven playback correction policy.
--- Small drift is intentionally tolerated so GTA keeps ownership of locomotion/tasks.
-local SOFT_CORRECTION_DISTANCE = 0.30
-local HARD_CORRECTION_DISTANCE = 3.00
-local MAX_HORIZONTAL_CORRECTION_PER_FRAME = 0.025
-local MAX_VERTICAL_CORRECTION_PER_FRAME = 0.012
-local VERTICAL_CORRECTION_THRESHOLD = 0.30
+local HARD_RESYNC_DISTANCE = 8.0
+local VELOCITY_ASSIST_START = 1.0
+local MAX_VELOCITY_ASSIST = 0.018
 
 local CONTROL_NAMES = {
-    "forwards",
-    "backwards",
-    "left",
-    "right",
-    "sprint",
-    "walk",
-    "jump",
-    "crouch",
-    "aim_weapon",
-    "fire",
-    "action",
+    "forwards", "backwards", "left", "right", "sprint", "walk",
+    "jump", "crouch", "aim_weapon", "fire", "action",
+}
+
+-- Normal GTA locomotion animations are task-driven. Moving a ped with
+-- setElementPosition does not automatically select them, so hybrid playback
+-- mirrors the recorded move state onto the smooth tracked ghost.
+local MOVE_ANIMATIONS = {
+    stand = {"PED", "IDLE_stance", true},
+    walk = {"PED", "WALK_player", true},
+    jog = {"PED", "RUN_player", true},
+    sprint = {"PED", "sprint_civi", true},
+    jump = {"PED", "JUMP_launch", false},
+    fall = {"PED", "FALL_fall", true},
+    land = {"PED", "JUMP_land", false},
 }
 
 local state = {
     recording = false,
     recordStartedAt = 0,
     lastSampleAt = 0,
-    lastKeyframeAt = 0,
     frames = {},
     firstFrame = 1,
+
     playback = false,
     paused = false,
     playbackStartedAt = 0,
-    pausedAt = 0,
     playbackOffset = 0,
     playbackIndex = 1,
+    replayMode = "hybrid",
+
     ghost = nil,
     ghostWeapon = nil,
+    ghostMoveState = nil,
+
     corrections = 0,
     hardResyncs = 0,
     currentDrift = 0,
     maxDrift = 0,
-    replayMode = "tracked",
     debug = true,
 }
 
 local function chat(message, r, g, b)
     outputChatBox("[REPLAY] " .. message, r or 120, g or 220, b or 255)
+end
+
+local function clamp(value, minimum, maximum)
+    return math.max(minimum, math.min(maximum, value))
 end
 
 local function distance3D(ax, ay, az, bx, by, bz)
@@ -83,10 +87,19 @@ local function clearControls(ped)
     if not isElement(ped) then
         return
     end
-
     for _, control in ipairs(CONTROL_NAMES) do
         setPedControlState(ped, control, false)
     end
+end
+
+local function getMoveState(ped)
+    if type(getPedMoveState) == "function" then
+        local ok, moveState = pcall(getPedMoveState, ped)
+        if ok and type(moveState) == "string" then
+            return moveState
+        end
+    end
+    return "stand"
 end
 
 local function getAimTarget(player, cameraTargetX, cameraTargetY, cameraTargetZ)
@@ -96,7 +109,6 @@ local function getAimTarget(player, cameraTargetX, cameraTargetY, cameraTargetZ)
             return x, y, z
         end
     end
-
     return cameraTargetX, cameraTargetY, cameraTargetZ
 end
 
@@ -111,39 +123,22 @@ local function captureFrame(now)
     local vx, vy, vz = getElementVelocity(player)
     local cx, cy, cz, tx, ty, tz = getCameraMatrix()
     local aimX, aimY, aimZ = getAimTarget(player, tx, ty, tz)
-    local timestamp = now - state.recordStartedAt
-    local keyframe = timestamp - state.lastKeyframeAt >= KEYFRAME_INTERVAL_MS or #state.frames == 0
-
-    if keyframe then
-        state.lastKeyframeAt = timestamp
-    end
 
     state.frames[#state.frames + 1] = {
-        t = timestamp,
-        x = x,
-        y = y,
-        z = z,
-        rx = rx,
-        ry = ry,
-        rz = rz,
-        vx = vx,
-        vy = vy,
-        vz = vz,
-        cx = cx,
-        cy = cy,
-        cz = cz,
-        tx = tx,
-        ty = ty,
-        tz = tz,
-        aimX = aimX,
-        aimY = aimY,
-        aimZ = aimZ,
+        t = now - state.recordStartedAt,
+        x = x, y = y, z = z,
+        rx = rx, ry = ry, rz = rz,
+        vx = vx, vy = vy, vz = vz,
+        cx = cx, cy = cy, cz = cz,
+        tx = tx, ty = ty, tz = tz,
+        aimX = aimX, aimY = aimY, aimZ = aimZ,
         weapon = getPedWeapon(player),
         weaponSlot = getPedWeaponSlot(player),
         controls = getControls(player),
-        keyframe = keyframe,
+        moveState = getMoveState(player),
     }
 
+    local timestamp = state.frames[#state.frames].t
     local cutoff = timestamp - BUFFER_DURATION_MS
     while state.firstFrame < #state.frames and state.frames[state.firstFrame + 1].t < cutoff do
         state.firstFrame = state.firstFrame + 1
@@ -162,11 +157,13 @@ end
 local function stopGhost()
     if isElement(state.ghost) then
         clearControls(state.ghost)
+        setPedAnimation(state.ghost, false)
         destroyElement(state.ghost)
     end
 
     state.ghost = nil
     state.ghostWeapon = nil
+    state.ghostMoveState = nil
     state.playback = false
     state.paused = false
     state.playbackIndex = 1
@@ -175,16 +172,11 @@ local function stopGhost()
 end
 
 local function ensureGhostWeapon(frame)
-    if not isElement(state.ghost) or not frame then
-        return
-    end
-
-    if state.ghostWeapon == frame.weapon then
+    if not isElement(state.ghost) or not frame or state.ghostWeapon == frame.weapon then
         return
     end
 
     state.ghostWeapon = frame.weapon
-
     if frame.weapon and frame.weapon > 0 and type(givePedWeapon) == "function" then
         givePedWeapon(state.ghost, frame.weapon, 9999, true)
     elseif type(setPedWeaponSlot) == "function" then
@@ -192,14 +184,38 @@ local function ensureGhostWeapon(frame)
     end
 end
 
+local function applyMoveAnimation(frame)
+    if not isElement(state.ghost) then
+        return
+    end
+
+    local moveState = frame.moveState or "stand"
+    if state.ghostMoveState == moveState then
+        return
+    end
+    state.ghostMoveState = moveState
+
+    -- Crouch/aim are better left to GTA controls because their weapon-specific
+    -- upper body pose matters more than a generic animation replacement.
+    if moveState == "crouch" or frame.controls[9] then
+        setPedAnimation(state.ghost, false)
+        return
+    end
+
+    local animation = MOVE_ANIMATIONS[moveState]
+    if not animation then
+        setPedAnimation(state.ghost, false)
+        return
+    end
+
+    setPedAnimation(state.ghost, animation[1], animation[2], -1, animation[3], true, false, false)
+end
+
 local function getReplayBounds()
     if #state.frames < 2 then
         return nil
     end
-
-    local first = state.frames[state.firstFrame]
-    local last = state.frames[#state.frames]
-    return first, last
+    return state.frames[state.firstFrame], state.frames[#state.frames]
 end
 
 local function findPlaybackFrames(time)
@@ -212,7 +228,6 @@ local function findPlaybackFrames(time)
         state.playbackIndex = state.firstFrame
         return first, first, 0
     end
-
     if time >= last.t then
         return last, last, 0
     end
@@ -221,18 +236,15 @@ local function findPlaybackFrames(time)
     while index < #state.frames and state.frames[index + 1].t <= time do
         index = index + 1
     end
-
     while index > state.firstFrame and state.frames[index].t > time do
         index = index - 1
     end
 
     state.playbackIndex = index
-
     local a = state.frames[index]
     local b = state.frames[math.min(index + 1, #state.frames)]
     local duration = math.max(b.t - a.t, 1)
-    local alpha = math.max(0, math.min(1, (time - a.t) / duration))
-    return a, b, alpha
+    return a, b, clamp((time - a.t) / duration, 0, 1)
 end
 
 local function spawnGhost()
@@ -242,9 +254,7 @@ local function spawnGhost()
     end
 
     stopGhost()
-
-    local model = getElementModel(localPlayer)
-    local ghost = createPed(model, first.x, first.y, first.z, first.rz)
+    local ghost = createPed(getElementModel(localPlayer), first.x, first.y, first.z, first.rz)
     if not isElement(ghost) then
         chat("Could not create replay ghost.", 255, 80, 80)
         return false
@@ -258,7 +268,6 @@ local function spawnGhost()
     setElementVelocity(ghost, first.vx, first.vy, first.vz)
     ensureGhostWeapon(first)
     applyControls(ghost, first.controls)
-
     return true
 end
 
@@ -268,17 +277,14 @@ local function startPlayback(offsetMs)
         chat("Need at least two recorded samples first. Use /replayrec.", 255, 120, 80)
         return
     end
-
     if not spawnGhost() then
         return
     end
 
     offsetMs = tonumber(offsetMs) or 0
-    offsetMs = math.max(first.t, math.min(last.t, first.t + offsetMs))
-
     state.playback = true
     state.paused = false
-    state.playbackOffset = offsetMs
+    state.playbackOffset = clamp(first.t + offsetMs, first.t, last.t)
     state.playbackStartedAt = getTickCount()
     state.playbackIndex = state.firstFrame
     state.corrections = 0
@@ -286,37 +292,15 @@ local function startPlayback(offsetMs)
     state.currentDrift = 0
     state.maxDrift = 0
 
-    chat(("Playback started (%s mode, %.2fs buffered, %d samples)."):format(state.replayMode, (last.t - first.t) / 1000, #state.frames - state.firstFrame + 1), 120, 255, 120)
-end
-
-local function seekPlayback(seconds)
-    local first, last = getReplayBounds()
-    if not first then
-        return
-    end
-
-    local offset = math.max(0, tonumber(seconds) or 0) * 1000
-    local target = math.min(last.t, first.t + offset)
-
-    state.playbackOffset = target
-    state.playbackStartedAt = getTickCount()
-    state.playbackIndex = state.firstFrame
-
-    local frame = select(1, findPlaybackFrames(target))
-    if frame and isElement(state.ghost) then
-        setElementPosition(state.ghost, frame.x, frame.y, frame.z)
-        setElementRotation(state.ghost, frame.rx, frame.ry, frame.rz)
-        setElementVelocity(state.ghost, frame.vx, frame.vy, frame.vz)
-        ensureGhostWeapon(frame)
-        applyControls(state.ghost, frame.controls)
-    end
+    chat(("Playback started (%s mode, %.2fs buffered, %d samples)."):format(
+        state.replayMode, (last.t - first.t) / 1000, #state.frames - state.firstFrame + 1
+    ), 120, 255, 120)
 end
 
 local function getPlaybackTime(now)
     if state.paused then
         return state.playbackOffset
     end
-
     return state.playbackOffset + (now - state.playbackStartedAt)
 end
 
@@ -324,20 +308,22 @@ local function updateTrackedMovement(a, b, alpha)
     local targetX = lerp(a.x, b.x, alpha)
     local targetY = lerp(a.y, b.y, alpha)
     local targetZ = lerp(a.z, b.z, alpha)
-    local targetRX = lerpAngle(a.rx, b.rx, alpha)
-    local targetRY = lerpAngle(a.ry, b.ry, alpha)
-    local targetRZ = lerpAngle(a.rz, b.rz, alpha)
-    local targetVX = lerp(a.vx, b.vx, alpha)
-    local targetVY = lerp(a.vy, b.vy, alpha)
-    local targetVZ = lerp(a.vz, b.vz, alpha)
-
     local gx, gy, gz = getElementPosition(state.ghost)
+
     state.currentDrift = distance3D(gx, gy, gz, targetX, targetY, targetZ)
     state.maxDrift = math.max(state.maxDrift, state.currentDrift)
 
     setElementPosition(state.ghost, targetX, targetY, targetZ)
-    setElementRotation(state.ghost, targetRX, targetRY, targetRZ)
-    setElementVelocity(state.ghost, targetVX, targetVY, targetVZ)
+    setElementRotation(state.ghost,
+        lerpAngle(a.rx, b.rx, alpha),
+        lerpAngle(a.ry, b.ry, alpha),
+        lerpAngle(a.rz, b.rz, alpha)
+    )
+    setElementVelocity(state.ghost,
+        lerp(a.vx, b.vx, alpha),
+        lerp(a.vy, b.vy, alpha),
+        lerp(a.vz, b.vz, alpha)
+    )
 end
 
 local function updateControlDrivenMovement(a, b, alpha)
@@ -345,50 +331,41 @@ local function updateControlDrivenMovement(a, b, alpha)
     local targetY = lerp(a.y, b.y, alpha)
     local targetZ = lerp(a.z, b.z, alpha)
     local gx, gy, gz = getElementPosition(state.ghost)
+    local dx, dy, dz = targetX - gx, targetY - gy, targetZ - gz
+    local drift = math.sqrt(dx * dx + dy * dy + dz * dz)
 
-    local dx = targetX - gx
-    local dy = targetY - gy
-    local dz = targetZ - gz
-    local horizontalDistance = math.sqrt(dx * dx + dy * dy)
-    local errorDistance = math.sqrt(horizontalDistance * horizontalDistance + dz * dz)
+    state.currentDrift = drift
+    state.maxDrift = math.max(state.maxDrift, drift)
 
-    state.currentDrift = errorDistance
-    state.maxDrift = math.max(state.maxDrift, errorDistance)
-
-    if errorDistance > HARD_CORRECTION_DISTANCE then
-        -- Only large divergence is allowed to snap. This is a safety net, not normal playback.
+    -- Do not touch position during normal controls playback. setElementPosition
+    -- resets/interferes with the ped locomotion task, which is what caused the
+    -- repeated teleport + animation restart behaviour in the first prototype.
+    if drift > HARD_RESYNC_DISTANCE then
         setElementPosition(state.ghost, targetX, targetY, targetZ)
-        setElementRotation(state.ghost, lerpAngle(a.rx, b.rx, alpha), lerpAngle(a.ry, b.ry, alpha), lerpAngle(a.rz, b.rz, alpha))
+        setElementRotation(state.ghost, 0, 0, lerpAngle(a.rz, b.rz, alpha))
         setElementVelocity(state.ghost, lerp(a.vx, b.vx, alpha), lerp(a.vy, b.vy, alpha), lerp(a.vz, b.vz, alpha))
         state.hardResyncs = state.hardResyncs + 1
         return
     end
 
-    if errorDistance <= SOFT_CORRECTION_DISTANCE then
+    if drift <= VELOCITY_ASSIST_START then
         return
     end
 
-    -- Correct continuously by a tiny capped amount rather than moving a percentage
-    -- of the whole error every keyframe. This preserves native locomotion and avoids
-    -- the visible half-meter snaps produced by sparse setElementPosition calls.
-    local correctionX, correctionY, correctionZ = 0, 0, 0
-
-    if horizontalDistance > 0.001 then
-        local horizontalStep = math.min(MAX_HORIZONTAL_CORRECTION_PER_FRAME, horizontalDistance - math.min(horizontalDistance, SOFT_CORRECTION_DISTANCE))
-        if horizontalStep > 0 then
-            correctionX = dx / horizontalDistance * horizontalStep
-            correctionY = dy / horizontalDistance * horizontalStep
-        end
+    local vx, vy, vz = getElementVelocity(state.ghost)
+    local horizontal = math.sqrt(dx * dx + dy * dy)
+    if horizontal > 0.001 then
+        local assist = math.min(MAX_VELOCITY_ASSIST, (horizontal - VELOCITY_ASSIST_START) * 0.004)
+        vx = vx + dx / horizontal * assist
+        vy = vy + dy / horizontal * assist
     end
 
-    if math.abs(dz) > VERTICAL_CORRECTION_THRESHOLD then
-        correctionZ = math.max(-MAX_VERTICAL_CORRECTION_PER_FRAME, math.min(MAX_VERTICAL_CORRECTION_PER_FRAME, dz))
+    if math.abs(dz) > 1.0 then
+        vz = vz + clamp(dz * 0.002, -0.006, 0.006)
     end
 
-    if correctionX ~= 0 or correctionY ~= 0 or correctionZ ~= 0 then
-        setElementPosition(state.ghost, gx + correctionX, gy + correctionY, gz + correctionZ)
-        state.corrections = state.corrections + 1
-    end
+    setElementVelocity(state.ghost, vx, vy, vz)
+    state.corrections = state.corrections + 1
 end
 
 local function updatePlayback(now)
@@ -405,11 +382,11 @@ local function updatePlayback(now)
     local playbackTime = getPlaybackTime(now)
     if playbackTime >= last.t then
         clearControls(state.ghost)
+        setPedAnimation(state.ghost, false)
         state.playback = false
         chat(("Playback complete. Max drift %.2fm."):format(state.maxDrift), 120, 255, 120)
         return
     end
-
     if state.paused then
         return
     end
@@ -419,31 +396,64 @@ local function updatePlayback(now)
         return
     end
 
-    applyControls(state.ghost, a.controls)
     ensureGhostWeapon(a)
 
-    if type(setPedAimTarget) == "function" and (a.controls[9] or a.controls[10]) then
-        local aimX = lerp(a.aimX, b.aimX, alpha)
-        local aimY = lerp(a.aimY, b.aimY, alpha)
-        local aimZ = lerp(a.aimZ, b.aimZ, alpha)
-        setPedAimTarget(state.ghost, aimX, aimY, aimZ)
-    end
-
     if state.replayMode == "controls" then
+        -- Pure diagnostic mode: GTA owns locomotion and we only bias velocity.
+        setPedAnimation(state.ghost, false)
+        state.ghostMoveState = nil
+        applyControls(state.ghost, a.controls)
         updateControlDrivenMovement(a, b, alpha)
     else
+        -- Smooth recorded trajectory. Hybrid additionally mirrors locomotion
+        -- animations while controls keep crouch/aim/fire states available.
         updateTrackedMovement(a, b, alpha)
+        applyControls(state.ghost, a.controls)
+        if state.replayMode == "hybrid" then
+            applyMoveAnimation(a)
+        else
+            setPedAnimation(state.ghost, false)
+            state.ghostMoveState = nil
+        end
+    end
+
+    if type(setPedAimTarget) == "function" and (a.controls[9] or a.controls[10]) then
+        setPedAimTarget(state.ghost,
+            lerp(a.aimX, b.aimX, alpha),
+            lerp(a.aimY, b.aimY, alpha),
+            lerp(a.aimZ, b.aimZ, alpha)
+        )
+    end
+end
+
+local function seekPlayback(seconds)
+    local first, last = getReplayBounds()
+    if not first or not isElement(state.ghost) then
+        return
+    end
+
+    local target = math.min(last.t, first.t + math.max(0, tonumber(seconds) or 0) * 1000)
+    state.playbackOffset = target
+    state.playbackStartedAt = getTickCount()
+    state.playbackIndex = state.firstFrame
+    state.ghostMoveState = nil
+
+    local frame = select(1, findPlaybackFrames(target))
+    if frame then
+        setElementPosition(state.ghost, frame.x, frame.y, frame.z)
+        setElementRotation(state.ghost, frame.rx, frame.ry, frame.rz)
+        setElementVelocity(state.ghost, frame.vx, frame.vy, frame.vz)
+        ensureGhostWeapon(frame)
+        applyControls(state.ghost, frame.controls)
     end
 end
 
 addEventHandler("onClientPreRender", root, function()
     local now = getTickCount()
-
     if state.recording and now - state.lastSampleAt >= SAMPLE_INTERVAL_MS then
         state.lastSampleAt = now
         captureFrame(now)
     end
-
     updatePlayback(now)
 end)
 
@@ -457,29 +467,15 @@ addEventHandler("onClientRender", root, function()
     local sampleCount = first and (#state.frames - state.firstFrame + 1) or 0
     local playbackTime = state.playback and getPlaybackTime(getTickCount()) / 1000 or 0
 
-    dxDrawText(
-        ("Replay prototype\nrecording: %s | samples: %d | buffer: %.2fs\nplayback: %s%s | mode: %s | time: %.2fs\ndrift: %.2fm | max: %.2fm | correction frames: %d | hard resyncs: %d")
-            :format(
-                tostring(state.recording),
-                sampleCount,
-                buffered,
-                tostring(state.playback),
-                state.paused and " (paused)" or "",
-                state.replayMode,
-                playbackTime,
-                state.currentDrift,
-                state.maxDrift,
-                state.corrections,
-                state.hardResyncs
-            ),
-        24,
-        180,
-        800,
-        320,
-        tocolor(255, 255, 255, 230),
-        1.0,
-        "default-bold"
-    )
+    dxDrawText(("Replay prototype\nrecording: %s | samples: %d | buffer: %.2fs\nplayback: %s%s | mode: %s | time: %.2fs\nmove: %s | drift: %.2fm | max: %.2fm | corrections: %d | hard resyncs: %d")
+        :format(
+            tostring(state.recording), sampleCount, buffered,
+            tostring(state.playback), state.paused and " (paused)" or "",
+            state.replayMode, playbackTime,
+            tostring(state.ghostMoveState or "native"), state.currentDrift, state.maxDrift,
+            state.corrections, state.hardResyncs
+        ),
+        24, 180, 800, 330, tocolor(255, 255, 255, 230), 1.0, "default-bold")
 end)
 
 addCommandHandler("replayrec", function()
@@ -489,7 +485,6 @@ addCommandHandler("replayrec", function()
     state.recording = true
     state.recordStartedAt = getTickCount()
     state.lastSampleAt = 0
-    state.lastKeyframeAt = -KEYFRAME_INTERVAL_MS
     chat("Recording started. On-foot only; keeps the last 60 seconds.", 120, 255, 120)
 end)
 
@@ -520,11 +515,10 @@ addCommandHandler("replaypause", function()
     if not state.playback or state.paused then
         return
     end
-
     state.playbackOffset = getPlaybackTime(getTickCount())
     state.paused = true
-    state.pausedAt = getTickCount()
     clearControls(state.ghost)
+    setPedAnimation(state.ghost, false)
     setElementFrozen(state.ghost, true)
     chat("Playback paused.")
 end)
@@ -533,9 +527,9 @@ addCommandHandler("replayresume", function()
     if not state.playback or not state.paused then
         return
     end
-
     state.paused = false
     state.playbackStartedAt = getTickCount()
+    state.ghostMoveState = nil
     setElementFrozen(state.ghost, false)
     chat("Playback resumed.")
 end)
@@ -545,22 +539,22 @@ addCommandHandler("replayseek", function(_, seconds)
         chat("Start playback first with /replayplay.", 255, 120, 80)
         return
     end
-
     seekPlayback(seconds)
     chat(("Seeked to %.2fs."):format(tonumber(seconds) or 0))
 end)
 
 addCommandHandler("replaymode", function(_, mode)
     mode = mode and mode:lower() or nil
-    if mode ~= "tracked" and mode ~= "controls" then
-        chat("Usage: /replaymode [tracked|controls]. Current: " .. state.replayMode, 255, 220, 100)
+    if mode ~= "hybrid" and mode ~= "tracked" and mode ~= "controls" then
+        chat("Usage: /replaymode [hybrid|tracked|controls]. Current: " .. state.replayMode, 255, 220, 100)
         return
     end
 
     state.replayMode = mode
     state.currentDrift = 0
     state.maxDrift = 0
-    chat("Replay mode: " .. mode .. (mode == "tracked" and " (smooth recorded trajectory)." or " (native GTA locomotion + continuous drift correction)."), 120, 255, 120)
+    state.ghostMoveState = nil
+    chat("Replay mode: " .. mode, 120, 255, 120)
 end)
 
 addCommandHandler("replaydebug", function()

--- a/test-resources/replay-prototype/client.lua
+++ b/test-resources/replay-prototype/client.lua
@@ -1,0 +1,490 @@
+local BUFFER_DURATION_MS = 60000
+local SAMPLE_INTERVAL_MS = 16
+local KEYFRAME_INTERVAL_MS = 500
+local SOFT_CORRECTION_DISTANCE = 0.15
+local HARD_CORRECTION_DISTANCE = 0.90
+
+local CONTROL_NAMES = {
+    "forwards",
+    "backwards",
+    "left",
+    "right",
+    "sprint",
+    "walk",
+    "jump",
+    "crouch",
+    "aim_weapon",
+    "fire",
+    "action",
+}
+
+local state = {
+    recording = false,
+    recordStartedAt = 0,
+    lastSampleAt = 0,
+    lastKeyframeAt = 0,
+    frames = {},
+    firstFrame = 1,
+    playback = false,
+    paused = false,
+    playbackStartedAt = 0,
+    pausedAt = 0,
+    playbackOffset = 0,
+    playbackIndex = 1,
+    ghost = nil,
+    ghostWeapon = nil,
+    corrections = 0,
+    hardResyncs = 0,
+    debug = true,
+}
+
+local function chat(message, r, g, b)
+    outputChatBox("[REPLAY] " .. message, r or 120, g or 220, b or 255)
+end
+
+local function distance3D(ax, ay, az, bx, by, bz)
+    local dx, dy, dz = ax - bx, ay - by, az - bz
+    return math.sqrt(dx * dx + dy * dy + dz * dz)
+end
+
+local function lerp(a, b, t)
+    return a + (b - a) * t
+end
+
+local function lerpAngle(a, b, t)
+    local delta = (b - a + 180) % 360 - 180
+    return a + delta * t
+end
+
+local function getControls(ped)
+    local controls = {}
+    for i, control in ipairs(CONTROL_NAMES) do
+        controls[i] = getPedControlState(ped, control) == true
+    end
+    return controls
+end
+
+local function applyControls(ped, controls)
+    for i, control in ipairs(CONTROL_NAMES) do
+        setPedControlState(ped, control, controls[i] == true)
+    end
+end
+
+local function clearControls(ped)
+    if not isElement(ped) then
+        return
+    end
+
+    for _, control in ipairs(CONTROL_NAMES) do
+        setPedControlState(ped, control, false)
+    end
+end
+
+local function getAimTarget(player, cameraTargetX, cameraTargetY, cameraTargetZ)
+    if type(getPedTargetEnd) == "function" then
+        local ok, x, y, z = pcall(getPedTargetEnd, player)
+        if ok and x then
+            return x, y, z
+        end
+    end
+
+    return cameraTargetX, cameraTargetY, cameraTargetZ
+end
+
+local function captureFrame(now)
+    local player = localPlayer
+    if not isElement(player) or isPedInVehicle(player) or isPedDead(player) then
+        return
+    end
+
+    local x, y, z = getElementPosition(player)
+    local rx, ry, rz = getElementRotation(player)
+    local vx, vy, vz = getElementVelocity(player)
+    local cx, cy, cz, tx, ty, tz = getCameraMatrix()
+    local aimX, aimY, aimZ = getAimTarget(player, tx, ty, tz)
+    local timestamp = now - state.recordStartedAt
+    local keyframe = timestamp - state.lastKeyframeAt >= KEYFRAME_INTERVAL_MS or #state.frames == 0
+
+    if keyframe then
+        state.lastKeyframeAt = timestamp
+    end
+
+    state.frames[#state.frames + 1] = {
+        t = timestamp,
+        x = x,
+        y = y,
+        z = z,
+        rx = rx,
+        ry = ry,
+        rz = rz,
+        vx = vx,
+        vy = vy,
+        vz = vz,
+        cx = cx,
+        cy = cy,
+        cz = cz,
+        tx = tx,
+        ty = ty,
+        tz = tz,
+        aimX = aimX,
+        aimY = aimY,
+        aimZ = aimZ,
+        weapon = getPedWeapon(player),
+        weaponSlot = getPedWeaponSlot(player),
+        controls = getControls(player),
+        keyframe = keyframe,
+    }
+
+    local cutoff = timestamp - BUFFER_DURATION_MS
+    while state.firstFrame < #state.frames and state.frames[state.firstFrame + 1].t < cutoff do
+        state.firstFrame = state.firstFrame + 1
+    end
+
+    if state.firstFrame > 512 then
+        local compacted = {}
+        for i = state.firstFrame, #state.frames do
+            compacted[#compacted + 1] = state.frames[i]
+        end
+        state.frames = compacted
+        state.firstFrame = 1
+    end
+end
+
+local function stopGhost()
+    if isElement(state.ghost) then
+        clearControls(state.ghost)
+        destroyElement(state.ghost)
+    end
+
+    state.ghost = nil
+    state.ghostWeapon = nil
+    state.playback = false
+    state.paused = false
+    state.playbackIndex = 1
+    state.playbackOffset = 0
+end
+
+local function ensureGhostWeapon(frame)
+    if not isElement(state.ghost) or not frame then
+        return
+    end
+
+    if state.ghostWeapon == frame.weapon then
+        return
+    end
+
+    state.ghostWeapon = frame.weapon
+
+    if frame.weapon and frame.weapon > 0 and type(givePedWeapon) == "function" then
+        givePedWeapon(state.ghost, frame.weapon, 9999, true)
+    elseif type(setPedWeaponSlot) == "function" then
+        setPedWeaponSlot(state.ghost, frame.weaponSlot or 0)
+    end
+end
+
+local function getReplayBounds()
+    if #state.frames < 2 then
+        return nil
+    end
+
+    local first = state.frames[state.firstFrame]
+    local last = state.frames[#state.frames]
+    return first, last
+end
+
+local function findPlaybackFrames(time)
+    local first, last = getReplayBounds()
+    if not first then
+        return nil
+    end
+
+    if time <= first.t then
+        state.playbackIndex = state.firstFrame
+        return first, first, 0
+    end
+
+    if time >= last.t then
+        return last, last, 0
+    end
+
+    local index = math.max(state.playbackIndex, state.firstFrame)
+    while index < #state.frames and state.frames[index + 1].t <= time do
+        index = index + 1
+    end
+
+    while index > state.firstFrame and state.frames[index].t > time do
+        index = index - 1
+    end
+
+    state.playbackIndex = index
+
+    local a = state.frames[index]
+    local b = state.frames[math.min(index + 1, #state.frames)]
+    local duration = math.max(b.t - a.t, 1)
+    local alpha = math.max(0, math.min(1, (time - a.t) / duration))
+    return a, b, alpha
+end
+
+local function spawnGhost()
+    local first = state.frames[state.firstFrame]
+    if not first then
+        return false
+    end
+
+    stopGhost()
+
+    local model = getElementModel(localPlayer)
+    local ghost = createPed(model, first.x, first.y, first.z, first.rz)
+    if not isElement(ghost) then
+        chat("Could not create replay ghost.", 255, 80, 80)
+        return false
+    end
+
+    state.ghost = ghost
+    setElementInterior(ghost, getElementInterior(localPlayer))
+    setElementDimension(ghost, getElementDimension(localPlayer))
+    setElementCollisionsEnabled(ghost, true)
+    setElementAlpha(ghost, 190)
+    setElementVelocity(ghost, first.vx, first.vy, first.vz)
+    ensureGhostWeapon(first)
+    applyControls(ghost, first.controls)
+
+    return true
+end
+
+local function startPlayback(offsetMs)
+    local first, last = getReplayBounds()
+    if not first then
+        chat("Need at least two recorded samples first. Use /replayrec.", 255, 120, 80)
+        return
+    end
+
+    if not spawnGhost() then
+        return
+    end
+
+    offsetMs = tonumber(offsetMs) or 0
+    offsetMs = math.max(first.t, math.min(last.t, first.t + offsetMs))
+
+    state.playback = true
+    state.paused = false
+    state.playbackOffset = offsetMs
+    state.playbackStartedAt = getTickCount()
+    state.playbackIndex = state.firstFrame
+    state.corrections = 0
+    state.hardResyncs = 0
+
+    chat(("Playback started (%.2fs buffered, %d samples)."):format((last.t - first.t) / 1000, #state.frames - state.firstFrame + 1), 120, 255, 120)
+end
+
+local function seekPlayback(seconds)
+    local first, last = getReplayBounds()
+    if not first then
+        return
+    end
+
+    local offset = math.max(0, tonumber(seconds) or 0) * 1000
+    local target = math.min(last.t, first.t + offset)
+
+    state.playbackOffset = target
+    state.playbackStartedAt = getTickCount()
+    state.playbackIndex = state.firstFrame
+
+    local frame = select(1, findPlaybackFrames(target))
+    if frame and isElement(state.ghost) then
+        setElementPosition(state.ghost, frame.x, frame.y, frame.z)
+        setElementRotation(state.ghost, frame.rx, frame.ry, frame.rz)
+        setElementVelocity(state.ghost, frame.vx, frame.vy, frame.vz)
+        ensureGhostWeapon(frame)
+        applyControls(state.ghost, frame.controls)
+    end
+end
+
+local function getPlaybackTime(now)
+    if state.paused then
+        return state.playbackOffset
+    end
+
+    return state.playbackOffset + (now - state.playbackStartedAt)
+end
+
+local function updatePlayback(now)
+    if not state.playback or not isElement(state.ghost) then
+        return
+    end
+
+    local first, last = getReplayBounds()
+    if not first then
+        stopGhost()
+        return
+    end
+
+    local playbackTime = getPlaybackTime(now)
+    if playbackTime >= last.t then
+        clearControls(state.ghost)
+        state.playback = false
+        chat("Playback complete.", 120, 255, 120)
+        return
+    end
+
+    if state.paused then
+        return
+    end
+
+    local a, b, alpha = findPlaybackFrames(playbackTime)
+    if not a then
+        return
+    end
+
+    applyControls(state.ghost, a.controls)
+    ensureGhostWeapon(a)
+
+    if type(setPedAimTarget) == "function" and (a.controls[9] or a.controls[10]) then
+        local aimX = lerp(a.aimX, b.aimX, alpha)
+        local aimY = lerp(a.aimY, b.aimY, alpha)
+        local aimZ = lerp(a.aimZ, b.aimZ, alpha)
+        setPedAimTarget(state.ghost, aimX, aimY, aimZ)
+    end
+
+    if a.keyframe then
+        local gx, gy, gz = getElementPosition(state.ghost)
+        local errorDistance = distance3D(gx, gy, gz, a.x, a.y, a.z)
+
+        if errorDistance > HARD_CORRECTION_DISTANCE then
+            setElementPosition(state.ghost, a.x, a.y, a.z)
+            setElementRotation(state.ghost, a.rx, a.ry, a.rz)
+            setElementVelocity(state.ghost, a.vx, a.vy, a.vz)
+            state.hardResyncs = state.hardResyncs + 1
+        elseif errorDistance > SOFT_CORRECTION_DISTANCE then
+            local correction = math.min(0.35, errorDistance * 0.25)
+            setElementPosition(
+                state.ghost,
+                lerp(gx, a.x, correction),
+                lerp(gy, a.y, correction),
+                lerp(gz, a.z, correction)
+            )
+            local grx, gry, grz = getElementRotation(state.ghost)
+            setElementRotation(state.ghost, lerpAngle(grx, a.rx, correction), lerpAngle(gry, a.ry, correction), lerpAngle(grz, a.rz, correction))
+            state.corrections = state.corrections + 1
+        end
+    end
+end
+
+addEventHandler("onClientPreRender", root, function()
+    local now = getTickCount()
+
+    if state.recording and now - state.lastSampleAt >= SAMPLE_INTERVAL_MS then
+        state.lastSampleAt = now
+        captureFrame(now)
+    end
+
+    updatePlayback(now)
+end)
+
+addEventHandler("onClientRender", root, function()
+    if not state.debug then
+        return
+    end
+
+    local first, last = getReplayBounds()
+    local buffered = first and ((last.t - first.t) / 1000) or 0
+    local sampleCount = first and (#state.frames - state.firstFrame + 1) or 0
+    local playbackTime = state.playback and getPlaybackTime(getTickCount()) / 1000 or 0
+
+    dxDrawText(
+        ("Replay prototype\nrecording: %s | samples: %d | buffer: %.2fs\nplayback: %s%s | time: %.2fs\ncorrections: %d | hard resyncs: %d")
+            :format(tostring(state.recording), sampleCount, buffered, tostring(state.playback), state.paused and " (paused)" or "", playbackTime, state.corrections, state.hardResyncs),
+        24,
+        180,
+        700,
+        300,
+        tocolor(255, 255, 255, 230),
+        1.0,
+        "default-bold"
+    )
+end)
+
+addCommandHandler("replayrec", function()
+    stopGhost()
+    state.frames = {}
+    state.firstFrame = 1
+    state.recording = true
+    state.recordStartedAt = getTickCount()
+    state.lastSampleAt = 0
+    state.lastKeyframeAt = -KEYFRAME_INTERVAL_MS
+    chat("Recording started. On-foot only; keeps the last 60 seconds.", 120, 255, 120)
+end)
+
+addCommandHandler("replaystop", function()
+    if state.recording then
+        state.recording = false
+        local first, last = getReplayBounds()
+        if first then
+            chat(("Recording stopped: %.2fs, %d samples."):format((last.t - first.t) / 1000, #state.frames - state.firstFrame + 1), 255, 220, 100)
+        else
+            chat("Recording stopped with no usable samples.", 255, 120, 80)
+        end
+        return
+    end
+
+    if state.playback or isElement(state.ghost) then
+        stopGhost()
+        chat("Playback stopped.", 255, 220, 100)
+    end
+end)
+
+addCommandHandler("replayplay", function(_, seconds)
+    state.recording = false
+    startPlayback((tonumber(seconds) or 0) * 1000)
+end)
+
+addCommandHandler("replaypause", function()
+    if not state.playback or state.paused then
+        return
+    end
+
+    state.playbackOffset = getPlaybackTime(getTickCount())
+    state.paused = true
+    state.pausedAt = getTickCount()
+    clearControls(state.ghost)
+    setElementFrozen(state.ghost, true)
+    chat("Playback paused.")
+end)
+
+addCommandHandler("replayresume", function()
+    if not state.playback or not state.paused then
+        return
+    end
+
+    state.paused = false
+    state.playbackStartedAt = getTickCount()
+    setElementFrozen(state.ghost, false)
+    chat("Playback resumed.")
+end)
+
+addCommandHandler("replayseek", function(_, seconds)
+    if not state.playback then
+        chat("Start playback first with /replayplay.", 255, 120, 80)
+        return
+    end
+
+    seekPlayback(seconds)
+    chat(("Seeked to %.2fs."):format(tonumber(seconds) or 0))
+end)
+
+addCommandHandler("replaydebug", function()
+    state.debug = not state.debug
+    chat("Debug overlay: " .. tostring(state.debug))
+end)
+
+addCommandHandler("replayclear", function()
+    state.recording = false
+    stopGhost()
+    state.frames = {}
+    state.firstFrame = 1
+    chat("Replay buffer cleared.")
+end)
+
+addEventHandler("onClientResourceStop", resourceRoot, function()
+    stopGhost()
+end)

--- a/test-resources/replay-prototype/client.lua
+++ b/test-resources/replay-prototype/client.lua
@@ -1,9 +1,14 @@
 local BUFFER_DURATION_MS = 60000
 local SAMPLE_INTERVAL_MS = 16
 local KEYFRAME_INTERVAL_MS = 500
-local SOFT_CORRECTION_DISTANCE = 0.75
-local HARD_CORRECTION_DISTANCE = 4.0
-local SOFT_CORRECTION_FACTOR = 0.08
+
+-- Control-driven playback correction policy.
+-- Small drift is intentionally tolerated so GTA keeps ownership of locomotion/tasks.
+local SOFT_CORRECTION_DISTANCE = 0.30
+local HARD_CORRECTION_DISTANCE = 3.00
+local MAX_HORIZONTAL_CORRECTION_PER_FRAME = 0.025
+local MAX_VERTICAL_CORRECTION_PER_FRAME = 0.012
+local VERTICAL_CORRECTION_THRESHOLD = 0.30
 
 local CONTROL_NAMES = {
     "forwards",
@@ -38,7 +43,6 @@ local state = {
     hardResyncs = 0,
     currentDrift = 0,
     maxDrift = 0,
-    lastCorrectedKeyframe = nil,
     replayMode = "tracked",
     debug = true,
 }
@@ -168,7 +172,6 @@ local function stopGhost()
     state.playbackIndex = 1
     state.playbackOffset = 0
     state.currentDrift = 0
-    state.lastCorrectedKeyframe = nil
 end
 
 local function ensureGhostWeapon(frame)
@@ -282,7 +285,6 @@ local function startPlayback(offsetMs)
     state.hardResyncs = 0
     state.currentDrift = 0
     state.maxDrift = 0
-    state.lastCorrectedKeyframe = nil
 
     chat(("Playback started (%s mode, %.2fs buffered, %d samples)."):format(state.replayMode, (last.t - first.t) / 1000, #state.frames - state.firstFrame + 1), 120, 255, 120)
 end
@@ -299,7 +301,6 @@ local function seekPlayback(seconds)
     state.playbackOffset = target
     state.playbackStartedAt = getTickCount()
     state.playbackIndex = state.firstFrame
-    state.lastCorrectedKeyframe = nil
 
     local frame = select(1, findPlaybackFrames(target))
     if frame and isElement(state.ghost) then
@@ -344,30 +345,48 @@ local function updateControlDrivenMovement(a, b, alpha)
     local targetY = lerp(a.y, b.y, alpha)
     local targetZ = lerp(a.z, b.z, alpha)
     local gx, gy, gz = getElementPosition(state.ghost)
-    local errorDistance = distance3D(gx, gy, gz, targetX, targetY, targetZ)
+
+    local dx = targetX - gx
+    local dy = targetY - gy
+    local dz = targetZ - gz
+    local horizontalDistance = math.sqrt(dx * dx + dy * dy)
+    local errorDistance = math.sqrt(horizontalDistance * horizontalDistance + dz * dz)
 
     state.currentDrift = errorDistance
     state.maxDrift = math.max(state.maxDrift, errorDistance)
 
-    if not a.keyframe or state.lastCorrectedKeyframe == a.t then
+    if errorDistance > HARD_CORRECTION_DISTANCE then
+        -- Only large divergence is allowed to snap. This is a safety net, not normal playback.
+        setElementPosition(state.ghost, targetX, targetY, targetZ)
+        setElementRotation(state.ghost, lerpAngle(a.rx, b.rx, alpha), lerpAngle(a.ry, b.ry, alpha), lerpAngle(a.rz, b.rz, alpha))
+        setElementVelocity(state.ghost, lerp(a.vx, b.vx, alpha), lerp(a.vy, b.vy, alpha), lerp(a.vz, b.vz, alpha))
+        state.hardResyncs = state.hardResyncs + 1
         return
     end
 
-    state.lastCorrectedKeyframe = a.t
+    if errorDistance <= SOFT_CORRECTION_DISTANCE then
+        return
+    end
 
-    if errorDistance > HARD_CORRECTION_DISTANCE then
-        setElementPosition(state.ghost, a.x, a.y, a.z)
-        setElementRotation(state.ghost, a.rx, a.ry, a.rz)
-        setElementVelocity(state.ghost, a.vx, a.vy, a.vz)
-        state.hardResyncs = state.hardResyncs + 1
-    elseif errorDistance > SOFT_CORRECTION_DISTANCE then
-        local correction = math.min(0.18, SOFT_CORRECTION_FACTOR + errorDistance * 0.02)
-        setElementPosition(
-            state.ghost,
-            lerp(gx, a.x, correction),
-            lerp(gy, a.y, correction),
-            lerp(gz, a.z, correction)
-        )
+    -- Correct continuously by a tiny capped amount rather than moving a percentage
+    -- of the whole error every keyframe. This preserves native locomotion and avoids
+    -- the visible half-meter snaps produced by sparse setElementPosition calls.
+    local correctionX, correctionY, correctionZ = 0, 0, 0
+
+    if horizontalDistance > 0.001 then
+        local horizontalStep = math.min(MAX_HORIZONTAL_CORRECTION_PER_FRAME, horizontalDistance - math.min(horizontalDistance, SOFT_CORRECTION_DISTANCE))
+        if horizontalStep > 0 then
+            correctionX = dx / horizontalDistance * horizontalStep
+            correctionY = dy / horizontalDistance * horizontalStep
+        end
+    end
+
+    if math.abs(dz) > VERTICAL_CORRECTION_THRESHOLD then
+        correctionZ = math.max(-MAX_VERTICAL_CORRECTION_PER_FRAME, math.min(MAX_VERTICAL_CORRECTION_PER_FRAME, dz))
+    end
+
+    if correctionX ~= 0 or correctionY ~= 0 or correctionZ ~= 0 then
+        setElementPosition(state.ghost, gx + correctionX, gy + correctionY, gz + correctionZ)
         state.corrections = state.corrections + 1
     end
 end
@@ -439,7 +458,7 @@ addEventHandler("onClientRender", root, function()
     local playbackTime = state.playback and getPlaybackTime(getTickCount()) / 1000 or 0
 
     dxDrawText(
-        ("Replay prototype\nrecording: %s | samples: %d | buffer: %.2fs\nplayback: %s%s | mode: %s | time: %.2fs\ndrift: %.2fm | max: %.2fm | corrections: %d | hard resyncs: %d")
+        ("Replay prototype\nrecording: %s | samples: %d | buffer: %.2fs\nplayback: %s%s | mode: %s | time: %.2fs\ndrift: %.2fm | max: %.2fm | correction frames: %d | hard resyncs: %d")
             :format(
                 tostring(state.recording),
                 sampleCount,
@@ -455,7 +474,7 @@ addEventHandler("onClientRender", root, function()
             ),
         24,
         180,
-        760,
+        800,
         320,
         tocolor(255, 255, 255, 230),
         1.0,
@@ -541,8 +560,7 @@ addCommandHandler("replaymode", function(_, mode)
     state.replayMode = mode
     state.currentDrift = 0
     state.maxDrift = 0
-    state.lastCorrectedKeyframe = nil
-    chat("Replay mode: " .. mode .. (mode == "tracked" and " (smooth recorded trajectory)." or " (GTA controls + sparse corrections)."), 120, 255, 120)
+    chat("Replay mode: " .. mode .. (mode == "tracked" and " (smooth recorded trajectory)." or " (native GTA locomotion + continuous drift correction)."), 120, 255, 120)
 end)
 
 addCommandHandler("replaydebug", function()

--- a/test-resources/replay-prototype/client.lua
+++ b/test-resources/replay-prototype/client.lua
@@ -1,8 +1,9 @@
 local BUFFER_DURATION_MS = 60000
 local SAMPLE_INTERVAL_MS = 16
 local KEYFRAME_INTERVAL_MS = 500
-local SOFT_CORRECTION_DISTANCE = 0.15
-local HARD_CORRECTION_DISTANCE = 0.90
+local SOFT_CORRECTION_DISTANCE = 0.75
+local HARD_CORRECTION_DISTANCE = 4.0
+local SOFT_CORRECTION_FACTOR = 0.08
 
 local CONTROL_NAMES = {
     "forwards",
@@ -35,6 +36,10 @@ local state = {
     ghostWeapon = nil,
     corrections = 0,
     hardResyncs = 0,
+    currentDrift = 0,
+    maxDrift = 0,
+    lastCorrectedKeyframe = nil,
+    replayMode = "tracked",
     debug = true,
 }
 
@@ -162,6 +167,8 @@ local function stopGhost()
     state.paused = false
     state.playbackIndex = 1
     state.playbackOffset = 0
+    state.currentDrift = 0
+    state.lastCorrectedKeyframe = nil
 end
 
 local function ensureGhostWeapon(frame)
@@ -273,8 +280,11 @@ local function startPlayback(offsetMs)
     state.playbackIndex = state.firstFrame
     state.corrections = 0
     state.hardResyncs = 0
+    state.currentDrift = 0
+    state.maxDrift = 0
+    state.lastCorrectedKeyframe = nil
 
-    chat(("Playback started (%.2fs buffered, %d samples)."):format((last.t - first.t) / 1000, #state.frames - state.firstFrame + 1), 120, 255, 120)
+    chat(("Playback started (%s mode, %.2fs buffered, %d samples)."):format(state.replayMode, (last.t - first.t) / 1000, #state.frames - state.firstFrame + 1), 120, 255, 120)
 end
 
 local function seekPlayback(seconds)
@@ -289,6 +299,7 @@ local function seekPlayback(seconds)
     state.playbackOffset = target
     state.playbackStartedAt = getTickCount()
     state.playbackIndex = state.firstFrame
+    state.lastCorrectedKeyframe = nil
 
     local frame = select(1, findPlaybackFrames(target))
     if frame and isElement(state.ghost) then
@@ -308,6 +319,59 @@ local function getPlaybackTime(now)
     return state.playbackOffset + (now - state.playbackStartedAt)
 end
 
+local function updateTrackedMovement(a, b, alpha)
+    local targetX = lerp(a.x, b.x, alpha)
+    local targetY = lerp(a.y, b.y, alpha)
+    local targetZ = lerp(a.z, b.z, alpha)
+    local targetRX = lerpAngle(a.rx, b.rx, alpha)
+    local targetRY = lerpAngle(a.ry, b.ry, alpha)
+    local targetRZ = lerpAngle(a.rz, b.rz, alpha)
+    local targetVX = lerp(a.vx, b.vx, alpha)
+    local targetVY = lerp(a.vy, b.vy, alpha)
+    local targetVZ = lerp(a.vz, b.vz, alpha)
+
+    local gx, gy, gz = getElementPosition(state.ghost)
+    state.currentDrift = distance3D(gx, gy, gz, targetX, targetY, targetZ)
+    state.maxDrift = math.max(state.maxDrift, state.currentDrift)
+
+    setElementPosition(state.ghost, targetX, targetY, targetZ)
+    setElementRotation(state.ghost, targetRX, targetRY, targetRZ)
+    setElementVelocity(state.ghost, targetVX, targetVY, targetVZ)
+end
+
+local function updateControlDrivenMovement(a, b, alpha)
+    local targetX = lerp(a.x, b.x, alpha)
+    local targetY = lerp(a.y, b.y, alpha)
+    local targetZ = lerp(a.z, b.z, alpha)
+    local gx, gy, gz = getElementPosition(state.ghost)
+    local errorDistance = distance3D(gx, gy, gz, targetX, targetY, targetZ)
+
+    state.currentDrift = errorDistance
+    state.maxDrift = math.max(state.maxDrift, errorDistance)
+
+    if not a.keyframe or state.lastCorrectedKeyframe == a.t then
+        return
+    end
+
+    state.lastCorrectedKeyframe = a.t
+
+    if errorDistance > HARD_CORRECTION_DISTANCE then
+        setElementPosition(state.ghost, a.x, a.y, a.z)
+        setElementRotation(state.ghost, a.rx, a.ry, a.rz)
+        setElementVelocity(state.ghost, a.vx, a.vy, a.vz)
+        state.hardResyncs = state.hardResyncs + 1
+    elseif errorDistance > SOFT_CORRECTION_DISTANCE then
+        local correction = math.min(0.18, SOFT_CORRECTION_FACTOR + errorDistance * 0.02)
+        setElementPosition(
+            state.ghost,
+            lerp(gx, a.x, correction),
+            lerp(gy, a.y, correction),
+            lerp(gz, a.z, correction)
+        )
+        state.corrections = state.corrections + 1
+    end
+end
+
 local function updatePlayback(now)
     if not state.playback or not isElement(state.ghost) then
         return
@@ -323,7 +387,7 @@ local function updatePlayback(now)
     if playbackTime >= last.t then
         clearControls(state.ghost)
         state.playback = false
-        chat("Playback complete.", 120, 255, 120)
+        chat(("Playback complete. Max drift %.2fm."):format(state.maxDrift), 120, 255, 120)
         return
     end
 
@@ -346,27 +410,10 @@ local function updatePlayback(now)
         setPedAimTarget(state.ghost, aimX, aimY, aimZ)
     end
 
-    if a.keyframe then
-        local gx, gy, gz = getElementPosition(state.ghost)
-        local errorDistance = distance3D(gx, gy, gz, a.x, a.y, a.z)
-
-        if errorDistance > HARD_CORRECTION_DISTANCE then
-            setElementPosition(state.ghost, a.x, a.y, a.z)
-            setElementRotation(state.ghost, a.rx, a.ry, a.rz)
-            setElementVelocity(state.ghost, a.vx, a.vy, a.vz)
-            state.hardResyncs = state.hardResyncs + 1
-        elseif errorDistance > SOFT_CORRECTION_DISTANCE then
-            local correction = math.min(0.35, errorDistance * 0.25)
-            setElementPosition(
-                state.ghost,
-                lerp(gx, a.x, correction),
-                lerp(gy, a.y, correction),
-                lerp(gz, a.z, correction)
-            )
-            local grx, gry, grz = getElementRotation(state.ghost)
-            setElementRotation(state.ghost, lerpAngle(grx, a.rx, correction), lerpAngle(gry, a.ry, correction), lerpAngle(grz, a.rz, correction))
-            state.corrections = state.corrections + 1
-        end
+    if state.replayMode == "controls" then
+        updateControlDrivenMovement(a, b, alpha)
+    else
+        updateTrackedMovement(a, b, alpha)
     end
 end
 
@@ -392,12 +439,24 @@ addEventHandler("onClientRender", root, function()
     local playbackTime = state.playback and getPlaybackTime(getTickCount()) / 1000 or 0
 
     dxDrawText(
-        ("Replay prototype\nrecording: %s | samples: %d | buffer: %.2fs\nplayback: %s%s | time: %.2fs\ncorrections: %d | hard resyncs: %d")
-            :format(tostring(state.recording), sampleCount, buffered, tostring(state.playback), state.paused and " (paused)" or "", playbackTime, state.corrections, state.hardResyncs),
+        ("Replay prototype\nrecording: %s | samples: %d | buffer: %.2fs\nplayback: %s%s | mode: %s | time: %.2fs\ndrift: %.2fm | max: %.2fm | corrections: %d | hard resyncs: %d")
+            :format(
+                tostring(state.recording),
+                sampleCount,
+                buffered,
+                tostring(state.playback),
+                state.paused and " (paused)" or "",
+                state.replayMode,
+                playbackTime,
+                state.currentDrift,
+                state.maxDrift,
+                state.corrections,
+                state.hardResyncs
+            ),
         24,
         180,
-        700,
-        300,
+        760,
+        320,
         tocolor(255, 255, 255, 230),
         1.0,
         "default-bold"
@@ -470,6 +529,20 @@ addCommandHandler("replayseek", function(_, seconds)
 
     seekPlayback(seconds)
     chat(("Seeked to %.2fs."):format(tonumber(seconds) or 0))
+end)
+
+addCommandHandler("replaymode", function(_, mode)
+    mode = mode and mode:lower() or nil
+    if mode ~= "tracked" and mode ~= "controls" then
+        chat("Usage: /replaymode [tracked|controls]. Current: " .. state.replayMode, 255, 220, 100)
+        return
+    end
+
+    state.replayMode = mode
+    state.currentDrift = 0
+    state.maxDrift = 0
+    state.lastCorrectedKeyframe = nil
+    chat("Replay mode: " .. mode .. (mode == "tracked" and " (smooth recorded trajectory)." or " (GTA controls + sparse corrections)."), 120, 255, 120)
 end)
 
 addCommandHandler("replaydebug", function()

--- a/test-resources/replay-prototype/meta.xml
+++ b/test-resources/replay-prototype/meta.xml
@@ -1,4 +1,5 @@
 <meta>
-    <info author="Neon" name="Player replay prototype" version="0.1.0" type="script" />
+    <info author="Neon" name="Player replay prototype" version="0.1.1" type="script" />
     <script src="client.lua" type="client" cache="false" />
+    <script src="view.lua" type="client" cache="false" />
 </meta>

--- a/test-resources/replay-prototype/meta.xml
+++ b/test-resources/replay-prototype/meta.xml
@@ -1,0 +1,4 @@
+<meta>
+    <info author="Neon" name="Player replay prototype" version="0.1.0" type="script" />
+    <script src="client.lua" type="client" cache="false" />
+</meta>

--- a/test-resources/replay-prototype/view.lua
+++ b/test-resources/replay-prototype/view.lua
@@ -1,0 +1,54 @@
+local cameraGhost = nil
+
+local function findReplayGhost()
+    local candidates = getElementsByType("ped", resourceRoot)
+    for i = #candidates, 1, -1 do
+        local ped = candidates[i]
+        if isElement(ped) and ped ~= localPlayer and getElementAlpha(ped) == 190 then
+            return ped
+        end
+    end
+    return nil
+end
+
+local function followReplayGhost()
+    setTimer(function()
+        local ghost = findReplayGhost()
+        if not isElement(ghost) then
+            return
+        end
+
+        cameraGhost = ghost
+        setCameraTarget(ghost)
+    end, 50, 1)
+end
+
+local function restorePlayerCamera()
+    if isElement(localPlayer) then
+        setCameraTarget(localPlayer)
+    end
+    cameraGhost = nil
+end
+
+addCommandHandler("replayplay", followReplayGhost)
+addCommandHandler("replayresume", followReplayGhost)
+
+addCommandHandler("replaystop", function()
+    setTimer(restorePlayerCamera, 0, 1)
+end)
+
+addCommandHandler("replayclear", function()
+    setTimer(restorePlayerCamera, 0, 1)
+end)
+
+addEventHandler("onClientChatMessage", root, function(message)
+    if type(message) ~= "string" then
+        return
+    end
+
+    if message:find("%[REPLAY%] Playback complete%.") or message:find("%[REPLAY%] Playback stopped%.") then
+        restorePlayerCamera()
+    end
+end)
+
+addEventHandler("onClientResourceStop", resourceRoot, restorePlayerCamera)


### PR DESCRIPTION
## What changed

Adds a client-side replay prototype under `test-resources/replay-prototype` to validate the replay concept before moving capture/playback into native C++.

The harness:
- records the local on-foot player into a 60-second rolling in-memory buffer
- samples at roughly 60 Hz using timestamps rather than frame numbers
- captures transform, velocity, camera, aim endpoint, weapon state and key control states
- spawns a semi-transparent local ghost ped for playback
- replays ped control states and aim target
- applies 500 ms transform keyframes with soft drift correction and hard resync thresholds
- supports play, pause, resume and seek
- displays sample count, buffered duration and correction/resync metrics

## Test commands

`/replayrec`
`/replaystop`
`/replayplay [startSeconds]`
`/replaypause`
`/replayresume`
`/replayseek <seconds>`
`/replaydebug`
`/replayclear`

## Scope

This is deliberately the first working validation harness: on-foot/local-player only, no vehicles, persistence, network upload, surrounding entity capture or anti-cheat scoring yet. If control-driven playback proves stable across FPS changes, the recorder/ring buffer can move into the native client layer while keeping a small Lua-facing control API.

## Validation

Reviewed the branch diff against `master` and kept the change isolated to a new test resource. GitHub Actions/build results are intentionally not awaited for this prototype.