### PR TITLE
Add resource-owned 2DFX model effects API

### DIFF
--- a/Client/mods/deathmatch/logic/CClient2DFXHookSupport.cpp
+++ b/Client/mods/deathmatch/logic/CClient2DFXHookSupport.cpp
@@ -1,0 +1,46 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.x / Neon
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Client/mods/deathmatch/logic/CClient2DFXHookSupport.cpp
+ *  PURPOSE:     Hook helpers required by the deathmatch-owned 2DFX hooks
+ *
+ *****************************************************************************/
+#include "StdInc.h"
+#include "../../../game_sa/HookSystem.h"
+#include "../../../game_sa/gamesa_init.h"
+
+// HookInstall is header-only in game_sa, but its two write helpers normally
+// live in the game_sa project. 2DFX installs its hooks from Client Deathmatch,
+// so provide the same small helpers locally instead of linking game_sa objects
+// into the deathmatch module.
+void MemCpy(void* destination, const void* source, uint amount)
+{
+    if (!destination || !source || amount == 0)
+        return;
+
+    DWORD oldProtection = 0;
+    if (!VirtualProtect(destination, amount, PAGE_EXECUTE_READWRITE, &oldProtection))
+    {
+        dassert(false);
+        return;
+    }
+
+    std::memcpy(destination, source, amount);
+    FlushInstructionCache(GetCurrentProcess(), destination, amount);
+
+    DWORD ignoredProtection = 0;
+    const BOOL restored = VirtualProtect(destination, amount, oldProtection, &ignoredProtection);
+    dassert(restored != FALSE);
+}
+
+BYTE* CreateJump(DWORD from, DWORD to, BYTE* byteArray)
+{
+    if (!byteArray)
+        return nullptr;
+
+    byteArray[0] = 0xE9;
+    const DWORD relativeOffset = to - (from + 5);
+    std::memcpy(&byteArray[1], &relativeOffset, sizeof(relativeOffset));
+    return byteArray;
+}

--- a/Client/mods/deathmatch/logic/CClient2DFXHookSupport.cpp
+++ b/Client/mods/deathmatch/logic/CClient2DFXHookSupport.cpp
@@ -7,6 +7,7 @@
  *
  *****************************************************************************/
 #include "StdInc.h"
+#include <SharedUtil.MemAccess.h>
 #include "../../../game_sa/HookSystem.h"
 #include "../../../game_sa/gamesa_init.h"
 

--- a/Client/mods/deathmatch/logic/CClient2DFXManager.cpp
+++ b/Client/mods/deathmatch/logic/CClient2DFXManager.cpp
@@ -1,0 +1,1165 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.x / Neon
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Client/mods/deathmatch/logic/CClient2DFXManager.cpp
+ *  PURPOSE:     Resource-owned model 2DFX state and native integration
+ *
+ *****************************************************************************/
+#include "StdInc.h"
+#include "CClient2DFXManager.h"
+#include "CClientDummy.h"
+#include "CResource.h"
+#include "../../../game_sa/CEntitySA.h"
+#include "../../../game_sa/CModelInfoSA.h"
+#include "../../../game_sa/HookSystem.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <limits>
+
+namespace
+{
+constexpr std::uintptr_t ADDRESS_2DFX_STORE = 0xB4C2D8;
+constexpr std::uintptr_t ADDRESS_2DFX_PLUGIN_OFFSET = 0xC3A1E0;
+constexpr std::uintptr_t ADDRESS_GET_2DFX = 0x4C4C70;
+constexpr std::uintptr_t ADDRESS_GET_2DFX_HOOK = 0x4C4CDC;
+constexpr std::uintptr_t ADDRESS_POST_CREATE_EFFECTS_HOOK = 0x533BAE;
+constexpr std::uintptr_t ADDRESS_FX = 0xA9AE00;
+constexpr std::uintptr_t ADDRESS_FX_DESTROY_ENTITY = 0x4A1280;
+constexpr std::uintptr_t ADDRESS_ESCALATORS = 0xC6E9A8;
+constexpr std::uintptr_t ADDRESS_ESCALATOR_SWITCH_OFF = 0x717860;
+constexpr std::uintptr_t ADDRESS_TXD_PUSH = 0x7316A0;
+constexpr std::uintptr_t ADDRESS_TXD_POP = 0x7316B0;
+constexpr std::uintptr_t ADDRESS_TXD_FIND = 0x731850;
+constexpr std::uintptr_t ADDRESS_TXD_SET = 0x7319C0;
+constexpr std::uintptr_t ADDRESS_RW_TEXTURE_READ = 0x7F3AC0;
+constexpr std::uintptr_t ADDRESS_RW_TEXTURE_DESTROY = 0x7F3820;
+constexpr std::uintptr_t ADDRESS_RW_FRAME_DESTROY = 0x7F05A0;
+constexpr std::uintptr_t ADDRESS_RP_ATOMIC_SET_FRAME = 0x74BF20;
+constexpr std::uintptr_t ADDRESS_RP_ATOMIC_DESTROY = 0x749DC0;
+
+constexpr std::size_t MAX_NATIVE_EFFECTS = 255;
+constexpr std::size_t PARTICLE_NAME_CAPACITY = 24;
+constexpr std::size_t ROADSIGN_LINE_CAPACITY = 16;
+
+std::uint32_t PackColor(const RwColor& color)
+{
+    return (static_cast<std::uint32_t>(color.a) << 24) | (static_cast<std::uint32_t>(color.r) << 16) |
+           (static_cast<std::uint32_t>(color.g) << 8) | static_cast<std::uint32_t>(color.b);
+}
+
+RwColor UnpackColor(std::uint32_t color)
+{
+    return RwColor{static_cast<std::uint8_t>((color >> 16) & 0xFF), static_cast<std::uint8_t>((color >> 8) & 0xFF),
+                   static_cast<std::uint8_t>(color & 0xFF), static_cast<std::uint8_t>((color >> 24) & 0xFF)};
+}
+
+std::string BoundedString(const char* value, std::size_t capacity)
+{
+    if (!value)
+        return {};
+    return std::string(value, strnlen(value, capacity));
+}
+
+bool CopyParticleName(char (&destination)[PARTICLE_NAME_CAPACITY], const std::string& value)
+{
+    if (value.size() >= PARTICLE_NAME_CAPACITY)
+        return false;
+    std::memset(destination, 0, sizeof(destination));
+    std::memcpy(destination, value.data(), value.size());
+    return true;
+}
+
+bool CopyRoadsignLine(char* destination, const std::string& value)
+{
+    if (!destination || value.size() > ROADSIGN_LINE_CAPACITY)
+        return false;
+    std::memset(destination, 0, ROADSIGN_LINE_CAPACITY);
+    std::memcpy(destination, value.data(), value.size());
+    return true;
+}
+
+RwTexture* LoadParticleTexture(const std::string& name)
+{
+    if (name.empty())
+        return nullptr;
+
+    using PushTxd = void(__cdecl*)();
+    using PopTxd = void(__cdecl*)();
+    using FindTxd = std::int32_t(__cdecl*)(const char*);
+    using SetTxd = void(__cdecl*)(std::int32_t);
+    using ReadTexture = RwTexture*(__cdecl*)(const char*, const char*);
+
+    reinterpret_cast<PushTxd>(ADDRESS_TXD_PUSH)();
+    const std::int32_t txd = reinterpret_cast<FindTxd>(ADDRESS_TXD_FIND)("particle");
+    if (txd >= 0)
+        reinterpret_cast<SetTxd>(ADDRESS_TXD_SET)(txd);
+    RwTexture* texture = reinterpret_cast<ReadTexture>(ADDRESS_RW_TEXTURE_READ)(name.c_str(), nullptr);
+    reinterpret_cast<PopTxd>(ADDRESS_TXD_POP)();
+    return texture;
+}
+
+void DestroyTexture(RwTexture*& texture)
+{
+    if (!texture)
+        return;
+    reinterpret_cast<void(__cdecl*)(RwTexture*)>(ADDRESS_RW_TEXTURE_DESTROY)(texture);
+    texture = nullptr;
+}
+
+bool ReplaceTexture(RwTexture*& texture, const std::string& name)
+{
+    if (texture && BoundedString(texture->name, RW_TEXTURE_NAME_LENGTH) == name)
+        return true;
+    if (!texture && name.empty())
+        return true;
+
+    // Load first. A bad texture name must not invalidate the live effect.
+    RwTexture* replacement = name.empty() ? nullptr : LoadParticleTexture(name);
+    if (!name.empty() && !replacement)
+        return false;
+
+    RwTexture* previous = texture;
+    texture = replacement;
+    if (previous)
+        reinterpret_cast<void(__cdecl*)(RwTexture*)>(ADDRESS_RW_TEXTURE_DESTROY)(previous);
+    return true;
+}
+}
+
+struct C2DFXNativeLight
+{
+    RwColor color;
+    float coronaFarClip;
+    float pointLightRange;
+    float coronaSize;
+    float shadowSize;
+    std::uint16_t flags;
+    e2dCoronaFlashType flashType;
+    bool coronaReflection;
+    std::uint8_t flareType;
+    std::uint8_t shadowMultiplier;
+    std::int8_t shadowDistance;
+    std::int8_t offsetX;
+    std::int8_t offsetY;
+    std::int8_t offsetZ;
+    std::uint8_t padding[2];
+    RwTexture* coronaTexture;
+    RwTexture* shadowTexture;
+    std::int32_t field28;
+    std::int32_t field2C;
+};
+static_assert(sizeof(C2DFXNativeLight) == 0x30, "Unexpected GTA 2DFX light layout");
+
+struct C2DFXNativeParticle
+{
+    char name[PARTICLE_NAME_CAPACITY];
+};
+static_assert(sizeof(C2DFXNativeParticle) == 0x18, "Unexpected GTA 2DFX particle layout");
+
+struct C2DFXNativeRoadsign
+{
+    RwV2d size;
+    RwV3d rotation;
+    std::uint8_t flags;
+    std::uint8_t padding[3];
+    char* text;
+    RpAtomic* atomic;
+};
+static_assert(sizeof(C2DFXNativeRoadsign) == 0x20, "Unexpected GTA 2DFX roadsign layout");
+
+struct C2DFXNativeEscalator
+{
+    RwV3d bottom;
+    RwV3d top;
+    RwV3d end;
+    std::uint8_t direction;
+    std::uint8_t padding[3];
+};
+static_assert(sizeof(C2DFXNativeEscalator) == 0x28, "Unexpected GTA 2DFX escalator layout");
+
+union C2DFXNativePayload
+{
+    C2DFXNativeLight light;
+    C2DFXNativeParticle particle;
+    C2DFXNativeRoadsign roadsign;
+    C2DFXNativeEscalator escalator;
+    std::uint8_t raw[0x30];
+};
+
+struct C2DFXNativeEffect
+{
+    CVector position;
+    e2dEffectType type;
+    std::uint8_t padding[3];
+    C2DFXNativePayload payload;
+};
+static_assert(sizeof(C2DFXNativeEffect) == 0x40, "Unexpected GTA C2dEffect layout");
+
+namespace
+{
+struct C2DFXNativeStore
+{
+    std::uint32_t count;
+    C2DFXNativeEffect effects[100];
+};
+
+struct C2DFXPluginData
+{
+    std::uint32_t count;
+    C2DFXNativeEffect effects[1];
+};
+
+struct CEscalatorNative
+{
+    RwV3d start;
+    RwV3d bottom;
+    RwV3d top;
+    RwV3d end;
+    std::uint8_t matrix[72];
+    bool exists;
+    bool objectCreated;
+    bool moveDown;
+    std::uint8_t padding7B;
+    std::int32_t intermediatePlanes;
+    std::uint32_t bottomPlanes;
+    std::uint32_t topPlanes;
+    std::uint8_t padding88[8];
+    RwSphere bounding;
+    float currentPosition;
+    CEntitySAInterface* entity;
+    void* objects[42];
+};
+static_assert(sizeof(CEscalatorNative) == 0x150, "Unexpected GTA escalator layout");
+
+C2DFXNativeEffect g_removedEffect{};
+
+C2DFXNativeEffect* NativeGetEffect(CBaseModelInfoSAInterface* modelInfo, std::uint32_t index)
+{
+    if (!modelInfo)
+        return nullptr;
+    using Get2DFX = C2DFXNativeEffect*(__thiscall*)(CBaseModelInfoSAInterface*, std::uint32_t);
+    return reinterpret_cast<Get2DFX>(ADDRESS_GET_2DFX)(modelInfo, index);
+}
+
+void DestroyRoadsignAtomic(C2DFXNativeEffect* effect)
+{
+    if (!effect || effect->type != e2dEffectType::ROADSIGN || !effect->payload.roadsign.atomic)
+        return;
+
+    RpAtomic* atomic = effect->payload.roadsign.atomic;
+    RwFrame* frame = RpAtomicGetFrame(atomic);
+    if (frame)
+    {
+        reinterpret_cast<void(__cdecl*)(RpAtomic*, RwFrame*)>(ADDRESS_RP_ATOMIC_SET_FRAME)(atomic, nullptr);
+        reinterpret_cast<void(__cdecl*)(RwFrame*)>(ADDRESS_RW_FRAME_DESTROY)(frame);
+    }
+    reinterpret_cast<void(__cdecl*)(RpAtomic*)>(ADDRESS_RP_ATOMIC_DESTROY)(atomic);
+    effect->payload.roadsign.atomic = nullptr;
+}
+
+void SetRoadsignColor(C2DFXNativeEffect* effect, std::uint32_t packedColor)
+{
+    if (!effect || effect->type != e2dEffectType::ROADSIGN || !effect->payload.roadsign.atomic)
+        return;
+    RpGeometry* geometry = effect->payload.roadsign.atomic->geometry;
+    if (!geometry)
+        return;
+
+    const RwColor color = UnpackColor(packedColor);
+    for (std::int32_t index = 0; index < geometry->materials.entries; ++index)
+    {
+        RpMaterial* material = geometry->materials.materials[index];
+        if (material)
+            material->color = color;
+    }
+}
+
+void DestroyParticleFxForModel(std::uint32_t model)
+{
+    auto* fx = reinterpret_cast<std::uint8_t*>(ADDRESS_FX);
+    void* node = *reinterpret_cast<void**>(fx + 0x44);
+    std::vector<CEntitySAInterface*> entities;
+
+    while (node)
+    {
+        void* previous = *reinterpret_cast<void**>(reinterpret_cast<std::uint8_t*>(node) + 0x4);
+        CEntitySAInterface* entity = *reinterpret_cast<CEntitySAInterface**>(reinterpret_cast<std::uint8_t*>(node) + 0xC);
+        if (entity && entity->m_nModelIndex == model && std::find(entities.begin(), entities.end(), entity) == entities.end())
+            entities.push_back(entity);
+        node = previous;
+    }
+
+    using DestroyEntityFx = void(__thiscall*)(void*, CEntitySAInterface*);
+    for (CEntitySAInterface* entity : entities)
+        reinterpret_cast<DestroyEntityFx>(ADDRESS_FX_DESTROY_ENTITY)(reinterpret_cast<void*>(ADDRESS_FX), entity);
+}
+
+void DisableEscalatorsForModel(std::uint32_t model)
+{
+    auto* escalators = reinterpret_cast<CEscalatorNative*>(ADDRESS_ESCALATORS);
+    using SwitchOff = void(__thiscall*)(CEscalatorNative*);
+    for (std::size_t index = 0; index < 32; ++index)
+    {
+        auto& escalator = escalators[index];
+        if (!escalator.exists || !escalator.entity || escalator.entity->m_nModelIndex != model)
+            continue;
+        reinterpret_cast<SwitchOff>(ADDRESS_ESCALATOR_SWITCH_OFF)(&escalator);
+        escalator.exists = false;
+    }
+}
+
+bool ReadEffectData(C2DFXNativeEffect* effect, S2DFXData& out)
+{
+    if (!effect)
+        return false;
+    out = {};
+    out.position = effect->position;
+
+    switch (effect->type)
+    {
+        case e2dEffectType::LIGHT:
+        {
+            const auto& light = effect->payload.light;
+            out.drawDistance = light.coronaFarClip;
+            out.lightRange = light.pointLightRange;
+            out.coronaSize = light.coronaSize;
+            out.shadowSize = light.shadowSize;
+            out.shadowMultiplier = light.shadowMultiplier;
+            out.shadowDistance = light.shadowDistance;
+            out.flashType = light.flashType;
+            out.coronaReflection = light.coronaReflection;
+            out.flareType = light.flareType;
+            out.offset = CVector(static_cast<float>(light.offsetX), static_cast<float>(light.offsetY), static_cast<float>(light.offsetZ));
+            out.color = PackColor(light.color);
+            out.flags = light.flags;
+            out.coronaName = light.coronaTexture ? BoundedString(light.coronaTexture->name, RW_TEXTURE_NAME_LENGTH) : std::string{};
+            out.shadowName = light.shadowTexture ? BoundedString(light.shadowTexture->name, RW_TEXTURE_NAME_LENGTH) : std::string{};
+            return true;
+        }
+        case e2dEffectType::PARTICLE:
+            out.particleName = BoundedString(effect->payload.particle.name, PARTICLE_NAME_CAPACITY);
+            return true;
+        case e2dEffectType::ROADSIGN:
+        {
+            const auto& roadsign = effect->payload.roadsign;
+            out.size = CVector(roadsign.size.x, roadsign.size.y, 0.0f);
+            out.rotation = CVector(roadsign.rotation.x, roadsign.rotation.y, roadsign.rotation.z);
+            out.flags = roadsign.flags;
+            if (roadsign.text)
+            {
+                for (std::size_t line = 0; line < 4; ++line)
+                    out.text[line] = BoundedString(roadsign.text + line * ROADSIGN_LINE_CAPACITY, ROADSIGN_LINE_CAPACITY);
+            }
+            if (roadsign.atomic && roadsign.atomic->geometry && roadsign.atomic->geometry->materials.entries > 0 && roadsign.atomic->geometry->materials.materials[0])
+                out.color = PackColor(roadsign.atomic->geometry->materials.materials[0]->color);
+            return true;
+        }
+        case e2dEffectType::ESCALATOR:
+            out.bottom = CVector(effect->payload.escalator.bottom.x, effect->payload.escalator.bottom.y, effect->payload.escalator.bottom.z);
+            out.top = CVector(effect->payload.escalator.top.x, effect->payload.escalator.top.y, effect->payload.escalator.top.z);
+            out.end = CVector(effect->payload.escalator.end.x, effect->payload.escalator.end.y, effect->payload.escalator.end.z);
+            out.direction = effect->payload.escalator.direction;
+            return true;
+        case e2dEffectType::SUN_GLARE:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool ApplyEffectData(C2DFXNativeEffect* effect, const S2DFXData& data)
+{
+    if (!effect)
+        return false;
+    effect->position = data.position;
+
+    switch (effect->type)
+    {
+        case e2dEffectType::LIGHT:
+        {
+            auto& light = effect->payload.light;
+            if (!ReplaceTexture(light.coronaTexture, data.coronaName))
+                return false;
+            if (!ReplaceTexture(light.shadowTexture, data.shadowName))
+                return false;
+            light.color = UnpackColor(data.color);
+            light.coronaFarClip = data.drawDistance;
+            light.pointLightRange = data.lightRange;
+            light.coronaSize = data.coronaSize;
+            light.shadowSize = data.shadowSize;
+            light.flags = data.flags;
+            light.flashType = data.flashType;
+            light.coronaReflection = data.coronaReflection;
+            light.flareType = data.flareType;
+            light.shadowMultiplier = data.shadowMultiplier;
+            light.shadowDistance = data.shadowDistance;
+            light.offsetX = static_cast<std::int8_t>(data.offset.fX);
+            light.offsetY = static_cast<std::int8_t>(data.offset.fY);
+            light.offsetZ = static_cast<std::int8_t>(data.offset.fZ);
+            return true;
+        }
+        case e2dEffectType::PARTICLE:
+            return CopyParticleName(effect->payload.particle.name, data.particleName);
+        case e2dEffectType::ROADSIGN:
+        {
+            auto& roadsign = effect->payload.roadsign;
+            if (!roadsign.text)
+                return false;
+            roadsign.size = RwV2d{data.size.fX, data.size.fY};
+            roadsign.rotation = RwV3d{data.rotation.fX, data.rotation.fY, data.rotation.fZ};
+            roadsign.flags = static_cast<std::uint8_t>(data.flags & 0xFF);
+            for (std::size_t line = 0; line < 4; ++line)
+            {
+                if (!CopyRoadsignLine(roadsign.text + line * ROADSIGN_LINE_CAPACITY, data.text[line]))
+                    return false;
+            }
+            SetRoadsignColor(effect, data.color);
+            return true;
+        }
+        case e2dEffectType::ESCALATOR:
+            effect->payload.escalator.bottom = RwV3d{data.bottom.fX, data.bottom.fY, data.bottom.fZ};
+            effect->payload.escalator.top = RwV3d{data.top.fX, data.top.fY, data.top.fZ};
+            effect->payload.escalator.end = RwV3d{data.end.fX, data.end.fY, data.end.fZ};
+            effect->payload.escalator.direction = data.direction;
+            return true;
+        case e2dEffectType::SUN_GLARE:
+            return true;
+        default:
+            return false;
+    }
+}
+
+void DestroyCustomResources(C2DFXNativeEffect* effect)
+{
+    if (!effect)
+        return;
+    if (effect->type == e2dEffectType::LIGHT)
+    {
+        DestroyTexture(effect->payload.light.coronaTexture);
+        DestroyTexture(effect->payload.light.shadowTexture);
+    }
+    else if (effect->type == e2dEffectType::ROADSIGN)
+        DestroyRoadsignAtomic(effect);
+}
+
+void PrepareVisualChange(std::uint32_t model, C2DFXNativeEffect* effect)
+{
+    if (!effect)
+        return;
+    switch (effect->type)
+    {
+        case e2dEffectType::PARTICLE:
+            DestroyParticleFxForModel(model);
+            break;
+        case e2dEffectType::ROADSIGN:
+            DestroyRoadsignAtomic(effect);
+            break;
+        case e2dEffectType::ESCALATOR:
+            DisableEscalatorsForModel(model);
+            break;
+        default:
+            break;
+    }
+}
+
+void RestreamModel(std::uint32_t model)
+{
+    if (g_pClientGame)
+        g_pClientGame->RestreamModel(static_cast<std::uint16_t>(model));
+}
+
+class C2DFXResourceTracker final : public CClientDummy
+{
+public:
+    C2DFXResourceTracker(CClientManager* manager, CResource* owner) : CClientDummy(manager, INVALID_ELEMENT_ID, "2dfxtracker"), m_owner(owner) {}
+    ~C2DFXResourceTracker() { CClient2DFXManager::GetSingleton().ReleaseResource(m_owner); }
+
+private:
+    CResource* m_owner{};
+};
+}
+
+struct CClient2DFXManager::SImpl
+{
+    struct SOverride
+    {
+        CResource* owner{};
+        S2DFXData data{};
+        std::uint64_t sequence{};
+    };
+
+    struct SOriginal
+    {
+        S2DFXData baseline{};
+        S2DFXData effective{};
+        bool captured{};
+        std::map<e2dEffectProperty, std::vector<SOverride>> overrides;
+        std::unordered_set<CResource*> removers;
+    };
+
+    struct SCustom
+    {
+        CResource* owner{};
+        std::unique_ptr<C2DFXNativeEffect> effect;
+        std::array<char, 64> roadsignText{};
+        S2DFXData baseline{};
+        S2DFXData current{};
+    };
+
+    struct SModel
+    {
+        std::uint32_t model{};
+        CBaseModelInfoSAInterface* native{};
+        std::unordered_map<std::uint32_t, SOriginal> originals;
+        std::vector<std::unique_ptr<SCustom>> customs;
+    };
+
+    CClientManager* manager{};
+    bool hooksInstalled{};
+    std::uint64_t nextSequence{1};
+    std::unordered_map<CBaseModelInfoSAInterface*, SModel> models;
+    std::unordered_set<CResource*> trackedResources;
+};
+
+CClient2DFXManager::~CClient2DFXManager() = default;
+
+namespace
+{
+CBaseModelInfoSAInterface* GetModelInterface(std::uint32_t model)
+{
+    CModelInfo* info = g_pGame ? g_pGame->GetModelInfo(model) : nullptr;
+    return info ? info->GetInterface() : nullptr;
+}
+
+CClient2DFXManager::SImpl::SModel* FindModel(CClient2DFXManager::SImpl* impl, std::uint32_t model)
+{
+    if (!impl)
+        return nullptr;
+    CBaseModelInfoSAInterface* native = GetModelInterface(model);
+    if (!native)
+        return nullptr;
+    auto iterator = impl->models.find(native);
+    return iterator == impl->models.end() ? nullptr : &iterator->second;
+}
+
+CClient2DFXManager::SImpl::SModel& EnsureModel(CClient2DFXManager::SImpl* impl, std::uint32_t model)
+{
+    CBaseModelInfoSAInterface* native = GetModelInterface(model);
+    auto [iterator, inserted] = impl->models.try_emplace(native);
+    if (inserted)
+    {
+        iterator->second.model = model;
+        iterator->second.native = native;
+    }
+    return iterator->second;
+}
+
+std::uint32_t NativeCount(const CClient2DFXManager::SImpl::SModel& state)
+{
+    const std::uint32_t total = state.native ? state.native->ucNumOf2DEffects : 0;
+    const std::uint32_t custom = static_cast<std::uint32_t>(state.customs.size());
+    return total >= custom ? total - custom : 0;
+}
+
+bool IsRemoved(const CClient2DFXManager::SImpl::SModel& model, std::uint32_t index)
+{
+    auto iterator = model.originals.find(index);
+    return iterator != model.originals.end() && !iterator->second.removers.empty();
+}
+
+bool EnsureTracked(CClient2DFXManager::SImpl* impl, CResource* owner)
+{
+    if (!impl || !impl->manager || !owner)
+        return false;
+    if (impl->trackedResources.contains(owner))
+        return true;
+
+    auto* tracker = new C2DFXResourceTracker(impl->manager, owner);
+    tracker->SetParent(owner->GetResourceDynamicEntity());
+    if (CElementGroup* group = owner->GetElementGroup())
+        group->Add(tracker);
+    impl->trackedResources.insert(owner);
+    return true;
+}
+
+bool CaptureOriginal(CClient2DFXManager::SImpl::SModel& model, std::uint32_t index)
+{
+    auto& original = model.originals[index];
+    if (original.captured)
+        return true;
+    C2DFXNativeEffect* effect = NativeGetEffect(model.native, index);
+    if (!effect || effect->type == e2dEffectType::UNKNOWN)
+        return false;
+    if (!ReadEffectData(effect, original.baseline))
+        return false;
+    original.effective = original.baseline;
+    original.captured = true;
+    return true;
+}
+
+S2DFXData BuildEffective(const CClient2DFXManager::SImpl::SOriginal& original)
+{
+    S2DFXData effective = original.baseline;
+    for (const auto& [property, stack] : original.overrides)
+    {
+        if (!stack.empty())
+            CClient2DFXManager::CopyProperty(effective, stack.back().data, property);
+    }
+    return effective;
+}
+
+bool ApplyOriginal(CClient2DFXManager::SImpl::SModel& model, std::uint32_t index)
+{
+    auto iterator = model.originals.find(index);
+    if (iterator == model.originals.end() || !iterator->second.captured)
+        return true;
+    auto& original = iterator->second;
+    original.effective = BuildEffective(original);
+    if (!original.removers.empty())
+        return true;
+    C2DFXNativeEffect* effect = NativeGetEffect(model.native, index);
+    return effect && effect->type != e2dEffectType::UNKNOWN && ApplyEffectData(effect, original.effective);
+}
+
+C2DFXNativeEffect* __cdecl Resolve2DFXHook(CBaseModelInfoSAInterface* modelInfo, void* geometry, std::uint32_t pluginCount, std::uint32_t index)
+{
+    return CClient2DFXManager::GetSingleton().ResolveNativeEffect(modelInfo, geometry, pluginCount, index);
+}
+
+void __declspec(naked) HookGet2DFX()
+{
+    __asm
+    {
+        push esi
+        push eax
+        push edi
+        push ebx
+        call Resolve2DFXHook
+        add esp, 16
+        pop edi
+        pop esi
+        pop ebp
+        pop ebx
+        retn 4
+    }
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+}
+
+void __cdecl NotifyEntityEffectsCreated(CEntitySAInterface* entity)
+{
+    CClient2DFXManager::GetSingleton().OnEntityEffectsCreated(entity);
+}
+
+void __declspec(naked) HookPostCreateEffects()
+{
+    __asm
+    {
+        push ebp
+        call NotifyEntityEffectsCreated
+        add esp, 4
+        pop edi
+        pop ebp
+        pop ebx
+        add esp, 0C0h
+        retn
+    }
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+}
+}
+
+CClient2DFXManager& CClient2DFXManager::GetSingleton()
+{
+    static CClient2DFXManager manager;
+    return manager;
+}
+
+void CClient2DFXManager::Initialize(CClientManager* manager)
+{
+    if (!m_impl)
+        m_impl = std::make_unique<SImpl>();
+    m_impl->manager = manager;
+    if (!m_impl->hooksInstalled)
+    {
+        HookInstall(ADDRESS_GET_2DFX_HOOK, HookGet2DFX, 10);
+        HookInstall(ADDRESS_POST_CREATE_EFFECTS_HOOK, HookPostCreateEffects, 10);
+        g_removedEffect = {};
+        g_removedEffect.type = e2dEffectType::UNKNOWN;
+        m_impl->hooksInstalled = true;
+    }
+}
+
+bool CClient2DFXManager::IsValidModel(std::uint32_t model) const
+{
+    return model <= std::numeric_limits<std::uint16_t>::max() && GetModelInterface(model) != nullptr;
+}
+
+bool CClient2DFXManager::IsModelLoaded(std::uint32_t model) const
+{
+    CModelInfo* info = g_pGame ? g_pGame->GetModelInfo(model) : nullptr;
+    return info && info->GetInterface() && info->IsLoaded();
+}
+
+std::uint32_t CClient2DFXManager::GetCount(std::uint32_t model, bool includeCustom) const
+{
+    CBaseModelInfoSAInterface* native = GetModelInterface(model);
+    if (!native)
+        return 0;
+    if (!m_impl)
+        return native->ucNumOf2DEffects;
+    auto iterator = m_impl->models.find(native);
+    if (iterator == m_impl->models.end() || includeCustom)
+        return native->ucNumOf2DEffects;
+    return NativeCount(iterator->second);
+}
+
+e2dEffectType CClient2DFXManager::GetType(std::uint32_t model, std::uint32_t index) const
+{
+    CBaseModelInfoSAInterface* native = GetModelInterface(model);
+    if (!native || index >= GetCount(model, true))
+        return e2dEffectType::NONE;
+    C2DFXNativeEffect* effect = NativeGetEffect(native, index);
+    return effect ? effect->type : e2dEffectType::NONE;
+}
+
+bool CClient2DFXManager::GetData(std::uint32_t model, std::uint32_t index, S2DFXData& out) const
+{
+    CBaseModelInfoSAInterface* native = GetModelInterface(model);
+    if (!native || index >= GetCount(model, true))
+        return false;
+    C2DFXNativeEffect* effect = NativeGetEffect(native, index);
+    if (!effect || effect->type == e2dEffectType::UNKNOWN)
+        return false;
+    if (!ReadEffectData(effect, out))
+        return false;
+
+    if (!m_impl)
+        return true;
+    auto modelIt = m_impl->models.find(native);
+    if (modelIt == m_impl->models.end())
+        return true;
+
+    const std::uint32_t nativeCount = NativeCount(modelIt->second);
+    if (index < nativeCount)
+    {
+        auto originalIt = modelIt->second.originals.find(index);
+        if (originalIt != modelIt->second.originals.end() && originalIt->second.captured)
+            out.color = originalIt->second.effective.color;
+    }
+    else
+    {
+        const std::size_t customIndex = index - nativeCount;
+        if (customIndex < modelIt->second.customs.size())
+            out = modelIt->second.customs[customIndex]->current;
+    }
+    return true;
+}
+
+bool CClient2DFXManager::Add(CResource* owner, std::uint32_t model, e2dEffectType type, const S2DFXData& data)
+{
+    if (!m_impl || !EnsureTracked(m_impl.get(), owner) || !IsModelLoaded(model))
+        return false;
+    if (type != e2dEffectType::LIGHT && type != e2dEffectType::PARTICLE && type != e2dEffectType::SUN_GLARE && type != e2dEffectType::ROADSIGN &&
+        type != e2dEffectType::ESCALATOR)
+        return false;
+
+    auto& state = EnsureModel(m_impl.get(), model);
+    if (!state.native || state.native->ucNumOf2DEffects >= MAX_NATIVE_EFFECTS)
+        return false;
+
+    auto custom = std::make_unique<SImpl::SCustom>();
+    custom->owner = owner;
+    custom->effect = std::make_unique<C2DFXNativeEffect>();
+    custom->effect->type = type;
+    custom->baseline = data;
+    custom->current = data;
+    if (type == e2dEffectType::ROADSIGN)
+        custom->effect->payload.roadsign.text = custom->roadsignText.data();
+
+    if (!ApplyEffectData(custom->effect.get(), data))
+    {
+        DestroyCustomResources(custom->effect.get());
+        return false;
+    }
+
+    state.customs.push_back(std::move(custom));
+    ++state.native->ucNumOf2DEffects;
+    if (type != e2dEffectType::LIGHT && type != e2dEffectType::SUN_GLARE)
+        RestreamModel(model);
+    return true;
+}
+
+bool CClient2DFXManager::Remove(CResource* owner, std::uint32_t model, std::uint32_t index)
+{
+    if (!m_impl || !EnsureTracked(m_impl.get(), owner))
+        return false;
+    SImpl::SModel* state = FindModel(m_impl.get(), model);
+    if (!state)
+    {
+        if (!IsModelLoaded(model))
+            return false;
+        state = &EnsureModel(m_impl.get(), model);
+    }
+
+    const std::uint32_t nativeCount = NativeCount(*state);
+    if (index >= state->native->ucNumOf2DEffects)
+        return false;
+
+    if (index >= nativeCount)
+    {
+        const std::size_t customIndex = index - nativeCount;
+        if (customIndex >= state->customs.size() || state->customs[customIndex]->owner != owner)
+            return false;
+        C2DFXNativeEffect* effect = state->customs[customIndex]->effect.get();
+        const e2dEffectType type = effect->type;
+        PrepareVisualChange(model, effect);
+        DestroyCustomResources(effect);
+        state->customs.erase(state->customs.begin() + customIndex);
+        --state->native->ucNumOf2DEffects;
+        if (type != e2dEffectType::LIGHT && type != e2dEffectType::SUN_GLARE)
+            RestreamModel(model);
+        return true;
+    }
+
+    if (!CaptureOriginal(*state, index))
+        return false;
+    auto& original = state->originals[index];
+    if (original.removers.contains(owner))
+        return true;
+    C2DFXNativeEffect* effect = NativeGetEffect(state->native, index);
+    PrepareVisualChange(model, effect);
+    original.removers.insert(owner);
+    RestreamModel(model);
+    return true;
+}
+
+bool CClient2DFXManager::Restore(CResource* owner, std::uint32_t model, std::uint32_t index)
+{
+    if (!m_impl || !owner)
+        return false;
+    SImpl::SModel* state = FindModel(m_impl.get(), model);
+    if (!state || index >= NativeCount(*state))
+        return false;
+    auto iterator = state->originals.find(index);
+    if (iterator == state->originals.end() || !iterator->second.removers.contains(owner))
+        return false;
+    iterator->second.removers.erase(owner);
+    ApplyOriginal(*state, index);
+    RestreamModel(model);
+    return true;
+}
+
+bool CClient2DFXManager::SetProperty(CResource* owner, std::uint32_t model, std::uint32_t index, e2dEffectProperty property, const S2DFXData& value)
+{
+    if (!m_impl || !EnsureTracked(m_impl.get(), owner) || !IsPropertyValid(GetType(model, index), property))
+        return false;
+    auto* state = FindModel(m_impl.get(), model);
+    if (!state)
+        state = &EnsureModel(m_impl.get(), model);
+    const std::uint32_t nativeCount = NativeCount(*state);
+    if (index >= state->native->ucNumOf2DEffects)
+        return false;
+
+    if (index >= nativeCount)
+    {
+        const std::size_t customIndex = index - nativeCount;
+        if (customIndex >= state->customs.size() || state->customs[customIndex]->owner != owner)
+            return false;
+        auto& custom = *state->customs[customIndex];
+        S2DFXData next = custom.current;
+        CopyProperty(next, value, property);
+        C2DFXNativeEffect* effect = custom.effect.get();
+        const S2DFXData previous = custom.current;
+        if (effect->type != e2dEffectType::LIGHT && effect->type != e2dEffectType::SUN_GLARE)
+            PrepareVisualChange(model, effect);
+        if (!ApplyEffectData(effect, next))
+        {
+            ApplyEffectData(effect, previous);
+            if (effect->type != e2dEffectType::LIGHT && effect->type != e2dEffectType::SUN_GLARE)
+                RestreamModel(model);
+            return false;
+        }
+        custom.current = std::move(next);
+        if (effect->type != e2dEffectType::LIGHT && effect->type != e2dEffectType::SUN_GLARE)
+            RestreamModel(model);
+        return true;
+    }
+
+    if (!CaptureOriginal(*state, index) || IsRemoved(*state, index))
+        return false;
+    auto& original = state->originals[index];
+    auto& stack = original.overrides[property];
+    const auto previousStack = stack;
+    stack.erase(std::remove_if(stack.begin(), stack.end(), [owner](const SImpl::SOverride& entry) { return entry.owner == owner; }), stack.end());
+    stack.push_back(SImpl::SOverride{owner, value, m_impl->nextSequence++});
+
+    C2DFXNativeEffect* effect = NativeGetEffect(state->native, index);
+    const e2dEffectType type = effect ? effect->type : e2dEffectType::UNKNOWN;
+    if (type != e2dEffectType::LIGHT && type != e2dEffectType::SUN_GLARE)
+        PrepareVisualChange(model, effect);
+    if (!ApplyOriginal(*state, index))
+    {
+        stack = previousStack;
+        ApplyOriginal(*state, index);
+        if (type != e2dEffectType::LIGHT && type != e2dEffectType::SUN_GLARE)
+            RestreamModel(model);
+        return false;
+    }
+    if (type != e2dEffectType::LIGHT && type != e2dEffectType::SUN_GLARE)
+        RestreamModel(model);
+    return true;
+}
+
+bool CClient2DFXManager::ResetProperty(CResource* owner, std::uint32_t model, std::uint32_t index, e2dEffectProperty property)
+{
+    if (!m_impl || !owner)
+        return false;
+    auto* state = FindModel(m_impl.get(), model);
+    if (!state)
+        return false;
+    const std::uint32_t nativeCount = NativeCount(*state);
+    if (index >= state->native->ucNumOf2DEffects)
+        return false;
+
+    if (index >= nativeCount)
+    {
+        const std::size_t customIndex = index - nativeCount;
+        if (customIndex >= state->customs.size() || state->customs[customIndex]->owner != owner)
+            return false;
+        auto& custom = *state->customs[customIndex];
+        if (!IsPropertyValid(custom.effect->type, property))
+            return false;
+        S2DFXData next = custom.current;
+        CopyProperty(next, custom.baseline, property);
+        if (custom.effect->type != e2dEffectType::LIGHT && custom.effect->type != e2dEffectType::SUN_GLARE)
+            PrepareVisualChange(model, custom.effect.get());
+        if (!ApplyEffectData(custom.effect.get(), next))
+            return false;
+        custom.current = std::move(next);
+        if (custom.effect->type != e2dEffectType::LIGHT && custom.effect->type != e2dEffectType::SUN_GLARE)
+            RestreamModel(model);
+        return true;
+    }
+
+    auto originalIt = state->originals.find(index);
+    if (originalIt == state->originals.end() || IsRemoved(*state, index))
+        return false;
+    auto stackIt = originalIt->second.overrides.find(property);
+    if (stackIt == originalIt->second.overrides.end())
+        return false;
+    auto& stack = stackIt->second;
+    const std::size_t oldSize = stack.size();
+    stack.erase(std::remove_if(stack.begin(), stack.end(), [owner](const SImpl::SOverride& entry) { return entry.owner == owner; }), stack.end());
+    if (stack.size() == oldSize)
+        return false;
+
+    C2DFXNativeEffect* effect = NativeGetEffect(state->native, index);
+    const e2dEffectType type = effect ? effect->type : e2dEffectType::UNKNOWN;
+    if (type != e2dEffectType::LIGHT && type != e2dEffectType::SUN_GLARE)
+        PrepareVisualChange(model, effect);
+    const bool result = ApplyOriginal(*state, index);
+    if (type != e2dEffectType::LIGHT && type != e2dEffectType::SUN_GLARE)
+        RestreamModel(model);
+    return result;
+}
+
+bool CClient2DFXManager::ResetModel(CResource* owner, std::uint32_t model)
+{
+    if (!m_impl || !owner)
+        return false;
+    auto* state = FindModel(m_impl.get(), model);
+    if (!state)
+        return false;
+
+    bool changed = false;
+    DestroyParticleFxForModel(model);
+    DisableEscalatorsForModel(model);
+    for (std::uint32_t index = 0; index < state->native->ucNumOf2DEffects; ++index)
+        DestroyRoadsignAtomic(NativeGetEffect(state->native, index));
+
+    for (auto iterator = state->customs.begin(); iterator != state->customs.end();)
+    {
+        if ((*iterator)->owner == owner)
+        {
+            DestroyCustomResources((*iterator)->effect.get());
+            iterator = state->customs.erase(iterator);
+            --state->native->ucNumOf2DEffects;
+            changed = true;
+        }
+        else
+            ++iterator;
+    }
+
+    for (auto& [index, original] : state->originals)
+    {
+        changed = original.removers.erase(owner) > 0 || changed;
+        for (auto& [property, stack] : original.overrides)
+        {
+            const std::size_t oldSize = stack.size();
+            stack.erase(std::remove_if(stack.begin(), stack.end(), [owner](const SImpl::SOverride& entry) { return entry.owner == owner; }), stack.end());
+            changed = stack.size() != oldSize || changed;
+        }
+        ApplyOriginal(*state, index);
+    }
+
+    if (changed)
+        RestreamModel(model);
+    return changed;
+}
+
+void CClient2DFXManager::ReleaseResource(CResource* owner)
+{
+    if (!m_impl || !owner)
+        return;
+    std::vector<std::uint32_t> models;
+    models.reserve(m_impl->models.size());
+    for (const auto& [native, state] : m_impl->models)
+        models.push_back(state.model);
+    for (std::uint32_t model : models)
+        ResetModel(owner, model);
+    m_impl->trackedResources.erase(owner);
+}
+
+C2DFXNativeEffect* CClient2DFXManager::ResolveNativeEffect(void* modelInfoPointer, void* geometry, std::uint32_t pluginCount, std::uint32_t index)
+{
+    auto* modelInfo = static_cast<CBaseModelInfoSAInterface*>(modelInfoPointer);
+    if (!modelInfo)
+        return nullptr;
+
+    SImpl::SModel* state = nullptr;
+    if (m_impl)
+    {
+        auto iterator = m_impl->models.find(modelInfo);
+        if (iterator != m_impl->models.end())
+            state = &iterator->second;
+    }
+
+    const std::uint32_t customCount = state ? static_cast<std::uint32_t>(state->customs.size()) : 0;
+    const std::uint32_t totalCount = modelInfo->ucNumOf2DEffects;
+    const std::uint32_t nativeCount = totalCount >= customCount ? totalCount - customCount : 0;
+    pluginCount = std::min(pluginCount, nativeCount);
+    const std::uint32_t storedCount = nativeCount - pluginCount;
+
+    C2DFXNativeEffect* result = nullptr;
+    if (index < storedCount)
+    {
+        if (modelInfo->s2DEffectIndex < 0)
+            return nullptr;
+        auto* store = reinterpret_cast<C2DFXNativeStore*>(ADDRESS_2DFX_STORE);
+        result = &store->effects[index + modelInfo->s2DEffectIndex];
+    }
+    else if (index < nativeCount)
+    {
+        if (!geometry)
+            return nullptr;
+        const std::int32_t offset = *reinterpret_cast<std::int32_t*>(ADDRESS_2DFX_PLUGIN_OFFSET);
+        auto** pluginPointer = reinterpret_cast<C2DFXPluginData**>(reinterpret_cast<std::uint8_t*>(geometry) + offset);
+        C2DFXPluginData* plugin = pluginPointer ? *pluginPointer : nullptr;
+        if (!plugin || index - storedCount >= plugin->count)
+            return nullptr;
+        result = &plugin->effects[index - storedCount];
+    }
+    else if (state && index < totalCount)
+    {
+        const std::size_t customIndex = index - nativeCount;
+        if (customIndex < state->customs.size())
+            result = state->customs[customIndex]->effect.get();
+    }
+
+    if (!state || index >= nativeCount)
+        return result;
+
+    auto originalIt = state->originals.find(index);
+    if (originalIt == state->originals.end())
+        return result;
+    if (!originalIt->second.removers.empty())
+        return &g_removedEffect;
+    if (result && originalIt->second.captured)
+        ApplyEffectData(result, originalIt->second.effective);
+    return result;
+}
+
+void CClient2DFXManager::OnEntityEffectsCreated(void* entityPointer)
+{
+    if (!m_impl || !entityPointer)
+        return;
+    auto* entity = static_cast<CEntitySAInterface*>(entityPointer);
+    CBaseModelInfoSAInterface* native = GetModelInterface(entity->m_nModelIndex);
+    if (!native)
+        return;
+    auto modelIt = m_impl->models.find(native);
+    if (modelIt == m_impl->models.end())
+        return;
+    auto& model = modelIt->second;
+    const std::uint32_t nativeCount = NativeCount(model);
+
+    for (const auto& [index, original] : model.originals)
+    {
+        if (index >= nativeCount || !original.captured || !original.removers.empty())
+            continue;
+        C2DFXNativeEffect* effect = NativeGetEffect(native, index);
+        if (effect && effect->type == e2dEffectType::ROADSIGN)
+            SetRoadsignColor(effect, original.effective.color);
+    }
+    for (const auto& custom : model.customs)
+    {
+        if (custom->effect && custom->effect->type == e2dEffectType::ROADSIGN)
+            SetRoadsignColor(custom->effect.get(), custom->current.color);
+    }
+}
+
+bool CClient2DFXManager::IsPropertyValid(e2dEffectType type, e2dEffectProperty property)
+{
+    if (property == e2dEffectProperty::POSITION)
+        return type != e2dEffectType::NONE && type != e2dEffectType::UNKNOWN;
+    switch (type)
+    {
+        case e2dEffectType::LIGHT:
+            return property >= e2dEffectProperty::FAR_CLIP_DISTANCE && property <= e2dEffectProperty::FLAGS;
+        case e2dEffectType::PARTICLE:
+            return property == e2dEffectProperty::PARTICLE_NAME;
+        case e2dEffectType::ROADSIGN:
+            return property == e2dEffectProperty::COLOR || property == e2dEffectProperty::FLAGS || property == e2dEffectProperty::SIZE ||
+                   property == e2dEffectProperty::ROTATION || (property >= e2dEffectProperty::TEXT_1 && property <= e2dEffectProperty::TEXT_4);
+        case e2dEffectType::ESCALATOR:
+            return property >= e2dEffectProperty::BOTTOM && property <= e2dEffectProperty::DIRECTION;
+        default:
+            return false;
+    }
+}
+
+void CClient2DFXManager::CopyProperty(S2DFXData& destination, const S2DFXData& source, e2dEffectProperty property)
+{
+    switch (property)
+    {
+        case e2dEffectProperty::POSITION: destination.position = source.position; break;
+        case e2dEffectProperty::FAR_CLIP_DISTANCE: destination.drawDistance = source.drawDistance; break;
+        case e2dEffectProperty::LIGHT_RANGE: destination.lightRange = source.lightRange; break;
+        case e2dEffectProperty::CORONA_SIZE: destination.coronaSize = source.coronaSize; break;
+        case e2dEffectProperty::SHADOW_SIZE: destination.shadowSize = source.shadowSize; break;
+        case e2dEffectProperty::SHADOW_MULT: destination.shadowMultiplier = source.shadowMultiplier; break;
+        case e2dEffectProperty::FLASH_TYPE: destination.flashType = source.flashType; break;
+        case e2dEffectProperty::CORONA_REFLECTION: destination.coronaReflection = source.coronaReflection; break;
+        case e2dEffectProperty::FLARE_TYPE: destination.flareType = source.flareType; break;
+        case e2dEffectProperty::SHADOW_DISTANCE: destination.shadowDistance = source.shadowDistance; break;
+        case e2dEffectProperty::OFFSET: destination.offset = source.offset; break;
+        case e2dEffectProperty::COLOR: destination.color = source.color; break;
+        case e2dEffectProperty::CORONA_NAME: destination.coronaName = source.coronaName; break;
+        case e2dEffectProperty::SHADOW_NAME: destination.shadowName = source.shadowName; break;
+        case e2dEffectProperty::FLAGS: destination.flags = source.flags; break;
+        case e2dEffectProperty::PARTICLE_NAME: destination.particleName = source.particleName; break;
+        case e2dEffectProperty::SIZE: destination.size = source.size; break;
+        case e2dEffectProperty::ROTATION: destination.rotation = source.rotation; break;
+        case e2dEffectProperty::TEXT_1: destination.text[0] = source.text[0]; break;
+        case e2dEffectProperty::TEXT_2: destination.text[1] = source.text[1]; break;
+        case e2dEffectProperty::TEXT_3: destination.text[2] = source.text[2]; break;
+        case e2dEffectProperty::TEXT_4: destination.text[3] = source.text[3]; break;
+        case e2dEffectProperty::BOTTOM: destination.bottom = source.bottom; break;
+        case e2dEffectProperty::TOP: destination.top = source.top; break;
+        case e2dEffectProperty::END: destination.end = source.end; break;
+        case e2dEffectProperty::DIRECTION: destination.direction = source.direction; break;
+    }
+}

--- a/Client/mods/deathmatch/logic/CClient2DFXManager.h
+++ b/Client/mods/deathmatch/logic/CClient2DFXManager.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <CVector.h>
+#include <SharedUtil.MemAccess.h>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -16,6 +17,15 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+// game_sa's fast-memory helpers expect this name to be visible when HookSystem.h
+// is included from the deathmatch module rather than through game_sa/StdInc.h.
+using SharedUtil::IsSlowMem;
+
+// Neon still exposes GTA's +0x0E 2DFX store index under its legacy name
+// `usUnknown`. Keep the 2DFX implementation source compatible with the upstream
+// terminology without changing the shared CBaseModelInfoSAInterface layout.
+#define s2DEffectIndex usUnknown
 
 class CClientManager;
 class CResource;

--- a/Client/mods/deathmatch/logic/CClient2DFXManager.h
+++ b/Client/mods/deathmatch/logic/CClient2DFXManager.h
@@ -1,0 +1,150 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.x / Neon
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Client/mods/deathmatch/logic/CClient2DFXManager.h
+ *  PURPOSE:     Resource-owned model 2DFX state and native integration
+ *
+ *****************************************************************************/
+#pragma once
+
+#include <CVector.h>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+class CClientManager;
+class CResource;
+struct C2DFXNativeEffect;
+
+enum class e2dEffectType : std::uint8_t
+{
+    LIGHT = 0,
+    PARTICLE = 1,
+    UNKNOWN = 2,
+    ATTRACTOR = 3,
+    SUN_GLARE = 4,
+    FURNITURE = 5,
+    ENEX = 6,
+    ROADSIGN = 7,
+    TRIGGER_POINT = 8,
+    COVER_POINT = 9,
+    ESCALATOR = 10,
+    NONE = 11,
+};
+
+enum class e2dCoronaFlashType : std::uint8_t
+{
+    DEFAULT = 0,
+    RANDOM,
+    RANDOM_WHEN_WET,
+    ANIM_SPEED_4X,
+    ANIM_SPEED_2X,
+    ANIM_SPEED_1X,
+    WARNLIGHT,
+    TRAFFICLIGHT,
+    TRAINCROSSING,
+    BRIDGE,
+    ONLY_RAIN,
+    ON5_OFF5,
+    ON6_OFF4,
+    ON4_OFF6,
+};
+
+enum class e2dEffectProperty : std::uint8_t
+{
+    POSITION,
+    FAR_CLIP_DISTANCE,
+    LIGHT_RANGE,
+    CORONA_SIZE,
+    SHADOW_SIZE,
+    SHADOW_MULT,
+    FLASH_TYPE,
+    CORONA_REFLECTION,
+    FLARE_TYPE,
+    SHADOW_DISTANCE,
+    OFFSET,
+    COLOR,
+    CORONA_NAME,
+    SHADOW_NAME,
+    FLAGS,
+    PARTICLE_NAME,
+    SIZE,
+    ROTATION,
+    TEXT_1,
+    TEXT_2,
+    TEXT_3,
+    TEXT_4,
+    BOTTOM,
+    TOP,
+    END,
+    DIRECTION,
+};
+
+struct S2DFXData
+{
+    CVector position{};
+    float drawDistance{};
+    float lightRange{};
+    float coronaSize{};
+    float shadowSize{};
+    std::uint8_t shadowMultiplier{};
+    std::int8_t shadowDistance{};
+    e2dCoronaFlashType flashType{e2dCoronaFlashType::DEFAULT};
+    bool coronaReflection{};
+    std::uint8_t flareType{};
+    CVector offset{};
+    std::uint32_t color{0xFFFFFFFFu};
+    std::uint16_t flags{};
+    std::string coronaName;
+    std::string shadowName;
+    std::string particleName;
+    CVector size{};
+    CVector rotation{};
+    std::string text[4];
+    CVector bottom{};
+    CVector top{};
+    CVector end{};
+    std::uint8_t direction{};
+};
+
+class CClient2DFXManager
+{
+public:
+    struct SImpl;
+
+    static CClient2DFXManager& GetSingleton();
+    void Initialize(CClientManager* manager);
+
+    bool IsValidModel(std::uint32_t model) const;
+    bool IsModelLoaded(std::uint32_t model) const;
+    std::uint32_t GetCount(std::uint32_t model, bool includeCustom = true) const;
+    e2dEffectType GetType(std::uint32_t model, std::uint32_t index) const;
+    bool GetData(std::uint32_t model, std::uint32_t index, S2DFXData& out) const;
+
+    bool Add(CResource* owner, std::uint32_t model, e2dEffectType type, const S2DFXData& data);
+    bool Remove(CResource* owner, std::uint32_t model, std::uint32_t index);
+    bool Restore(CResource* owner, std::uint32_t model, std::uint32_t index);
+    bool ResetModel(CResource* owner, std::uint32_t model);
+    bool SetProperty(CResource* owner, std::uint32_t model, std::uint32_t index, e2dEffectProperty property, const S2DFXData& value);
+    bool ResetProperty(CResource* owner, std::uint32_t model, std::uint32_t index, e2dEffectProperty property);
+    void ReleaseResource(CResource* owner);
+
+    static bool IsPropertyValid(e2dEffectType type, e2dEffectProperty property);
+    static void CopyProperty(S2DFXData& destination, const S2DFXData& source, e2dEffectProperty property);
+
+    C2DFXNativeEffect* ResolveNativeEffect(void* modelInfo, void* geometry, std::uint32_t pluginCount, std::uint32_t index);
+    void OnEntityEffectsCreated(void* entity);
+
+private:
+    CClient2DFXManager() = default;
+    ~CClient2DFXManager();
+    CClient2DFXManager(const CClient2DFXManager&) = delete;
+    CClient2DFXManager& operator=(const CClient2DFXManager&) = delete;
+
+    std::unique_ptr<SImpl> m_impl;
+};

--- a/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -10,6 +10,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include "../luadefs/CLua2DFXDefs.h"
 #include "../luadefs/CLuaFireDefs.h"
 #include "../luadefs/CLuaClientDefs.h"
 #include "../luadefs/CLuaVectorGraphicDefs.h"
@@ -258,6 +259,7 @@ void CLuaManager::LoadCFunctions()
     CLuaEffectDefs::LoadFunctions();
     CLuaElementDefs::LoadFunctions();
     CLuaEngineDefs::LoadFunctions();
+    CLua2DFXDefs::LoadFunctions();
     CLuaFireDefs::LoadFunctions();
     CLuaGUIDefs::LoadFunctions();
     CLuaMarkerDefs::LoadFunctions();

--- a/Client/mods/deathmatch/logic/luadefs/CLua2DFXDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLua2DFXDefs.cpp
@@ -1,0 +1,789 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.x / Neon
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Client/mods/deathmatch/logic/luadefs/CLua2DFXDefs.cpp
+ *  PURPOSE:     Resource-owned model 2DFX Lua API
+ *
+ *****************************************************************************/
+#include "StdInc.h"
+#include "CLua2DFXDefs.h"
+#include "../CClient2DFXManager.h"
+
+#include <cmath>
+#include <limits>
+
+namespace
+{
+    int AbsIndex(lua_State* luaVM, int index)
+    {
+        if (index > 0 || index <= LUA_REGISTRYINDEX)
+            return index;
+        return lua_gettop(luaVM) + index + 1;
+    }
+
+    CClient2DFXManager& Manager()
+    {
+        CClient2DFXManager& manager = CClient2DFXManager::GetSingleton();
+        manager.Initialize(CLuaDefs::m_pManager);
+        return manager;
+    }
+
+    CResource* Owner(lua_State* luaVM)
+    {
+        CLuaMain* main = CLuaDefs::m_pLuaManager ? CLuaDefs::m_pLuaManager->GetVirtualMachine(luaVM) : nullptr;
+        return main ? main->GetResource() : nullptr;
+    }
+
+    void LogError(lua_State* luaVM, const char* function, const char* message)
+    {
+        if (CLuaDefs::m_pScriptDebugging)
+            CLuaDefs::m_pScriptDebugging->LogCustom(luaVM, SString("Bad argument @ '%s' [%s]", function, message));
+    }
+
+    bool IsFinite(float value)
+    {
+        return std::isfinite(value);
+    }
+
+    bool IsFinite(const CVector& value)
+    {
+        return IsFinite(value.fX) && IsFinite(value.fY) && IsFinite(value.fZ);
+    }
+
+    bool ReadNumberField(lua_State* luaVM, int tableIndex, const char* key, float& output)
+    {
+        tableIndex = AbsIndex(luaVM, tableIndex);
+        lua_getfield(luaVM, tableIndex, key);
+        const bool valid = lua_isnumber(luaVM, -1) != 0;
+        if (valid)
+            output = static_cast<float>(lua_tonumber(luaVM, -1));
+        lua_pop(luaVM, 1);
+        return valid && IsFinite(output);
+    }
+
+    bool ReadIntegerField(lua_State* luaVM, int tableIndex, const char* key, int& output)
+    {
+        float value{};
+        if (!ReadNumberField(luaVM, tableIndex, key, value) || std::floor(value) != value || value < static_cast<float>(std::numeric_limits<int>::min()) ||
+            value > static_cast<float>(std::numeric_limits<int>::max()))
+            return false;
+        output = static_cast<int>(value);
+        return true;
+    }
+
+    bool ReadBoolField(lua_State* luaVM, int tableIndex, const char* key, bool& output)
+    {
+        tableIndex = AbsIndex(luaVM, tableIndex);
+        lua_getfield(luaVM, tableIndex, key);
+        const bool valid = lua_isboolean(luaVM, -1) != 0;
+        if (valid)
+            output = lua_toboolean(luaVM, -1) != 0;
+        lua_pop(luaVM, 1);
+        return valid;
+    }
+
+    bool ReadStringField(lua_State* luaVM, int tableIndex, const char* key, std::string& output)
+    {
+        tableIndex = AbsIndex(luaVM, tableIndex);
+        lua_getfield(luaVM, tableIndex, key);
+        const bool valid = lua_type(luaVM, -1) == LUA_TSTRING;
+        if (valid)
+            output = lua_tostring(luaVM, -1);
+        lua_pop(luaVM, 1);
+        return valid;
+    }
+
+    bool ReadVector(lua_State* luaVM, int index, CVector& output, std::size_t components = 3)
+    {
+        index = AbsIndex(luaVM, index);
+        if (!lua_istable(luaVM, index))
+            return false;
+
+        float values[3]{};
+        for (std::size_t component = 0; component < components; ++component)
+        {
+            lua_rawgeti(luaVM, index, static_cast<int>(component + 1));
+            const bool valid = lua_isnumber(luaVM, -1) != 0;
+            if (valid)
+                values[component] = static_cast<float>(lua_tonumber(luaVM, -1));
+            lua_pop(luaVM, 1);
+            if (!valid || !IsFinite(values[component]))
+                return false;
+        }
+        output = CVector(values[0], values[1], components > 2 ? values[2] : 0.0f);
+        return true;
+    }
+
+    bool ReadVectorField(lua_State* luaVM, int tableIndex, const char* key, CVector& output, std::size_t components = 3)
+    {
+        tableIndex = AbsIndex(luaVM, tableIndex);
+        lua_getfield(luaVM, tableIndex, key);
+        const bool result = ReadVector(luaVM, -1, output, components);
+        lua_pop(luaVM, 1);
+        return result;
+    }
+
+    bool ReadPackedColor(lua_State* luaVM, int index, std::uint32_t& color)
+    {
+        if (!lua_isnumber(luaVM, index))
+            return false;
+        const double value = lua_tonumber(luaVM, index);
+        if (!std::isfinite(value) || value < static_cast<double>(std::numeric_limits<std::int32_t>::min()) ||
+            value > static_cast<double>(std::numeric_limits<std::uint32_t>::max()))
+            return false;
+        color = static_cast<std::uint32_t>(static_cast<std::int64_t>(value));
+        return true;
+    }
+
+    bool ReadColorField(lua_State* luaVM, int tableIndex, const char* key, std::uint32_t& color)
+    {
+        tableIndex = AbsIndex(luaVM, tableIndex);
+        lua_getfield(luaVM, tableIndex, key);
+        const bool result = ReadPackedColor(luaVM, -1, color);
+        lua_pop(luaVM, 1);
+        return result;
+    }
+
+    bool StringToEffectType(const char* value, e2dEffectType& output)
+    {
+        if (!value)
+            return false;
+        if (strcmp(value, "light") == 0) output = e2dEffectType::LIGHT;
+        else if (strcmp(value, "particle") == 0) output = e2dEffectType::PARTICLE;
+        else if (strcmp(value, "sun_glare") == 0) output = e2dEffectType::SUN_GLARE;
+        else if (strcmp(value, "roadsign") == 0) output = e2dEffectType::ROADSIGN;
+        else if (strcmp(value, "escalator") == 0) output = e2dEffectType::ESCALATOR;
+        else return false;
+        return true;
+    }
+
+    const char* EffectTypeToString(e2dEffectType type)
+    {
+        switch (type)
+        {
+            case e2dEffectType::LIGHT: return "light";
+            case e2dEffectType::PARTICLE: return "particle";
+            case e2dEffectType::SUN_GLARE: return "sun_glare";
+            case e2dEffectType::ROADSIGN: return "roadsign";
+            case e2dEffectType::ESCALATOR: return "escalator";
+            default: return "unknown";
+        }
+    }
+
+    bool StringToFlashType(const char* value, e2dCoronaFlashType& output)
+    {
+        if (!value) return false;
+        struct Pair { const char* name; e2dCoronaFlashType value; };
+        static const Pair values[]{
+            {"default", e2dCoronaFlashType::DEFAULT}, {"random_flashing", e2dCoronaFlashType::RANDOM},
+            {"random_at_wet_weather", e2dCoronaFlashType::RANDOM_WHEN_WET}, {"anim_speed_4x", e2dCoronaFlashType::ANIM_SPEED_4X},
+            {"anim_speed_2x", e2dCoronaFlashType::ANIM_SPEED_2X}, {"anim_speed_1x", e2dCoronaFlashType::ANIM_SPEED_1X},
+            {"warnlight", e2dCoronaFlashType::WARNLIGHT}, {"trafficlight", e2dCoronaFlashType::TRAFFICLIGHT},
+            {"traincrosslight", e2dCoronaFlashType::TRAINCROSSING}, {"at_rain_only", e2dCoronaFlashType::ONLY_RAIN},
+            {"on_off_at_5", e2dCoronaFlashType::ON5_OFF5}, {"on_at_6_off_at_4", e2dCoronaFlashType::ON6_OFF4},
+            {"on_at_4_off_at_6", e2dCoronaFlashType::ON4_OFF6},
+        };
+        for (const auto& item : values)
+        {
+            if (strcmp(item.name, value) == 0)
+            {
+                output = item.value;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    const char* FlashTypeToString(e2dCoronaFlashType type)
+    {
+        switch (type)
+        {
+            case e2dCoronaFlashType::DEFAULT: return "default";
+            case e2dCoronaFlashType::RANDOM: return "random_flashing";
+            case e2dCoronaFlashType::RANDOM_WHEN_WET: return "random_at_wet_weather";
+            case e2dCoronaFlashType::ANIM_SPEED_4X: return "anim_speed_4x";
+            case e2dCoronaFlashType::ANIM_SPEED_2X: return "anim_speed_2x";
+            case e2dCoronaFlashType::ANIM_SPEED_1X: return "anim_speed_1x";
+            case e2dCoronaFlashType::WARNLIGHT: return "warnlight";
+            case e2dCoronaFlashType::TRAFFICLIGHT: return "trafficlight";
+            case e2dCoronaFlashType::TRAINCROSSING: return "traincrosslight";
+            case e2dCoronaFlashType::ONLY_RAIN: return "at_rain_only";
+            case e2dCoronaFlashType::ON5_OFF5: return "on_off_at_5";
+            case e2dCoronaFlashType::ON6_OFF4: return "on_at_6_off_at_4";
+            case e2dCoronaFlashType::ON4_OFF6: return "on_at_4_off_at_6";
+            default: return "default";
+        }
+    }
+
+    bool StringToProperty(const char* value, e2dEffectProperty& output)
+    {
+        if (!value) return false;
+        struct Pair { const char* name; e2dEffectProperty property; };
+        static const Pair properties[]{
+            {"drawDistance", e2dEffectProperty::FAR_CLIP_DISTANCE}, {"lightRange", e2dEffectProperty::LIGHT_RANGE},
+            {"coronaSize", e2dEffectProperty::CORONA_SIZE}, {"shadowSize", e2dEffectProperty::SHADOW_SIZE},
+            {"shadowMultiplier", e2dEffectProperty::SHADOW_MULT}, {"showMode", e2dEffectProperty::FLASH_TYPE},
+            {"coronaReflection", e2dEffectProperty::CORONA_REFLECTION}, {"flareType", e2dEffectProperty::FLARE_TYPE},
+            {"shadowDistance", e2dEffectProperty::SHADOW_DISTANCE}, {"offset", e2dEffectProperty::OFFSET},
+            {"color", e2dEffectProperty::COLOR}, {"coronaName", e2dEffectProperty::CORONA_NAME},
+            {"shadowName", e2dEffectProperty::SHADOW_NAME}, {"flags", e2dEffectProperty::FLAGS},
+            {"name", e2dEffectProperty::PARTICLE_NAME}, {"size", e2dEffectProperty::SIZE}, {"rotation", e2dEffectProperty::ROTATION},
+            {"text1", e2dEffectProperty::TEXT_1}, {"text2", e2dEffectProperty::TEXT_2}, {"text3", e2dEffectProperty::TEXT_3},
+            {"text4", e2dEffectProperty::TEXT_4}, {"bottom", e2dEffectProperty::BOTTOM}, {"top", e2dEffectProperty::TOP},
+            {"end", e2dEffectProperty::END}, {"direction", e2dEffectProperty::DIRECTION},
+        };
+        for (const auto& item : properties)
+        {
+            if (strcmp(item.name, value) == 0)
+            {
+                output = item.property;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool ReadFlags(lua_State* luaVM, int index, e2dEffectType type, std::uint16_t& flags)
+    {
+        index = AbsIndex(luaVM, index);
+        if (lua_isnumber(luaVM, index))
+        {
+            const double value = lua_tonumber(luaVM, index);
+            if (!std::isfinite(value) || value < 0.0 || value > 65535.0 || std::floor(value) != value)
+                return false;
+            flags = static_cast<std::uint16_t>(value);
+            return true;
+        }
+        if (!lua_istable(luaVM, index))
+            return false;
+
+        flags = 0;
+        if (type == e2dEffectType::LIGHT)
+        {
+            struct Flag { const char* name; unsigned bit; };
+            static const Flag values[]{
+                {"checkObstacles", 0}, {"fogType", 1}, {"fogType2", 2}, {"withoutCorona", 3}, {"onlyLongDistance", 4}, {"atDay", 5},
+                {"atNight", 6}, {"blinking1", 7}, {"onlyFromBelow", 8}, {"blinking2", 9}, {"updateHeightAboveGround", 10},
+                {"checkDirection", 11}, {"blinking3", 12},
+            };
+            for (const auto& item : values)
+            {
+                lua_getfield(luaVM, index, item.name);
+                if (lua_isboolean(luaVM, -1) && lua_toboolean(luaVM, -1))
+                    flags |= static_cast<std::uint16_t>(1u << item.bit);
+                else if (!lua_isnil(luaVM, -1) && !lua_isboolean(luaVM, -1))
+                {
+                    lua_pop(luaVM, 1);
+                    return false;
+                }
+                lua_pop(luaVM, 1);
+            }
+            return true;
+        }
+        if (type == e2dEffectType::ROADSIGN)
+        {
+            int lines = 4;
+            int characters = 16;
+            lua_getfield(luaVM, index, "lines");
+            if (!lua_isnil(luaVM, -1))
+            {
+                if (!lua_isnumber(luaVM, -1)) { lua_pop(luaVM, 1); return false; }
+                lines = static_cast<int>(lua_tonumber(luaVM, -1));
+            }
+            lua_pop(luaVM, 1);
+            lua_getfield(luaVM, index, "charactersPerLine");
+            if (!lua_isnil(luaVM, -1))
+            {
+                if (!lua_isnumber(luaVM, -1)) { lua_pop(luaVM, 1); return false; }
+                characters = static_cast<int>(lua_tonumber(luaVM, -1));
+            }
+            lua_pop(luaVM, 1);
+            if (lines < 1 || lines > 4 || (characters != 2 && characters != 4 && characters != 8 && characters != 16))
+                return false;
+            const int lineBits = lines == 4 ? 0 : lines;
+            int characterBits = 0;
+            if (characters == 2) characterBits = 1;
+            else if (characters == 4) characterBits = 2;
+            else if (characters == 8) characterBits = 3;
+            flags = static_cast<std::uint16_t>((lineBits & 3) | ((characterBits & 3) << 2));
+            return true;
+        }
+        return false;
+    }
+
+    bool ReadFlagsField(lua_State* luaVM, int tableIndex, const char* key, e2dEffectType type, std::uint16_t& flags)
+    {
+        tableIndex = AbsIndex(luaVM, tableIndex);
+        lua_getfield(luaVM, tableIndex, key);
+        const bool result = ReadFlags(luaVM, -1, type, flags);
+        lua_pop(luaVM, 1);
+        return result;
+    }
+
+    void PushVector(lua_State* luaVM, const CVector& value, std::size_t components = 3)
+    {
+        lua_createtable(luaVM, static_cast<int>(components), 0);
+        lua_pushnumber(luaVM, value.fX); lua_rawseti(luaVM, -2, 1);
+        lua_pushnumber(luaVM, value.fY); lua_rawseti(luaVM, -2, 2);
+        if (components > 2) { lua_pushnumber(luaVM, value.fZ); lua_rawseti(luaVM, -2, 3); }
+    }
+
+    void PushColor(lua_State* luaVM, std::uint32_t color)
+    {
+        lua_createtable(luaVM, 4, 0);
+        lua_pushnumber(luaVM, (color >> 16) & 0xFF); lua_rawseti(luaVM, -2, 1);
+        lua_pushnumber(luaVM, (color >> 8) & 0xFF); lua_rawseti(luaVM, -2, 2);
+        lua_pushnumber(luaVM, color & 0xFF); lua_rawseti(luaVM, -2, 3);
+        lua_pushnumber(luaVM, (color >> 24) & 0xFF); lua_rawseti(luaVM, -2, 4);
+    }
+
+    void PushFlags(lua_State* luaVM, e2dEffectType type, std::uint16_t flags)
+    {
+        lua_newtable(luaVM);
+        if (type == e2dEffectType::LIGHT)
+        {
+            struct Flag { const char* name; unsigned bit; };
+            static const Flag values[]{
+                {"checkObstacles", 0}, {"fogType", 1}, {"fogType2", 2}, {"withoutCorona", 3}, {"onlyLongDistance", 4}, {"atDay", 5},
+                {"atNight", 6}, {"blinking1", 7}, {"onlyFromBelow", 8}, {"blinking2", 9}, {"updateHeightAboveGround", 10},
+                {"checkDirection", 11}, {"blinking3", 12},
+            };
+            for (const auto& item : values)
+            {
+                lua_pushboolean(luaVM, (flags & (1u << item.bit)) != 0);
+                lua_setfield(luaVM, -2, item.name);
+            }
+        }
+        else if (type == e2dEffectType::ROADSIGN)
+        {
+            const int lineBits = flags & 3;
+            const int charBits = (flags >> 2) & 3;
+            lua_pushnumber(luaVM, lineBits == 0 ? 4 : lineBits); lua_setfield(luaVM, -2, "lines");
+            const int chars = charBits == 0 ? 16 : (charBits == 1 ? 2 : (charBits == 2 ? 4 : 8));
+            lua_pushnumber(luaVM, chars); lua_setfield(luaVM, -2, "charactersPerLine");
+        }
+    }
+
+    bool ReadEffectData(lua_State* luaVM, int tableIndex, e2dEffectType type, S2DFXData& data, const char*& error)
+    {
+        if (type == e2dEffectType::SUN_GLARE)
+            return lua_isnil(luaVM, tableIndex) || lua_istable(luaVM, tableIndex);
+        if (!lua_istable(luaVM, tableIndex)) { error = "properties must be a table"; return false; }
+        tableIndex = AbsIndex(luaVM, tableIndex);
+
+        if (type == e2dEffectType::LIGHT)
+        {
+            float shadowMultiplier{}, shadowDistance{}, flareType{};
+            std::string showMode;
+            if (!ReadNumberField(luaVM, tableIndex, "drawDistance", data.drawDistance) || data.drawDistance < 0.0f) { error = "invalid drawDistance"; return false; }
+            if (!ReadNumberField(luaVM, tableIndex, "lightRange", data.lightRange) || data.lightRange < 0.0f) { error = "invalid lightRange"; return false; }
+            if (!ReadNumberField(luaVM, tableIndex, "coronaSize", data.coronaSize) || data.coronaSize < 0.0f) { error = "invalid coronaSize"; return false; }
+            if (!ReadNumberField(luaVM, tableIndex, "shadowSize", data.shadowSize) || data.shadowSize < 0.0f) { error = "invalid shadowSize"; return false; }
+            if (!ReadNumberField(luaVM, tableIndex, "shadowMultiplier", shadowMultiplier) || shadowMultiplier < 0.0f || shadowMultiplier > 255.0f || std::floor(shadowMultiplier) != shadowMultiplier) { error = "invalid shadowMultiplier"; return false; }
+            if (!ReadStringField(luaVM, tableIndex, "showMode", showMode) || !StringToFlashType(showMode.c_str(), data.flashType)) { error = "invalid showMode"; return false; }
+            if (!ReadBoolField(luaVM, tableIndex, "coronaReflection", data.coronaReflection)) { error = "invalid coronaReflection"; return false; }
+            if (!ReadNumberField(luaVM, tableIndex, "flareType", flareType) || flareType < 0.0f || flareType > 1.0f || std::floor(flareType) != flareType) { error = "invalid flareType"; return false; }
+            if (!ReadFlagsField(luaVM, tableIndex, "flags", type, data.flags)) { error = "invalid flags"; return false; }
+            if (!ReadNumberField(luaVM, tableIndex, "shadowDistance", shadowDistance) || shadowDistance < -128.0f || shadowDistance > 127.0f || std::floor(shadowDistance) != shadowDistance) { error = "invalid shadowDistance"; return false; }
+            if (!ReadVectorField(luaVM, tableIndex, "offset", data.offset) || data.offset.fX < -128.0f || data.offset.fX > 127.0f || data.offset.fY < -128.0f || data.offset.fY > 127.0f || data.offset.fZ < -128.0f || data.offset.fZ > 127.0f) { error = "invalid offset"; return false; }
+            if (!ReadColorField(luaVM, tableIndex, "color", data.color)) { error = "invalid color"; return false; }
+            if (!ReadStringField(luaVM, tableIndex, "coronaName", data.coronaName) || data.coronaName.empty()) { error = "invalid coronaName"; return false; }
+            if (!ReadStringField(luaVM, tableIndex, "shadowName", data.shadowName) || data.shadowName.empty()) { error = "invalid shadowName"; return false; }
+            data.shadowMultiplier = static_cast<std::uint8_t>(shadowMultiplier);
+            data.shadowDistance = static_cast<std::int8_t>(shadowDistance);
+            data.flareType = static_cast<std::uint8_t>(flareType);
+            return true;
+        }
+        if (type == e2dEffectType::PARTICLE)
+        {
+            if (!ReadStringField(luaVM, tableIndex, "name", data.particleName) || data.particleName.empty() || data.particleName.size() >= 24) { error = "particle name must contain 1-23 characters"; return false; }
+            return true;
+        }
+        if (type == e2dEffectType::ROADSIGN)
+        {
+            if (!ReadVectorField(luaVM, tableIndex, "size", data.size, 2) || data.size.fX <= 0.0f || data.size.fY <= 0.0f) { error = "invalid size"; return false; }
+            if (!ReadVectorField(luaVM, tableIndex, "rotation", data.rotation)) { error = "invalid rotation"; return false; }
+            if (!ReadFlagsField(luaVM, tableIndex, "flags", type, data.flags)) { error = "invalid flags"; return false; }
+            if (!ReadColorField(luaVM, tableIndex, "color", data.color)) { error = "invalid color"; return false; }
+            for (std::size_t line = 0; line < 4; ++line)
+            {
+                const char* keys[]{"text1", "text2", "text3", "text4"};
+                if (!ReadStringField(luaVM, tableIndex, keys[line], data.text[line]) || data.text[line].size() > 16) { error = "roadsign lines may contain at most 16 characters"; return false; }
+            }
+            return true;
+        }
+        if (type == e2dEffectType::ESCALATOR)
+        {
+            float direction{};
+            if (!ReadVectorField(luaVM, tableIndex, "bottom", data.bottom)) { error = "invalid bottom"; return false; }
+            if (!ReadVectorField(luaVM, tableIndex, "top", data.top)) { error = "invalid top"; return false; }
+            if (!ReadVectorField(luaVM, tableIndex, "end", data.end)) { error = "invalid end"; return false; }
+            if (!ReadNumberField(luaVM, tableIndex, "direction", direction) || (direction != 0.0f && direction != 1.0f)) { error = "direction must be 0 or 1"; return false; }
+            data.direction = static_cast<std::uint8_t>(direction);
+            return true;
+        }
+        error = "unsupported effect type";
+        return false;
+    }
+
+    bool ReadPropertyValue(lua_State* luaVM, int index, e2dEffectType type, e2dEffectProperty property, S2DFXData& data)
+    {
+        float number{};
+        switch (property)
+        {
+            case e2dEffectProperty::FAR_CLIP_DISTANCE:
+            case e2dEffectProperty::LIGHT_RANGE:
+            case e2dEffectProperty::CORONA_SIZE:
+            case e2dEffectProperty::SHADOW_SIZE:
+                if (!lua_isnumber(luaVM, index)) return false;
+                number = static_cast<float>(lua_tonumber(luaVM, index));
+                if (!IsFinite(number) || number < 0.0f) return false;
+                if (property == e2dEffectProperty::FAR_CLIP_DISTANCE) data.drawDistance = number;
+                else if (property == e2dEffectProperty::LIGHT_RANGE) data.lightRange = number;
+                else if (property == e2dEffectProperty::CORONA_SIZE) data.coronaSize = number;
+                else data.shadowSize = number;
+                return true;
+            case e2dEffectProperty::SHADOW_MULT:
+                if (!lua_isnumber(luaVM, index)) return false;
+                number = static_cast<float>(lua_tonumber(luaVM, index));
+                if (!IsFinite(number) || number < 0.0f || number > 255.0f || std::floor(number) != number) return false;
+                data.shadowMultiplier = static_cast<std::uint8_t>(number); return true;
+            case e2dEffectProperty::FLASH_TYPE:
+                return lua_type(luaVM, index) == LUA_TSTRING && StringToFlashType(lua_tostring(luaVM, index), data.flashType);
+            case e2dEffectProperty::CORONA_REFLECTION:
+                if (!lua_isboolean(luaVM, index)) return false;
+                data.coronaReflection = lua_toboolean(luaVM, index) != 0; return true;
+            case e2dEffectProperty::FLARE_TYPE:
+                if (!lua_isnumber(luaVM, index)) return false;
+                number = static_cast<float>(lua_tonumber(luaVM, index));
+                if (number != 0.0f && number != 1.0f) return false;
+                data.flareType = static_cast<std::uint8_t>(number); return true;
+            case e2dEffectProperty::SHADOW_DISTANCE:
+                if (!lua_isnumber(luaVM, index)) return false;
+                number = static_cast<float>(lua_tonumber(luaVM, index));
+                if (!IsFinite(number) || number < -128.0f || number > 127.0f || std::floor(number) != number) return false;
+                data.shadowDistance = static_cast<std::int8_t>(number); return true;
+            case e2dEffectProperty::OFFSET:
+                if (!ReadVector(luaVM, index, data.offset) || data.offset.fX < -128.0f || data.offset.fX > 127.0f || data.offset.fY < -128.0f || data.offset.fY > 127.0f || data.offset.fZ < -128.0f || data.offset.fZ > 127.0f) return false;
+                return true;
+            case e2dEffectProperty::COLOR:
+                return ReadPackedColor(luaVM, index, data.color);
+            case e2dEffectProperty::CORONA_NAME:
+                if (lua_type(luaVM, index) != LUA_TSTRING) return false;
+                data.coronaName = lua_tostring(luaVM, index); return !data.coronaName.empty();
+            case e2dEffectProperty::SHADOW_NAME:
+                if (lua_type(luaVM, index) != LUA_TSTRING) return false;
+                data.shadowName = lua_tostring(luaVM, index); return !data.shadowName.empty();
+            case e2dEffectProperty::FLAGS:
+                return ReadFlags(luaVM, index, type, data.flags);
+            case e2dEffectProperty::PARTICLE_NAME:
+                if (lua_type(luaVM, index) != LUA_TSTRING) return false;
+                data.particleName = lua_tostring(luaVM, index); return !data.particleName.empty() && data.particleName.size() < 24;
+            case e2dEffectProperty::SIZE:
+                return ReadVector(luaVM, index, data.size, 2) && data.size.fX > 0.0f && data.size.fY > 0.0f;
+            case e2dEffectProperty::ROTATION:
+                return ReadVector(luaVM, index, data.rotation);
+            case e2dEffectProperty::TEXT_1:
+            case e2dEffectProperty::TEXT_2:
+            case e2dEffectProperty::TEXT_3:
+            case e2dEffectProperty::TEXT_4:
+            {
+                if (lua_type(luaVM, index) != LUA_TSTRING) return false;
+                const std::size_t line = static_cast<std::size_t>(property) - static_cast<std::size_t>(e2dEffectProperty::TEXT_1);
+                data.text[line] = lua_tostring(luaVM, index); return data.text[line].size() <= 16;
+            }
+            case e2dEffectProperty::BOTTOM: return ReadVector(luaVM, index, data.bottom);
+            case e2dEffectProperty::TOP: return ReadVector(luaVM, index, data.top);
+            case e2dEffectProperty::END: return ReadVector(luaVM, index, data.end);
+            case e2dEffectProperty::DIRECTION:
+                if (!lua_isnumber(luaVM, index)) return false;
+                number = static_cast<float>(lua_tonumber(luaVM, index));
+                if (number != 0.0f && number != 1.0f) return false;
+                data.direction = static_cast<std::uint8_t>(number); return true;
+            default: return false;
+        }
+    }
+
+    void PushProperties(lua_State* luaVM, e2dEffectType type, const S2DFXData& data)
+    {
+        lua_newtable(luaVM);
+        if (type == e2dEffectType::LIGHT)
+        {
+            lua_pushnumber(luaVM, data.drawDistance); lua_setfield(luaVM, -2, "drawDistance");
+            lua_pushnumber(luaVM, data.lightRange); lua_setfield(luaVM, -2, "lightRange");
+            lua_pushnumber(luaVM, data.coronaSize); lua_setfield(luaVM, -2, "coronaSize");
+            lua_pushnumber(luaVM, data.shadowSize); lua_setfield(luaVM, -2, "shadowSize");
+            lua_pushnumber(luaVM, data.shadowMultiplier); lua_setfield(luaVM, -2, "shadowMultiplier");
+            lua_pushstring(luaVM, FlashTypeToString(data.flashType)); lua_setfield(luaVM, -2, "showMode");
+            lua_pushboolean(luaVM, data.coronaReflection); lua_setfield(luaVM, -2, "coronaReflection");
+            lua_pushnumber(luaVM, data.flareType); lua_setfield(luaVM, -2, "flareType");
+            lua_pushnumber(luaVM, data.flags); lua_setfield(luaVM, -2, "flags");
+            lua_pushnumber(luaVM, data.shadowDistance); lua_setfield(luaVM, -2, "shadowDistance");
+            PushVector(luaVM, data.offset); lua_setfield(luaVM, -2, "offset");
+            PushColor(luaVM, data.color); lua_setfield(luaVM, -2, "color");
+            lua_pushstring(luaVM, data.coronaName.c_str()); lua_setfield(luaVM, -2, "coronaName");
+            lua_pushstring(luaVM, data.shadowName.c_str()); lua_setfield(luaVM, -2, "shadowName");
+        }
+        else if (type == e2dEffectType::PARTICLE)
+        {
+            lua_pushstring(luaVM, data.particleName.c_str()); lua_setfield(luaVM, -2, "name");
+        }
+        else if (type == e2dEffectType::ROADSIGN)
+        {
+            PushVector(luaVM, data.size, 2); lua_setfield(luaVM, -2, "size");
+            PushVector(luaVM, data.rotation); lua_setfield(luaVM, -2, "rotation");
+            lua_pushnumber(luaVM, data.flags); lua_setfield(luaVM, -2, "flags");
+            PushColor(luaVM, data.color); lua_setfield(luaVM, -2, "color");
+            const char* keys[]{"text1", "text2", "text3", "text4"};
+            for (std::size_t line = 0; line < 4; ++line) { lua_pushstring(luaVM, data.text[line].c_str()); lua_setfield(luaVM, -2, keys[line]); }
+        }
+        else if (type == e2dEffectType::ESCALATOR)
+        {
+            PushVector(luaVM, data.bottom); lua_setfield(luaVM, -2, "bottom");
+            PushVector(luaVM, data.top); lua_setfield(luaVM, -2, "top");
+            PushVector(luaVM, data.end); lua_setfield(luaVM, -2, "end");
+            lua_pushnumber(luaVM, data.direction); lua_setfield(luaVM, -2, "direction");
+        }
+    }
+
+    bool ReadModelIndex(lua_State* luaVM, int modelArg, int indexArg, std::uint32_t& model, std::uint32_t& index)
+    {
+        if (!lua_isnumber(luaVM, modelArg) || !lua_isnumber(luaVM, indexArg))
+            return false;
+        const double modelValue = lua_tonumber(luaVM, modelArg);
+        const double indexValue = lua_tonumber(luaVM, indexArg);
+        if (!std::isfinite(modelValue) || !std::isfinite(indexValue) || modelValue < 0.0 || modelValue > 65535.0 || indexValue < 0.0 ||
+            indexValue > static_cast<double>(std::numeric_limits<std::uint32_t>::max()) || std::floor(modelValue) != modelValue || std::floor(indexValue) != indexValue)
+            return false;
+        model = static_cast<std::uint32_t>(modelValue);
+        index = static_cast<std::uint32_t>(indexValue);
+        return true;
+    }
+}
+
+void CLua2DFXDefs::LoadFunctions()
+{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
+        {"addModel2DFX", AddModel2DFX}, {"removeModel2DFX", RemoveModel2DFX}, {"restoreModel2DFX", RestoreModel2DFX},
+        {"resetModel2DFXEffects", ResetModel2DFXEffects}, {"setModel2DFXPosition", SetModel2DFXPosition},
+        {"setModel2DFXProperty", SetModel2DFXProperty}, {"resetModel2DFXProperty", ResetModel2DFXProperty},
+        {"resetModel2DFXPosition", ResetModel2DFXPosition}, {"getModel2DFXPosition", GetModel2DFXPosition},
+        {"getModel2DFXProperty", GetModel2DFXProperty}, {"getModel2DFXEffects", GetModel2DFXEffects},
+        {"getModel2DFXCount", GetModel2DFXCount}, {"getModel2DFXType", GetModel2DFXType},
+    };
+    for (const auto& [name, function] : functions)
+        CLuaCFunctions::AddFunction(name, function);
+}
+
+int CLua2DFXDefs::AddModel2DFX(lua_State* luaVM)
+{
+    const char* function = "addModel2DFX";
+    if (lua_gettop(luaVM) < 6 || !lua_isnumber(luaVM, 1) || !lua_isnumber(luaVM, 2) || !lua_isnumber(luaVM, 3) || !lua_isnumber(luaVM, 4) ||
+        lua_type(luaVM, 5) != LUA_TSTRING)
+    {
+        LogError(luaVM, function, "expected model, x, y, z, type, properties"); lua_pushboolean(luaVM, false); return 1;
+    }
+    const double modelValue = lua_tonumber(luaVM, 1);
+    CVector position(static_cast<float>(lua_tonumber(luaVM, 2)), static_cast<float>(lua_tonumber(luaVM, 3)), static_cast<float>(lua_tonumber(luaVM, 4)));
+    e2dEffectType type{};
+    if (!std::isfinite(modelValue) || modelValue < 0.0 || modelValue > 65535.0 || std::floor(modelValue) != modelValue || !IsFinite(position) ||
+        !StringToEffectType(lua_tostring(luaVM, 5), type))
+    {
+        LogError(luaVM, function, "invalid model, position or effect type"); lua_pushboolean(luaVM, false); return 1;
+    }
+    S2DFXData data{};
+    data.position = position;
+    const char* error = nullptr;
+    if (!ReadEffectData(luaVM, 6, type, data, error))
+    {
+        LogError(luaVM, function, error ? error : "invalid properties"); lua_pushboolean(luaVM, false); return 1;
+    }
+    CResource* owner = Owner(luaVM);
+    const bool result = owner && Manager().Add(owner, static_cast<std::uint32_t>(modelValue), type, data);
+    lua_pushboolean(luaVM, result);
+    return 1;
+}
+
+int CLua2DFXDefs::RemoveModel2DFX(lua_State* luaVM)
+{
+    std::uint32_t model{}, index{};
+    CResource* owner = Owner(luaVM);
+    const bool result = owner && ReadModelIndex(luaVM, 1, 2, model, index) && Manager().Remove(owner, model, index);
+    lua_pushboolean(luaVM, result);
+    return 1;
+}
+
+int CLua2DFXDefs::RestoreModel2DFX(lua_State* luaVM)
+{
+    std::uint32_t model{}, index{};
+    CResource* owner = Owner(luaVM);
+    if (owner && ReadModelIndex(luaVM, 1, 2, model, index))
+        Manager().Restore(owner, model, index);
+    return 0;
+}
+
+int CLua2DFXDefs::ResetModel2DFXEffects(lua_State* luaVM)
+{
+    if (!lua_isnumber(luaVM, 1)) return 0;
+    const double value = lua_tonumber(luaVM, 1);
+    CResource* owner = Owner(luaVM);
+    if (owner && std::isfinite(value) && value >= 0.0 && value <= 65535.0 && std::floor(value) == value)
+        Manager().ResetModel(owner, static_cast<std::uint32_t>(value));
+    return 0;
+}
+
+int CLua2DFXDefs::SetModel2DFXPosition(lua_State* luaVM)
+{
+    std::uint32_t model{}, index{};
+    if (!ReadModelIndex(luaVM, 1, 2, model, index) || !lua_isnumber(luaVM, 3) || !lua_isnumber(luaVM, 4) || !lua_isnumber(luaVM, 5))
+        return 0;
+    S2DFXData value{};
+    value.position = CVector(static_cast<float>(lua_tonumber(luaVM, 3)), static_cast<float>(lua_tonumber(luaVM, 4)), static_cast<float>(lua_tonumber(luaVM, 5)));
+    CResource* owner = Owner(luaVM);
+    if (owner && IsFinite(value.position))
+        Manager().SetProperty(owner, model, index, e2dEffectProperty::POSITION, value);
+    return 0;
+}
+
+int CLua2DFXDefs::SetModel2DFXProperty(lua_State* luaVM)
+{
+    std::uint32_t model{}, index{};
+    e2dEffectProperty property{};
+    if (!ReadModelIndex(luaVM, 1, 2, model, index) || lua_type(luaVM, 3) != LUA_TSTRING || !StringToProperty(lua_tostring(luaVM, 3), property))
+    {
+        lua_pushboolean(luaVM, false); return 1;
+    }
+    e2dEffectType type = Manager().GetType(model, index);
+    S2DFXData value{};
+    if (!CClient2DFXManager::IsPropertyValid(type, property) || !ReadPropertyValue(luaVM, 4, type, property, value))
+    {
+        lua_pushboolean(luaVM, false); return 1;
+    }
+    CResource* owner = Owner(luaVM);
+    lua_pushboolean(luaVM, owner && Manager().SetProperty(owner, model, index, property, value));
+    return 1;
+}
+
+int CLua2DFXDefs::ResetModel2DFXProperty(lua_State* luaVM)
+{
+    std::uint32_t model{}, index{};
+    e2dEffectProperty property{};
+    CResource* owner = Owner(luaVM);
+    if (owner && ReadModelIndex(luaVM, 1, 2, model, index) && lua_type(luaVM, 3) == LUA_TSTRING && StringToProperty(lua_tostring(luaVM, 3), property))
+        Manager().ResetProperty(owner, model, index, property);
+    return 0;
+}
+
+int CLua2DFXDefs::ResetModel2DFXPosition(lua_State* luaVM)
+{
+    std::uint32_t model{}, index{};
+    CResource* owner = Owner(luaVM);
+    if (owner && ReadModelIndex(luaVM, 1, 2, model, index))
+        Manager().ResetProperty(owner, model, index, e2dEffectProperty::POSITION);
+    return 0;
+}
+
+int CLua2DFXDefs::GetModel2DFXPosition(lua_State* luaVM)
+{
+    std::uint32_t model{}, index{};
+    S2DFXData data{};
+    if (!ReadModelIndex(luaVM, 1, 2, model, index) || !Manager().GetData(model, index, data))
+    {
+        lua_pushboolean(luaVM, false); return 1;
+    }
+    lua_pushnumber(luaVM, data.position.fX); lua_pushnumber(luaVM, data.position.fY); lua_pushnumber(luaVM, data.position.fZ);
+    return 3;
+}
+
+int CLua2DFXDefs::GetModel2DFXProperty(lua_State* luaVM)
+{
+    std::uint32_t model{}, index{};
+    e2dEffectProperty property{};
+    S2DFXData data{};
+    if (!ReadModelIndex(luaVM, 1, 2, model, index) || lua_type(luaVM, 3) != LUA_TSTRING || !StringToProperty(lua_tostring(luaVM, 3), property) ||
+        !Manager().GetData(model, index, data) || !CClient2DFXManager::IsPropertyValid(Manager().GetType(model, index), property))
+    {
+        lua_pushboolean(luaVM, false); return 1;
+    }
+    switch (property)
+    {
+        case e2dEffectProperty::FAR_CLIP_DISTANCE: lua_pushnumber(luaVM, data.drawDistance); return 1;
+        case e2dEffectProperty::LIGHT_RANGE: lua_pushnumber(luaVM, data.lightRange); return 1;
+        case e2dEffectProperty::CORONA_SIZE: lua_pushnumber(luaVM, data.coronaSize); return 1;
+        case e2dEffectProperty::SHADOW_SIZE: lua_pushnumber(luaVM, data.shadowSize); return 1;
+        case e2dEffectProperty::SHADOW_MULT: lua_pushnumber(luaVM, data.shadowMultiplier); return 1;
+        case e2dEffectProperty::FLASH_TYPE: lua_pushstring(luaVM, FlashTypeToString(data.flashType)); return 1;
+        case e2dEffectProperty::CORONA_REFLECTION: lua_pushboolean(luaVM, data.coronaReflection); return 1;
+        case e2dEffectProperty::FLARE_TYPE: lua_pushnumber(luaVM, data.flareType); return 1;
+        case e2dEffectProperty::SHADOW_DISTANCE: lua_pushnumber(luaVM, data.shadowDistance); return 1;
+        case e2dEffectProperty::OFFSET: lua_pushnumber(luaVM, data.offset.fX); lua_pushnumber(luaVM, data.offset.fY); lua_pushnumber(luaVM, data.offset.fZ); return 3;
+        case e2dEffectProperty::COLOR:
+            lua_pushnumber(luaVM, (data.color >> 16) & 0xFF); lua_pushnumber(luaVM, (data.color >> 8) & 0xFF); lua_pushnumber(luaVM, data.color & 0xFF); lua_pushnumber(luaVM, (data.color >> 24) & 0xFF); return 4;
+        case e2dEffectProperty::CORONA_NAME: lua_pushstring(luaVM, data.coronaName.c_str()); return 1;
+        case e2dEffectProperty::SHADOW_NAME: lua_pushstring(luaVM, data.shadowName.c_str()); return 1;
+        case e2dEffectProperty::FLAGS:
+            if (lua_toboolean(luaVM, 4)) PushFlags(luaVM, Manager().GetType(model, index), data.flags); else lua_pushnumber(luaVM, data.flags);
+            return 1;
+        case e2dEffectProperty::PARTICLE_NAME: lua_pushstring(luaVM, data.particleName.c_str()); return 1;
+        case e2dEffectProperty::SIZE: lua_pushnumber(luaVM, data.size.fX); lua_pushnumber(luaVM, data.size.fY); return 2;
+        case e2dEffectProperty::ROTATION: lua_pushnumber(luaVM, data.rotation.fX); lua_pushnumber(luaVM, data.rotation.fY); lua_pushnumber(luaVM, data.rotation.fZ); return 3;
+        case e2dEffectProperty::TEXT_1: lua_pushstring(luaVM, data.text[0].c_str()); return 1;
+        case e2dEffectProperty::TEXT_2: lua_pushstring(luaVM, data.text[1].c_str()); return 1;
+        case e2dEffectProperty::TEXT_3: lua_pushstring(luaVM, data.text[2].c_str()); return 1;
+        case e2dEffectProperty::TEXT_4: lua_pushstring(luaVM, data.text[3].c_str()); return 1;
+        case e2dEffectProperty::BOTTOM: lua_pushnumber(luaVM, data.bottom.fX); lua_pushnumber(luaVM, data.bottom.fY); lua_pushnumber(luaVM, data.bottom.fZ); return 3;
+        case e2dEffectProperty::TOP: lua_pushnumber(luaVM, data.top.fX); lua_pushnumber(luaVM, data.top.fY); lua_pushnumber(luaVM, data.top.fZ); return 3;
+        case e2dEffectProperty::END: lua_pushnumber(luaVM, data.end.fX); lua_pushnumber(luaVM, data.end.fY); lua_pushnumber(luaVM, data.end.fZ); return 3;
+        case e2dEffectProperty::DIRECTION: lua_pushnumber(luaVM, data.direction); return 1;
+        default: lua_pushboolean(luaVM, false); return 1;
+    }
+}
+
+int CLua2DFXDefs::GetModel2DFXEffects(lua_State* luaVM)
+{
+    if (!lua_isnumber(luaVM, 1)) { lua_pushboolean(luaVM, false); return 1; }
+    const double modelValue = lua_tonumber(luaVM, 1);
+    if (!std::isfinite(modelValue) || modelValue < 0.0 || modelValue > 65535.0 || std::floor(modelValue) != modelValue) { lua_pushboolean(luaVM, false); return 1; }
+    const std::uint32_t model = static_cast<std::uint32_t>(modelValue);
+    const bool includeCustom = lua_gettop(luaVM) < 2 || lua_toboolean(luaVM, 2) != 0;
+    if (!Manager().IsValidModel(model)) { lua_pushboolean(luaVM, false); return 1; }
+
+    lua_newtable(luaVM);
+    const std::uint32_t count = Manager().GetCount(model, includeCustom);
+    for (std::uint32_t index = 0; index < count; ++index)
+    {
+        lua_pushnumber(luaVM, index);
+        lua_newtable(luaVM);
+        const e2dEffectType type = Manager().GetType(model, index);
+        S2DFXData data{};
+        const bool available = Manager().GetData(model, index, data);
+        if (available) PushVector(luaVM, data.position); else PushVector(luaVM, CVector());
+        lua_setfield(luaVM, -2, "position");
+        lua_pushstring(luaVM, EffectTypeToString(type)); lua_setfield(luaVM, -2, "type");
+        if (available) PushProperties(luaVM, type, data); else lua_newtable(luaVM);
+        lua_setfield(luaVM, -2, "properties");
+        lua_settable(luaVM, -3);
+    }
+    return 1;
+}
+
+int CLua2DFXDefs::GetModel2DFXCount(lua_State* luaVM)
+{
+    if (!lua_isnumber(luaVM, 1)) { lua_pushnumber(luaVM, 0); return 1; }
+    const double modelValue = lua_tonumber(luaVM, 1);
+    if (!std::isfinite(modelValue) || modelValue < 0.0 || modelValue > 65535.0 || std::floor(modelValue) != modelValue) { lua_pushnumber(luaVM, 0); return 1; }
+    const bool includeCustom = lua_gettop(luaVM) < 2 || lua_toboolean(luaVM, 2) != 0;
+    lua_pushnumber(luaVM, Manager().GetCount(static_cast<std::uint32_t>(modelValue), includeCustom));
+    return 1;
+}
+
+int CLua2DFXDefs::GetModel2DFXType(lua_State* luaVM)
+{
+    std::uint32_t model{}, index{};
+    if (!ReadModelIndex(luaVM, 1, 2, model, index)) { lua_pushboolean(luaVM, false); return 1; }
+    const e2dEffectType type = Manager().GetType(model, index);
+    if (type == e2dEffectType::NONE) { lua_pushboolean(luaVM, false); return 1; }
+    lua_pushstring(luaVM, EffectTypeToString(type));
+    return 1;
+}

--- a/Client/mods/deathmatch/logic/luadefs/CLua2DFXDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLua2DFXDefs.h
@@ -1,0 +1,30 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.x / Neon
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Client/mods/deathmatch/logic/luadefs/CLua2DFXDefs.h
+ *
+ *****************************************************************************/
+#pragma once
+
+#include "CLuaDefs.h"
+
+class CLua2DFXDefs : public CLuaDefs
+{
+public:
+    static void LoadFunctions();
+
+    LUA_DECLARE(AddModel2DFX);
+    LUA_DECLARE(RemoveModel2DFX);
+    LUA_DECLARE(RestoreModel2DFX);
+    LUA_DECLARE(ResetModel2DFXEffects);
+    LUA_DECLARE(SetModel2DFXPosition);
+    LUA_DECLARE(SetModel2DFXProperty);
+    LUA_DECLARE(ResetModel2DFXProperty);
+    LUA_DECLARE(ResetModel2DFXPosition);
+    LUA_DECLARE(GetModel2DFXPosition);
+    LUA_DECLARE(GetModel2DFXProperty);
+    LUA_DECLARE(GetModel2DFXEffects);
+    LUA_DECLARE(GetModel2DFXCount);
+    LUA_DECLARE(GetModel2DFXType);
+};

--- a/test-resources/2dfx-showcase/README.md
+++ b/test-resources/2dfx-showcase/README.md
@@ -1,6 +1,15 @@
-# 2DFX cinematic showcase
+# 2DFX runway showcase
 
-Gameplay-only showcase for the resource-owned model 2DFX API in PR #56.
+Gameplay-only cinematic for the resource-owned model 2DFX API in PR #56.
+
+The scene uses the Verdant Meadows runway between:
+
+```text
+100.74450, 2501.11401, 16.48438
+424.00473, 2503.03442, 16.48438
+```
+
+No mall, buildings, escalators or decorative showcase props are created. Runtime models are invisible anchors; the camera should show only the normal GTA runway and native 2DFX output.
 
 ## Run
 
@@ -9,36 +18,48 @@ start 2dfx-showcase
 /2dfxshow
 ```
 
-The full cinematic is about 42 seconds. HUD/chat are hidden while recording and the player is staged in an isolated dimension over Verdant Meadows. Setup/restream work is performed while the camera is faded to black.
+The full sequence lasts about 38 seconds. Setup, runtime-model allocation and targeted particle/roadsign restreams happen while the camera is black. The recorded timeline never calls `engineRestreamWorld()`.
 
 Use `/2dfxshow stop` to abort and restore the player immediately.
 
 ## Production commands
 
 - `/2dfxshow` or `/2dfxshow full` — full seven-shot cinematic.
-- `/2dfxshow shot 1` — sunset / native SUN_GLARE.
-- `/2dfxshow shot 2` — model-level neon light wave.
-- `/2dfxshow shot 3` — mutate and restore a vanilla GTA light.
-- `/2dfxshow shot 4` — native particle 2DFX on rooftop-style anchors.
-- `/2dfxshow shot 5` — generated native roadsign text.
-- `/2dfxshow shot 6` — two native escalators moving in opposite directions.
-- `/2dfxshow shot 7` — final wide shot with everything active.
-- `/2dfxshow final` — hold the final composition indefinitely for screenshots.
-- `/2dfxshow setup` — hold the final scene with chat/HUD visible for visual inspection.
+- `/2dfxshow shot 1` — clean sunset runway / native `SUN_GLARE` establishing shot.
+- `/2dfxshow shot 2` — night transition and far-to-near runway edge ignition.
+- `/2dfxshow shot 3` — model-level color chase, centerline animation and flash modes.
+- `/2dfxshow shot 4` — close-up mutation and restoration of a real GTA lamp 2DFX.
+- `/2dfxshow shot 5` — native `smoke_flare` and `fire` particle gates at the far threshold.
+- `/2dfxshow shot 6` — native generated roadsign text on the runway.
+- `/2dfxshow shot 7` — full-runway finale with color waves, threshold lights and centerline strobes.
+- `/2dfxshow final` — hold the final composition for screenshots.
+- `/2dfxshow setup` — hold the final composition with HUD/chat visible for visual inspection.
 - `/2dfxshow stop` — cleanup and restore player/camera/time/weather.
 
-## Visual claims
+## What the light show is doing
 
-The scene deliberately uses no custom DFF, TXD, shader or texture. The visible feature work is GTA's native 2DFX system driven from Lua:
+The runway is split into six longitudinal segments. Each segment gets three independently allocated runtime models: left edge, right edge and centerline. Multiple invisible objects share each model, so changing one model-level 2DFX instantly changes a whole physical section of runway.
 
-- six independently allocated lamp models receive custom `LIGHT` effects and animate as a boulevard wave;
-- a real GTA lamp 2DFX is recolored/enlarged and then restored;
-- `PARTICLE` uses native `fire` and `smoke_flare` systems;
-- `ROADSIGN` generates the showcase title/capability text from native roadsign glyphs;
-- paired `ESCALATOR` effects create and animate GTA's actual escalator step objects;
-- multiple `SUN_GLARE` directions are staged at sunset so the camera can catch the native glare response;
-- resource teardown resets all model mutations and frees every runtime model slot.
+That is used to demonstrate the actual model-level nature of GTA's 2DFX system rather than faking a per-object light animation.
+
+The final scene contains roughly:
+
+- 60 edge-light anchors across both runway sides;
+- 24 centerline light anchors;
+- two 9-light threshold bars;
+- six independently controlled longitudinal light segments per side;
+- six independently controlled centerline segments;
+- native `showMode` blinking/strobe changes;
+- live color, corona-size and point-light-range mutations;
+- one real GTA lamp whose original native 2DFX is mutated and restored;
+- four native `smoke_flare` particle anchors and two native `fire` particle anchors;
+- two native `ROADSIGN` effects reading `NATIVE_GTA_2DFX / SCRIPTED_IN_LUA` and `NO_SHADERS / NO_CUSTOM_ASSETS`;
+- a sunset `SUN_GLARE` cluster at the far end.
+
+## Visual claim
+
+There are no custom DFFs, TXDs, shaders or textures in the showcase. The runway remains the stock GTA environment; the visual spectacle is produced by native GTA 2DFX types controlled from Lua.
 
 ## Recording notes
 
-Record 16:9. Start recording immediately before `/2dfxshow`; the initial fade hides model allocation and targeted restreams. No `engineRestreamWorld()` is used by the showcase.
+Record 16:9. First run `/2dfxshow setup` and make sure both runway edges are correctly aligned with the asphalt and the roadsigns face the intended camera direction. If those are aligned, `/2dfxshow` should be ready to record without additional world restreams.

--- a/test-resources/2dfx-showcase/README.md
+++ b/test-resources/2dfx-showcase/README.md
@@ -63,3 +63,5 @@ There are no custom DFFs, TXDs, shaders or textures in the showcase. The runway 
 ## Recording notes
 
 Record 16:9. First run `/2dfxshow setup` and make sure both runway edges are correctly aligned with the asphalt and the roadsigns face the intended camera direction. If those are aligned, `/2dfxshow` should be ready to record without additional world restreams.
+
+The runway axis is computed directly from the two supplied endpoint coordinates, so changing the endpoints later automatically repositions every edge/center/threshold anchor and every camera path around the new line.

--- a/test-resources/2dfx-showcase/README.md
+++ b/test-resources/2dfx-showcase/README.md
@@ -40,16 +40,18 @@ Use `/2dfxshow stop` to abort and restore the player immediately.
 
 Thirty physical model-1226 lamp posts are placed down each side of the runway. Each side is split into six model-level groups, five lamp posts per group. The runtime models inherit the 1226 visual, and their native light 2DFX is used when the clone exposes it. If a runtime slot does not clone the native effect, the showcase creates the equivalent LIGHT at the original 1226 effect position and reuses the original 1226 `coronaName`/`shadowName` instead of hard-coding a sprite.
 
+The two physical rows are oriented from the native 1226 light-head position: the script rotates each lamp so its actual lamp head points toward the runway centre. This avoids hard-coded per-side yaw guesses and keeps the orientation correct if the runway axis changes.
+
 This means one Lua mutation changes five real lamp posts at once. Left and right use separate runtime models, so the show can produce opposite color waves, alternating blink patterns, `warnlight`/`trafficlight` modes, corona-size pulses and range changes while still demonstrating GTA's model-level semantics.
 
-The centerline and threshold lights also reuse the native 1226 corona texture. `coronamoon` is intentionally isolated to shot 5, where seven invisible anchors form a large multicolor moon arc in the sky; it is no longer used for ordinary runway lights.
+The centerline and threshold lights reuse the native 1226 corona texture, but their LIGHT position is local `{0, 0, 0}` on anchors placed only a few centimetres above the runway. They therefore render at asphalt level instead of inheriting the several-metre-high lamp-head position. `coronamoon` is intentionally isolated to shot 5, where seven invisible anchors form a large multicolor moon arc in the sky; it is no longer used for ordinary runway lights.
 
 The final scene contains roughly:
 
 - 60 visible GTA lamp posts across both runway sides;
 - 12 independently controlled lamp-post model groups (six left + six right);
-- 24 centerline light anchors in six independently controlled groups;
-- two 9-light threshold bars;
+- 24 ground-level centerline light anchors in six independently controlled groups;
+- two 9-light ground-level threshold bars;
 - native `showMode` blinking (`warnlight`, `trafficlight`, `on_off_at_5`);
 - live color, corona-size and point-light-range mutations;
 - seven intentional multicolor `coronamoon` sprites for the sky-burst shot;
@@ -63,7 +65,7 @@ There are no custom DFFs, TXDs, shaders or textures in the showcase. Lamp posts 
 
 ## Recording notes
 
-Record 16:9. First run `/2dfxshow setup` and verify that both lamp-post rows sit just outside the asphalt edges and that their heads face sensibly toward the runway. If required, adjust `RUNWAY_HALF_WIDTH` or the two lamp yaw offsets in `client_scene.lua`.
+Record 16:9. First run `/2dfxshow setup` and verify that both lamp-post rows sit just outside the asphalt edges, that both sets of lamp heads point inward, and that centerline/threshold coronas sit on the asphalt rather than floating at lamp height.
 
 Then test `/2dfxshow shot 5` separately: the moons should read as one intentional sky arc, not as runway lights. Finally run `/2dfxshow shot 6` to verify particle/roadsign orientation before recording the full show.
 

--- a/test-resources/2dfx-showcase/README.md
+++ b/test-resources/2dfx-showcase/README.md
@@ -1,0 +1,44 @@
+# 2DFX cinematic showcase
+
+Gameplay-only showcase for the resource-owned model 2DFX API in PR #56.
+
+## Run
+
+```text
+start 2dfx-showcase
+/2dfxshow
+```
+
+The full cinematic is about 42 seconds. HUD/chat are hidden while recording and the player is staged in an isolated dimension over Verdant Meadows. Setup/restream work is performed while the camera is faded to black.
+
+Use `/2dfxshow stop` to abort and restore the player immediately.
+
+## Production commands
+
+- `/2dfxshow` or `/2dfxshow full` — full seven-shot cinematic.
+- `/2dfxshow shot 1` — sunset / native SUN_GLARE.
+- `/2dfxshow shot 2` — model-level neon light wave.
+- `/2dfxshow shot 3` — mutate and restore a vanilla GTA light.
+- `/2dfxshow shot 4` — native particle 2DFX on rooftop-style anchors.
+- `/2dfxshow shot 5` — generated native roadsign text.
+- `/2dfxshow shot 6` — two native escalators moving in opposite directions.
+- `/2dfxshow shot 7` — final wide shot with everything active.
+- `/2dfxshow final` — hold the final composition indefinitely for screenshots.
+- `/2dfxshow setup` — hold the final scene with chat/HUD visible for visual inspection.
+- `/2dfxshow stop` — cleanup and restore player/camera/time/weather.
+
+## Visual claims
+
+The scene deliberately uses no custom DFF, TXD, shader or texture. The visible feature work is GTA's native 2DFX system driven from Lua:
+
+- six independently allocated lamp models receive custom `LIGHT` effects and animate as a boulevard wave;
+- a real GTA lamp 2DFX is recolored/enlarged and then restored;
+- `PARTICLE` uses native `fire` and `smoke_flare` systems;
+- `ROADSIGN` generates the showcase title/capability text from native roadsign glyphs;
+- paired `ESCALATOR` effects create and animate GTA's actual escalator step objects;
+- multiple `SUN_GLARE` directions are staged at sunset so the camera can catch the native glare response;
+- resource teardown resets all model mutations and frees every runtime model slot.
+
+## Recording notes
+
+Record 16:9. Start recording immediately before `/2dfxshow`; the initial fade hides model allocation and targeted restreams. No `engineRestreamWorld()` is used by the showcase.

--- a/test-resources/2dfx-showcase/README.md
+++ b/test-resources/2dfx-showcase/README.md
@@ -9,7 +9,7 @@ The scene uses the Verdant Meadows runway between:
 424.00473, 2503.03442, 16.48438
 ```
 
-No mall, buildings, escalators or decorative showcase props are created. Runtime models are invisible anchors; the camera should show only the normal GTA runway and native 2DFX output.
+The runway itself stays stock GTA. The only visible objects added for the main light show are real GTA lamp posts (model 1226); centerline, threshold, particle, roadsign, sun-glare and moon carriers use tiny invisible runtime anchors.
 
 ## Run
 
@@ -26,42 +26,45 @@ Use `/2dfxshow stop` to abort and restore the player immediately.
 
 - `/2dfxshow` or `/2dfxshow full` — full seven-shot cinematic.
 - `/2dfxshow shot 1` — clean sunset runway / native `SUN_GLARE` establishing shot.
-- `/2dfxshow shot 2` — night transition and far-to-near runway edge ignition.
-- `/2dfxshow shot 3` — model-level color chase, centerline animation and flash modes.
-- `/2dfxshow shot 4` — close-up mutation and restoration of a real GTA lamp 2DFX.
-- `/2dfxshow shot 5` — native `smoke_flare` and `fire` particle gates at the far threshold.
-- `/2dfxshow shot 6` — native generated roadsign text on the runway.
-- `/2dfxshow shot 7` — full-runway finale with color waves, threshold lights and centerline strobes.
+- `/2dfxshow shot 2` — night transition and far-to-near ignition of the physical lamp-post rows.
+- `/2dfxshow shot 3` — model-level color chase, left/right blinking modes, centerline animation and corona pulses.
+- `/2dfxshow shot 4` — close-up mutation and restoration of a cloned GTA lamp's native 2DFX when available.
+- `/2dfxshow shot 5` — deliberate multicolor `coronamoon` burst arranged as an arc in the sky.
+- `/2dfxshow shot 6` — native `smoke_flare`/`fire` particle gates plus generated native roadsign text.
+- `/2dfxshow shot 7` — full-runway finale with lamp-post color waves, threshold lights and centerline strobes.
 - `/2dfxshow final` — hold the final composition for screenshots.
 - `/2dfxshow setup` — hold the final composition with HUD/chat visible for visual inspection.
 - `/2dfxshow stop` — cleanup and restore player/camera/time/weather.
 
-## What the light show is doing
+## What the lamp show is doing
 
-The runway is split into six longitudinal segments. Each segment gets three independently allocated runtime models: left edge, right edge and centerline. Multiple invisible objects share each model, so changing one model-level 2DFX instantly changes a whole physical section of runway.
+Thirty physical model-1226 lamp posts are placed down each side of the runway. Each side is split into six model-level groups, five lamp posts per group. The runtime models inherit the 1226 visual, and their native light 2DFX is used when the clone exposes it. If a runtime slot does not clone the native effect, the showcase creates the equivalent LIGHT at the original 1226 effect position and reuses the original 1226 `coronaName`/`shadowName` instead of hard-coding a sprite.
 
-That is used to demonstrate the actual model-level nature of GTA's 2DFX system rather than faking a per-object light animation.
+This means one Lua mutation changes five real lamp posts at once. Left and right use separate runtime models, so the show can produce opposite color waves, alternating blink patterns, `warnlight`/`trafficlight` modes, corona-size pulses and range changes while still demonstrating GTA's model-level semantics.
+
+The centerline and threshold lights also reuse the native 1226 corona texture. `coronamoon` is intentionally isolated to shot 5, where seven invisible anchors form a large multicolor moon arc in the sky; it is no longer used for ordinary runway lights.
 
 The final scene contains roughly:
 
-- 60 edge-light anchors across both runway sides;
-- 24 centerline light anchors;
+- 60 visible GTA lamp posts across both runway sides;
+- 12 independently controlled lamp-post model groups (six left + six right);
+- 24 centerline light anchors in six independently controlled groups;
 - two 9-light threshold bars;
-- six independently controlled longitudinal light segments per side;
-- six independently controlled centerline segments;
-- native `showMode` blinking/strobe changes;
+- native `showMode` blinking (`warnlight`, `trafficlight`, `on_off_at_5`);
 - live color, corona-size and point-light-range mutations;
-- one real GTA lamp whose original native 2DFX is mutated and restored;
+- seven intentional multicolor `coronamoon` sprites for the sky-burst shot;
 - four native `smoke_flare` particle anchors and two native `fire` particle anchors;
 - two native `ROADSIGN` effects reading `NATIVE_GTA_2DFX / SCRIPTED_IN_LUA` and `NO_SHADERS / NO_CUSTOM_ASSETS`;
 - a sunset `SUN_GLARE` cluster at the far end.
 
 ## Visual claim
 
-There are no custom DFFs, TXDs, shaders or textures in the showcase. The runway remains the stock GTA environment; the visual spectacle is produced by native GTA 2DFX types controlled from Lua.
+There are no custom DFFs, TXDs, shaders or textures in the showcase. Lamp posts and all texture names come from GTA itself; the spectacle is produced by native GTA 2DFX types controlled from Lua.
 
 ## Recording notes
 
-Record 16:9. First run `/2dfxshow setup` and make sure both runway edges are correctly aligned with the asphalt and the roadsigns face the intended camera direction. If those are aligned, `/2dfxshow` should be ready to record without additional world restreams.
+Record 16:9. First run `/2dfxshow setup` and verify that both lamp-post rows sit just outside the asphalt edges and that their heads face sensibly toward the runway. If required, adjust `RUNWAY_HALF_WIDTH` or the two lamp yaw offsets in `client_scene.lua`.
 
-The runway axis is computed directly from the two supplied endpoint coordinates, so changing the endpoints later automatically repositions every edge/center/threshold anchor and every camera path around the new line.
+Then test `/2dfxshow shot 5` separately: the moons should read as one intentional sky arc, not as runway lights. Finally run `/2dfxshow shot 6` to verify particle/roadsign orientation before recording the full show.
+
+The runway axis is computed directly from the two supplied endpoint coordinates, so changing the endpoints later automatically repositions every lamp, edge/center/threshold effect and camera path around the new line.

--- a/test-resources/2dfx-showcase/client_scene.lua
+++ b/test-resources/2dfx-showcase/client_scene.lua
@@ -1,0 +1,350 @@
+local S = DFXShowcase
+local state = S.state
+local PALETTE = S.PALETTE
+
+function S.customLightProperties(color)
+    return {
+        drawDistance = 170,
+        lightRange = 0,
+        coronaSize = 0.05,
+        shadowSize = 8,
+        shadowMultiplier = 45,
+        showMode = "default",
+        coronaReflection = false,
+        flareType = 0,
+        flags = { atNight = true, checkObstacles = true },
+        shadowDistance = 0,
+        offset = { 0, 0, 0 },
+        color = color,
+        coronaName = "coronamoon",
+        shadowName = "shad_exp",
+    }
+end
+
+function S.findFirstLight(model)
+    local count = getModel2DFXCount(model, false)
+    for index = 0, count - 1 do
+        if getModel2DFXType(model, index) == "light" then
+            return index
+        end
+    end
+    return nil
+end
+
+function S.neutralizeNativeLights(model)
+    local count = getModel2DFXCount(model, false)
+    local firstPosition = nil
+    for index = 0, count - 1 do
+        if getModel2DFXType(model, index) == "light" then
+            if not firstPosition then
+                local x, y, z = getModel2DFXPosition(model, index)
+                if type(x) == "number" then
+                    firstPosition = { x, y, z }
+                end
+            end
+            setModel2DFXProperty(model, index, "coronaSize", 0.05)
+            setModel2DFXProperty(model, index, "lightRange", 0)
+            setModel2DFXProperty(model, index, "shadowSize", 0)
+            S.rememberTouchedModel(model)
+        end
+    end
+    return firstPosition or { 0, 0, 5.4 }
+end
+
+function S.addCustomLight(model, color)
+    local position = S.neutralizeNativeLights(model)
+    if not addModel2DFX(model, position[1], position[2], position[3], "light", S.customLightProperties(color)) then
+        return false
+    end
+    S.rememberTouchedModel(model)
+    return getModel2DFXCount(model, true) - 1
+end
+
+function S.setLight(model, effect, color, size, range)
+    if not model or effect == nil then
+        return
+    end
+    setModel2DFXProperty(model, effect, "color", color)
+    setModel2DFXProperty(model, effect, "coronaSize", size)
+    setModel2DFXProperty(model, effect, "lightRange", range)
+end
+
+function S.setLampRowsOff()
+    for row, model in ipairs(state.lampModels) do
+        S.setLight(model, state.lampEffects[row], PALETTE[row], 0.05, 0)
+    end
+    if state.heroModel and state.heroEffect then
+        S.setLight(state.heroModel, state.heroEffect, PALETTE[1], 0.08, 0)
+    end
+end
+
+function S.activateLampRow(row)
+    local model = state.lampModels[row]
+    local effect = state.lampEffects[row]
+    if model and effect then
+        S.setLight(model, effect, PALETTE[row], 1.65, 23)
+    end
+end
+
+function S.applyAllLights()
+    for row = 1, #state.lampModels do
+        S.activateLampRow(row)
+    end
+    if state.heroModel and state.heroEffect then
+        S.setLight(state.heroModel, state.heroEffect, tocolor(80, 245, 255, 255), 2.35, 30)
+    end
+end
+
+function S.buildRuntimeModels()
+    for row = 1, 6 do
+        local model = S.requestObjectModel(1226)
+        if not model then
+            return false, "could not allocate lamp model " .. row
+        end
+        state.lampModels[row] = model
+    end
+
+    state.heroModel = S.requestObjectModel(1226)
+    if not state.heroModel then
+        return false, "could not allocate hero lamp model"
+    end
+
+    for i = 1, 2 do
+        local model = S.requestObjectModel(1337)
+        if not model then
+            return false, "could not allocate particle model " .. i
+        end
+        state.particleModels[i] = model
+    end
+
+    for i = 1, 3 do
+        local model = S.requestObjectModel(1337)
+        if not model then
+            return false, "could not allocate roadsign model " .. i
+        end
+        state.roadsignModels[i] = model
+    end
+
+    for i = 1, 2 do
+        local model = S.requestObjectModel(1337)
+        if not model then
+            return false, "could not allocate escalator model " .. i
+        end
+        state.escalatorModels[i] = model
+    end
+
+    state.sunModel = S.requestObjectModel(1337)
+    if not state.sunModel then
+        return false, "could not allocate sun glare model"
+    end
+
+    local vanillaClone = S.requestObjectModel(1226)
+    if vanillaClone then
+        state.vanillaModel = vanillaClone
+    else
+        state.vanillaModel = 1226
+    end
+    return true
+end
+
+function S.buildDecor()
+    for row, model in ipairs(state.lampModels) do
+        local y = -18 + (row - 1) * 7.0
+        if not S.spawn(model, -7.0, y, 0, 0) or not S.spawn(model, 7.0, y, 0, 180) then
+            return false, "could not create boulevard lamps"
+        end
+    end
+
+    if not S.spawn(state.heroModel, 0, 6.0, 0, 0) then
+        return false, "could not create hero lamp"
+    end
+
+    if not S.spawn(state.particleModels[1], -11.0, 14.0, 5.0, 0, 1, 1) or
+       not S.spawn(state.particleModels[2], 11.0, 16.0, 5.5, 0, 1, 1) then
+        return false, "could not create particle anchors"
+    end
+
+    S.spawn(970, 0, 27.8, 1.4, 0, 1.8)
+    S.spawn(970, -8.0, 24.8, 1.2, 0, 1.2)
+    S.spawn(970, 8.0, 24.8, 1.2, 0, 1.2)
+    if not S.spawn(state.roadsignModels[1], 0, 27.5, 0, 0, 1, 1) or
+       not S.spawn(state.roadsignModels[2], -8.0, 24.5, 0, 0, 1, 1) or
+       not S.spawn(state.roadsignModels[3], 8.0, 24.5, 0, 0, 1, 1) then
+        return false, "could not create roadsign anchors"
+    end
+
+    S.spawn(980, 0, 41.0, 2.5, 0, 1.35)
+    S.spawn(970, -7.2, 34.0, 1.0, 90, 1.4)
+    S.spawn(970, 7.2, 34.0, 1.0, 90, 1.4)
+    if not S.spawn(state.escalatorModels[1], -5.0, 27.5, 0, 0, 1, 1) or
+       not S.spawn(state.escalatorModels[2], 5.0, 27.5, 0, 0, 1, 1) then
+        return false, "could not create escalator anchors"
+    end
+
+    if not S.spawn(state.sunModel, 0, 48.0, 7.0, 0, 1, 1) then
+        return false, "could not create sun glare anchor"
+    end
+
+    state.vanillaObject = S.spawn(state.vanillaModel, 12.0, 3.0, 0, 0)
+    if not state.vanillaObject then
+        return false, "could not create vanilla light object"
+    end
+
+    S.spawn(1280, -3.5, -6.0, 0, 90)
+    S.spawn(1280, 3.5, -6.0, 0, 270)
+    S.spawn(970, -10.0, 3.0, 0.8, 90, 1.4)
+    S.spawn(970, 10.0, 3.0, 0.8, 90, 1.4)
+    return true
+end
+
+function S.addRoadsign(model, position, size, lines, text)
+    local props = {
+        size = size,
+        rotation = { 90, 0, 0 },
+        flags = { lines = lines, charactersPerLine = 16 },
+        color = tocolor(80, 225, 255, 255),
+        text1 = text[1] or "",
+        text2 = text[2] or "",
+        text3 = text[3] or "",
+        text4 = text[4] or "",
+    }
+    if not addModel2DFX(model, position[1], position[2], position[3], "roadsign", props) then
+        return false
+    end
+    S.rememberTouchedModel(model)
+    return true
+end
+
+function S.addEscalator(model, direction)
+    local props = {
+        bottom = { 0, 0, 0.25 },
+        top = { 0, 8.5, 4.6 },
+        ["end"] = { 0, 12.0, 4.6 },
+        direction = direction,
+    }
+    if not addModel2DFX(model, 0, -3.5, 0.25, "escalator", props) then
+        return false
+    end
+    S.rememberTouchedModel(model)
+    return true
+end
+
+function S.captureVanillaLight()
+    local index = S.findFirstLight(state.vanillaModel)
+    if index == nil and state.vanillaModel ~= 1226 then
+        state.vanillaModel = 1226
+        if isElement(state.vanillaObject) then
+            setElementModel(state.vanillaObject, 1226)
+        end
+        index = S.findFirstLight(1226)
+    end
+    if index == nil then
+        return false
+    end
+
+    state.vanillaEffect = index
+    local drawDistance = getModel2DFXProperty(state.vanillaModel, index, "drawDistance")
+    local coronaSize = getModel2DFXProperty(state.vanillaModel, index, "coronaSize")
+    local lightRange = getModel2DFXProperty(state.vanillaModel, index, "lightRange")
+    local r, g, b, a = getModel2DFXProperty(state.vanillaModel, index, "color")
+    if type(drawDistance) ~= "number" or type(coronaSize) ~= "number" or
+       type(lightRange) ~= "number" or type(r) ~= "number" then
+        return false
+    end
+
+    state.vanillaBaseline = {
+        drawDistance = drawDistance,
+        coronaSize = coronaSize,
+        lightRange = lightRange,
+        color = tocolor(r, g, b, a),
+    }
+    return true
+end
+
+function S.addEffects()
+    for row, model in ipairs(state.lampModels) do
+        local index = S.addCustomLight(model, PALETTE[row])
+        if index == false then
+            return false, "failed to add custom light row " .. row
+        end
+        state.lampEffects[row] = index
+    end
+
+    state.heroEffect = S.addCustomLight(state.heroModel, PALETTE[1])
+    if state.heroEffect == false then
+        return false, "failed to add hero light"
+    end
+
+    if not addModel2DFX(state.particleModels[1], 0, 0, 0.3, "particle", { name = "fire" }) then
+        return false, "failed to add fire particle"
+    end
+    S.rememberTouchedModel(state.particleModels[1])
+
+    if not addModel2DFX(state.particleModels[2], 0, 0, 0.3, "particle", { name = "smoke_flare" }) then
+        return false, "failed to add smoke particle"
+    end
+    S.rememberTouchedModel(state.particleModels[2])
+
+    if not S.addRoadsign(state.roadsignModels[1], { 0, 0, 3.3 }, { 5.5, 2.8 }, 4,
+        { "NEON_BOULEVARD", "NATIVE_GTA_2DFX", "SCRIPTED_IN_LUA", "NO_CUSTOM_ASSETS" }) then
+        return false, "failed to add main roadsign"
+    end
+
+    if not S.addRoadsign(state.roadsignModels[2], { 0, 0, 2.6 }, { 3.2, 1.0 }, 1,
+        { "LIGHTS_FROM_LUA", "", "", "" }) then
+        return false, "failed to add left roadsign"
+    end
+
+    if not S.addRoadsign(state.roadsignModels[3], { 0, 0, 2.6 }, { 3.2, 1.0 }, 1,
+        { "NATIVE_2DFX", "", "", "" }) then
+        return false, "failed to add right roadsign"
+    end
+
+    if not S.addEscalator(state.escalatorModels[1], 0) or
+       not S.addEscalator(state.escalatorModels[2], 1) then
+        return false, "failed to add escalators"
+    end
+
+    for step = 0, 7 do
+        local angle = math.rad(step * 45)
+        local x = math.cos(angle) * 12.0
+        local y = math.sin(angle) * 12.0
+        local z = (step % 2 == 0) and 3.0 or 6.0
+        if not addModel2DFX(state.sunModel, x, y, z, "sun_glare", {}) then
+            return false, "failed to add sun glare"
+        end
+    end
+    S.rememberTouchedModel(state.sunModel)
+
+    if not S.captureVanillaLight() then
+        return false, "could not find vanilla model 1226 light 2DFX"
+    end
+
+    S.setLampRowsOff()
+    return true
+end
+
+function S.mutateVanillaLight()
+    if state.vanillaEffect == nil or not state.vanillaBaseline then
+        return
+    end
+    local model = state.vanillaModel
+    local index = state.vanillaEffect
+    setModel2DFXProperty(model, index, "drawDistance", state.vanillaBaseline.drawDistance + 120)
+    setModel2DFXProperty(model, index, "coronaSize", math.max(2.8, state.vanillaBaseline.coronaSize * 2.5))
+    setModel2DFXProperty(model, index, "lightRange", state.vanillaBaseline.lightRange + 20)
+    setModel2DFXProperty(model, index, "color", tocolor(35, 240, 255, 255))
+    S.rememberTouchedModel(model)
+end
+
+function S.restoreVanillaLight()
+    if state.vanillaEffect == nil then
+        return
+    end
+    local model = state.vanillaModel
+    local index = state.vanillaEffect
+    resetModel2DFXProperty(model, index, "drawDistance")
+    resetModel2DFXProperty(model, index, "coronaSize")
+    resetModel2DFXProperty(model, index, "lightRange")
+    resetModel2DFXProperty(model, index, "color")
+end

--- a/test-resources/2dfx-showcase/client_scene.lua
+++ b/test-resources/2dfx-showcase/client_scene.lua
@@ -76,6 +76,10 @@ function S.addCustomLight(model, color, size, range, showMode, coronaName, posit
     return getModel2DFXCount(model, true) - 1
 end
 
+function S.addGroundLight(model, color, size, range, showMode)
+    return S.addCustomLight(model, color, size, range, showMode or "default", nil, { 0, 0, 0 })
+end
+
 function S.ensureLampLight(model, color)
     local index = S.findFirstLight(model)
     if index ~= nil then
@@ -83,6 +87,42 @@ function S.ensureLampLight(model, color)
         return index
     end
     return S.addCustomLight(model, color, 0.04, 0, "default")
+end
+
+-- Model 1226 is asymmetric: the native 2DFX position tells us where the lamp
+-- head actually is in model space. Rotate each physical row so that this vector
+-- points toward the runway centre instead of relying on a guessed +/-90 offset.
+function S.lampYawForLateral(lateral)
+    local template = state.lightTemplate
+    local basis = state.basis
+    if not template or not basis then
+        return basis and basis.yaw or 270
+    end
+
+    local headX = template.position[1] or 0
+    local headY = template.position[2] or 0
+    if math.abs(headX) + math.abs(headY) < 0.001 then
+        return basis.yaw
+    end
+
+    local targetX, targetY
+    if lateral < 0 then
+        targetX, targetY = basis.px, basis.py
+    else
+        targetX, targetY = -basis.px, -basis.py
+    end
+
+    local localAngle = math.deg(math.atan2(headY, headX))
+    local targetAngle = math.deg(math.atan2(targetY, targetX))
+    local yaw = targetAngle - localAngle
+    while yaw < 0 do yaw = yaw + 360 end
+    while yaw >= 360 do yaw = yaw - 360 end
+    return yaw
+end
+
+function S.spawnRunwayLamp(model, t, lateral, height)
+    local x, y, z = S.runwayPoint(t, lateral, height or 0)
+    return S.spawnWorld(model, x, y, z, S.lampYawForLateral(lateral), 1.0, 255)
 end
 
 function S.setLight(model, effect, color, size, range, showMode)
@@ -196,24 +236,27 @@ function S.buildRunwayAnchors()
     for index = 1, EDGE_STATIONS do
         local segment = segmentForStation(index, EDGE_STATIONS)
         local t = 0.045 + ((index - 1) / (EDGE_STATIONS - 1)) * 0.91
-        if not S.spawnOnRunway(state.edgeModels.left[segment], t, -S.RUNWAY_HALF_WIDTH - 2.0, 0, 255, 1.0, 90) or
-           not S.spawnOnRunway(state.edgeModels.right[segment], t, S.RUNWAY_HALF_WIDTH + 2.0, 0, 255, 1.0, -90) then
+        if not S.spawnRunwayLamp(state.edgeModels.left[segment], t, -S.RUNWAY_HALF_WIDTH - 2.0, 0) or
+           not S.spawnRunwayLamp(state.edgeModels.right[segment], t, S.RUNWAY_HALF_WIDTH + 2.0, 0) then
             return false, "could not create runway lamp posts"
         end
     end
 
+    -- Ground carriers sit only a few centimetres above the asphalt. Their 2DFX
+    -- position is local zero, so the corona itself is at runway level rather
+    -- than inheriting the several-metre-high lamp-head offset from model 1226.
     for index = 1, CENTER_STATIONS do
         local segment = segmentForStation(index, CENTER_STATIONS)
         local t = 0.07 + ((index - 1) / (CENTER_STATIONS - 1)) * 0.86
-        if not S.spawnOnRunway(state.centerModels[segment], t, 0, 0.10, 0, 0.06) then
+        if not S.spawnOnRunway(state.centerModels[segment], t, 0, 0.035, 0, 0.06) then
             return false, "could not create runway center anchors"
         end
     end
 
     for side = -4, 4 do
         local lateral = side * 4.0
-        if not S.spawnOnRunway(state.thresholdModels[1], 0.035, lateral, 0.12, 0, 0.06) or
-           not S.spawnOnRunway(state.thresholdModels[2], 0.965, lateral, 0.12, 0, 0.06) then
+        if not S.spawnOnRunway(state.thresholdModels[1], 0.035, lateral, 0.035, 0, 0.06) or
+           not S.spawnOnRunway(state.thresholdModels[2], 0.965, lateral, 0.035, 0, 0.06) then
             return false, "could not create runway threshold anchors"
         end
     end
@@ -248,7 +291,7 @@ function S.buildRunwayAnchors()
         end
     end
 
-    state.vanillaObject = S.spawnOnRunway(state.vanillaModel, 0.53, -27.0, 0, 255, 1.0, 90)
+    state.vanillaObject = S.spawnRunwayLamp(state.vanillaModel, 0.53, -27.0, 0)
     if not state.vanillaObject then
         return false, "could not create hero vanilla lamp"
     end
@@ -303,14 +346,14 @@ function S.addEffects()
     for segment = 1, SEGMENTS do
         state.edgeEffects.left[segment] = S.ensureLampLight(state.edgeModels.left[segment], PALETTE[segment])
         state.edgeEffects.right[segment] = S.ensureLampLight(state.edgeModels.right[segment], PALETTE[7 - segment])
-        state.centerEffects[segment] = S.addCustomLight(state.centerModels[segment], PALETTE[6], 0.02, 0)
+        state.centerEffects[segment] = S.addGroundLight(state.centerModels[segment], PALETTE[6], 0.02, 0)
         if state.edgeEffects.left[segment] == false or state.edgeEffects.right[segment] == false or state.centerEffects[segment] == false then
             return false, "failed to prepare runway light segment " .. segment
         end
     end
 
-    state.thresholdEffects[1] = S.addCustomLight(state.thresholdModels[1], tocolor(45, 255, 150, 255), 0.03, 0)
-    state.thresholdEffects[2] = S.addCustomLight(state.thresholdModels[2], tocolor(255, 55, 85, 255), 0.03, 0)
+    state.thresholdEffects[1] = S.addGroundLight(state.thresholdModels[1], tocolor(45, 255, 150, 255), 0.03, 0)
+    state.thresholdEffects[2] = S.addGroundLight(state.thresholdModels[2], tocolor(255, 55, 85, 255), 0.03, 0)
     if state.thresholdEffects[1] == false or state.thresholdEffects[2] == false then
         return false, "failed to add threshold lights"
     end

--- a/test-resources/2dfx-showcase/client_scene.lua
+++ b/test-resources/2dfx-showcase/client_scene.lua
@@ -2,23 +2,198 @@ local S = DFXShowcase
 local state = S.state
 local PALETTE = S.PALETTE
 
-function S.customLightProperties(color)
+local SEGMENTS = 6
+local EDGE_STATIONS = 30
+local CENTER_STATIONS = 24
+
+function S.lightProperties(color, size, range, showMode)
     return {
-        drawDistance = 170,
-        lightRange = 0,
-        coronaSize = 0.05,
-        shadowSize = 8,
-        shadowMultiplier = 45,
-        showMode = "default",
+        drawDistance = 260,
+        lightRange = range or 0,
+        coronaSize = size or 0.04,
+        shadowSize = 0,
+        shadowMultiplier = 0,
+        showMode = showMode or "default",
         coronaReflection = false,
         flareType = 0,
-        flags = { atNight = true, checkObstacles = true },
+        flags = { atNight = true, checkObstacles = false },
         shadowDistance = 0,
         offset = { 0, 0, 0 },
         color = color,
         coronaName = "coronamoon",
         shadowName = "shad_exp",
     }
+end
+
+function S.addLight(model, color, size, range, showMode)
+    if not addModel2DFX(model, 0, 0, 0.22, "light", S.lightProperties(color, size, range, showMode)) then
+        return false
+    end
+    S.rememberTouchedModel(model)
+    return getModel2DFXCount(model, true) - 1
+end
+
+function S.setLight(model, effect, color, size, range, showMode)
+    if not model or effect == nil then
+        return
+    end
+    if color then
+        setModel2DFXProperty(model, effect, "color", color)
+    end
+    if size then
+        setModel2DFXProperty(model, effect, "coronaSize", size)
+    end
+    if range then
+        setModel2DFXProperty(model, effect, "lightRange", range)
+    end
+    if showMode then
+        setModel2DFXProperty(model, effect, "showMode", showMode)
+    end
+end
+
+function S.setEdgeSegment(side, segment, color, size, range, showMode)
+    local model = state.edgeModels[side][segment]
+    local effect = state.edgeEffects[side][segment]
+    S.setLight(model, effect, color, size, range, showMode)
+end
+
+function S.setCenterSegment(segment, color, size, range, showMode)
+    S.setLight(state.centerModels[segment], state.centerEffects[segment], color, size, range, showMode)
+end
+
+function S.setThreshold(index, color, size, range, showMode)
+    S.setLight(state.thresholdModels[index], state.thresholdEffects[index], color, size, range, showMode)
+end
+
+function S.allLightsOff()
+    for segment = 1, SEGMENTS do
+        S.setEdgeSegment("left", segment, PALETTE[1], 0.035, 0, "default")
+        S.setEdgeSegment("right", segment, PALETTE[1], 0.035, 0, "default")
+        S.setCenterSegment(segment, PALETTE[6], 0.025, 0, "default")
+    end
+    S.setThreshold(1, tocolor(40, 255, 150, 255), 0.035, 0, "default")
+    S.setThreshold(2, tocolor(255, 65, 90, 255), 0.035, 0, "default")
+end
+
+function S.applyFinalLights(step)
+    step = step or 0
+    for segment = 1, SEGMENTS do
+        local leftColor = PALETTE[((segment + step - 2) % #PALETTE) + 1]
+        local rightColor = PALETTE[((#PALETTE - segment + step) % #PALETTE) + 1]
+        S.setEdgeSegment("left", segment, leftColor, 1.55, 4, "default")
+        S.setEdgeSegment("right", segment, rightColor, 1.55, 4, "default")
+        S.setCenterSegment(segment, PALETTE[6], 0.72, 0, "default")
+    end
+    S.setThreshold(1, tocolor(45, 255, 150, 255), 1.25, 0, "default")
+    S.setThreshold(2, tocolor(255, 55, 85, 255), 1.25, 0, "default")
+end
+
+function S.buildRuntimeModels()
+    for segment = 1, SEGMENTS do
+        state.edgeModels.left[segment] = S.requestObjectModel(1337)
+        state.edgeModels.right[segment] = S.requestObjectModel(1337)
+        state.centerModels[segment] = S.requestObjectModel(1337)
+        if not state.edgeModels.left[segment] or not state.edgeModels.right[segment] or not state.centerModels[segment] then
+            return false, "could not allocate runway light model group " .. segment
+        end
+    end
+
+    for index = 1, 2 do
+        state.thresholdModels[index] = S.requestObjectModel(1337)
+        state.particleModels[index] = S.requestObjectModel(1337)
+        state.roadsignModels[index] = S.requestObjectModel(1337)
+        if not state.thresholdModels[index] or not state.particleModels[index] or not state.roadsignModels[index] then
+            return false, "could not allocate showcase model group " .. index
+        end
+    end
+
+    state.sunModel = S.requestObjectModel(1337)
+    if not state.sunModel then
+        return false, "could not allocate sun-glare model"
+    end
+
+    state.vanillaModel = S.requestObjectModel(1226)
+    if not state.vanillaModel then
+        state.vanillaModel = 1226
+    end
+
+    return true
+end
+
+local function segmentForStation(index, count)
+    return math.min(SEGMENTS, math.floor((index - 1) * SEGMENTS / count) + 1)
+end
+
+function S.buildRunwayAnchors()
+    for index = 1, EDGE_STATIONS do
+        local segment = segmentForStation(index, EDGE_STATIONS)
+        local t = 0.045 + ((index - 1) / (EDGE_STATIONS - 1)) * 0.91
+        if not S.spawnOnRunway(state.edgeModels.left[segment], t, -S.RUNWAY_HALF_WIDTH, 0.12, 0, 0.08) or
+           not S.spawnOnRunway(state.edgeModels.right[segment], t, S.RUNWAY_HALF_WIDTH, 0.12, 0, 0.08) then
+            return false, "could not create runway edge anchors"
+        end
+    end
+
+    for index = 1, CENTER_STATIONS do
+        local segment = segmentForStation(index, CENTER_STATIONS)
+        local t = 0.07 + ((index - 1) / (CENTER_STATIONS - 1)) * 0.86
+        if not S.spawnOnRunway(state.centerModels[segment], t, 0, 0.10, 0, 0.06) then
+            return false, "could not create runway center anchors"
+        end
+    end
+
+    for side = -4, 4 do
+        local lateral = side * 4.0
+        if not S.spawnOnRunway(state.thresholdModels[1], 0.035, lateral, 0.12, 0, 0.06) or
+           not S.spawnOnRunway(state.thresholdModels[2], 0.965, lateral, 0.12, 0, 0.06) then
+            return false, "could not create runway threshold anchors"
+        end
+    end
+
+    for _, lateral in ipairs({ -10, -5, 5, 10 }) do
+        if not S.spawnOnRunway(state.particleModels[1], 0.885, lateral, 0.25, 0, 0.05) then
+            return false, "could not create smoke-flare anchors"
+        end
+    end
+    for _, lateral in ipairs({ -13, 13 }) do
+        if not S.spawnOnRunway(state.particleModels[2], 0.92, lateral, 0.15, 0, 0.05) then
+            return false, "could not create fire anchors"
+        end
+    end
+
+    if not S.spawnOnRunway(state.roadsignModels[1], 0.10, 0, 0.05, 0, 0.05) or
+       not S.spawnOnRunway(state.roadsignModels[2], 0.90, 0, 0.05, 0, 0.05) then
+        return false, "could not create roadsign anchors"
+    end
+
+    if not S.spawnOnRunway(state.sunModel, 0.94, 0, 4.0, 0, 0.05) then
+        return false, "could not create sun-glare anchor"
+    end
+
+    state.vanillaObject = S.spawnOnRunway(state.vanillaModel, 0.53, -24.0, 0, 255, 1.0)
+    if not state.vanillaObject then
+        return false, "could not create vanilla lamp"
+    end
+
+    return true
+end
+
+function S.addRoadsign(model, text, reverse)
+    local props = {
+        size = { 5.5, 1.9 },
+        rotation = { 90, 0, reverse and 270 or 90 },
+        flags = { lines = 2, charactersPerLine = 16 },
+        color = tocolor(80, 230, 255, 255),
+        text1 = text[1] or "",
+        text2 = text[2] or "",
+        text3 = "",
+        text4 = "",
+    }
+    if not addModel2DFX(model, 0, 0, 3.0, "roadsign", props) then
+        return false
+    end
+    S.rememberTouchedModel(model)
+    return true
 end
 
 function S.findFirstLight(model)
@@ -29,204 +204,6 @@ function S.findFirstLight(model)
         end
     end
     return nil
-end
-
-function S.neutralizeNativeLights(model)
-    local count = getModel2DFXCount(model, false)
-    local firstPosition = nil
-    for index = 0, count - 1 do
-        if getModel2DFXType(model, index) == "light" then
-            if not firstPosition then
-                local x, y, z = getModel2DFXPosition(model, index)
-                if type(x) == "number" then
-                    firstPosition = { x, y, z }
-                end
-            end
-            setModel2DFXProperty(model, index, "coronaSize", 0.05)
-            setModel2DFXProperty(model, index, "lightRange", 0)
-            setModel2DFXProperty(model, index, "shadowSize", 0)
-            S.rememberTouchedModel(model)
-        end
-    end
-    return firstPosition or { 0, 0, 5.4 }
-end
-
-function S.addCustomLight(model, color)
-    local position = S.neutralizeNativeLights(model)
-    if not addModel2DFX(model, position[1], position[2], position[3], "light", S.customLightProperties(color)) then
-        return false
-    end
-    S.rememberTouchedModel(model)
-    return getModel2DFXCount(model, true) - 1
-end
-
-function S.setLight(model, effect, color, size, range)
-    if not model or effect == nil then
-        return
-    end
-    setModel2DFXProperty(model, effect, "color", color)
-    setModel2DFXProperty(model, effect, "coronaSize", size)
-    setModel2DFXProperty(model, effect, "lightRange", range)
-end
-
-function S.setLampRowsOff()
-    for row, model in ipairs(state.lampModels) do
-        S.setLight(model, state.lampEffects[row], PALETTE[row], 0.05, 0)
-    end
-    if state.heroModel and state.heroEffect then
-        S.setLight(state.heroModel, state.heroEffect, PALETTE[1], 0.08, 0)
-    end
-end
-
-function S.activateLampRow(row)
-    local model = state.lampModels[row]
-    local effect = state.lampEffects[row]
-    if model and effect then
-        S.setLight(model, effect, PALETTE[row], 1.65, 23)
-    end
-end
-
-function S.applyAllLights()
-    for row = 1, #state.lampModels do
-        S.activateLampRow(row)
-    end
-    if state.heroModel and state.heroEffect then
-        S.setLight(state.heroModel, state.heroEffect, tocolor(80, 245, 255, 255), 2.35, 30)
-    end
-end
-
-function S.buildRuntimeModels()
-    for row = 1, 6 do
-        local model = S.requestObjectModel(1226)
-        if not model then
-            return false, "could not allocate lamp model " .. row
-        end
-        state.lampModels[row] = model
-    end
-
-    state.heroModel = S.requestObjectModel(1226)
-    if not state.heroModel then
-        return false, "could not allocate hero lamp model"
-    end
-
-    for i = 1, 2 do
-        local model = S.requestObjectModel(1337)
-        if not model then
-            return false, "could not allocate particle model " .. i
-        end
-        state.particleModels[i] = model
-    end
-
-    for i = 1, 3 do
-        local model = S.requestObjectModel(1337)
-        if not model then
-            return false, "could not allocate roadsign model " .. i
-        end
-        state.roadsignModels[i] = model
-    end
-
-    for i = 1, 2 do
-        local model = S.requestObjectModel(1337)
-        if not model then
-            return false, "could not allocate escalator model " .. i
-        end
-        state.escalatorModels[i] = model
-    end
-
-    state.sunModel = S.requestObjectModel(1337)
-    if not state.sunModel then
-        return false, "could not allocate sun glare model"
-    end
-
-    local vanillaClone = S.requestObjectModel(1226)
-    if vanillaClone then
-        state.vanillaModel = vanillaClone
-    else
-        state.vanillaModel = 1226
-    end
-    return true
-end
-
-function S.buildDecor()
-    for row, model in ipairs(state.lampModels) do
-        local y = -18 + (row - 1) * 7.0
-        if not S.spawn(model, -7.0, y, 0, 0) or not S.spawn(model, 7.0, y, 0, 180) then
-            return false, "could not create boulevard lamps"
-        end
-    end
-
-    if not S.spawn(state.heroModel, 0, 6.0, 0, 0) then
-        return false, "could not create hero lamp"
-    end
-
-    if not S.spawn(state.particleModels[1], -11.0, 14.0, 5.0, 0, 1, 1) or
-       not S.spawn(state.particleModels[2], 11.0, 16.0, 5.5, 0, 1, 1) then
-        return false, "could not create particle anchors"
-    end
-
-    S.spawn(970, 0, 27.8, 1.4, 0, 1.8)
-    S.spawn(970, -8.0, 24.8, 1.2, 0, 1.2)
-    S.spawn(970, 8.0, 24.8, 1.2, 0, 1.2)
-    if not S.spawn(state.roadsignModels[1], 0, 27.5, 0, 0, 1, 1) or
-       not S.spawn(state.roadsignModels[2], -8.0, 24.5, 0, 0, 1, 1) or
-       not S.spawn(state.roadsignModels[3], 8.0, 24.5, 0, 0, 1, 1) then
-        return false, "could not create roadsign anchors"
-    end
-
-    S.spawn(980, 0, 41.0, 2.5, 0, 1.35)
-    S.spawn(970, -7.2, 34.0, 1.0, 90, 1.4)
-    S.spawn(970, 7.2, 34.0, 1.0, 90, 1.4)
-    if not S.spawn(state.escalatorModels[1], -5.0, 27.5, 0, 0, 1, 1) or
-       not S.spawn(state.escalatorModels[2], 5.0, 27.5, 0, 0, 1, 1) then
-        return false, "could not create escalator anchors"
-    end
-
-    if not S.spawn(state.sunModel, 0, 48.0, 7.0, 0, 1, 1) then
-        return false, "could not create sun glare anchor"
-    end
-
-    state.vanillaObject = S.spawn(state.vanillaModel, 12.0, 3.0, 0, 0)
-    if not state.vanillaObject then
-        return false, "could not create vanilla light object"
-    end
-
-    S.spawn(1280, -3.5, -6.0, 0, 90)
-    S.spawn(1280, 3.5, -6.0, 0, 270)
-    S.spawn(970, -10.0, 3.0, 0.8, 90, 1.4)
-    S.spawn(970, 10.0, 3.0, 0.8, 90, 1.4)
-    return true
-end
-
-function S.addRoadsign(model, position, size, lines, text)
-    local props = {
-        size = size,
-        rotation = { 90, 0, 0 },
-        flags = { lines = lines, charactersPerLine = 16 },
-        color = tocolor(80, 225, 255, 255),
-        text1 = text[1] or "",
-        text2 = text[2] or "",
-        text3 = text[3] or "",
-        text4 = text[4] or "",
-    }
-    if not addModel2DFX(model, position[1], position[2], position[3], "roadsign", props) then
-        return false
-    end
-    S.rememberTouchedModel(model)
-    return true
-end
-
-function S.addEscalator(model, direction)
-    local props = {
-        bottom = { 0, 0, 0.25 },
-        top = { 0, 8.5, 4.6 },
-        ["end"] = { 0, 12.0, 4.6 },
-        direction = direction,
-    }
-    if not addModel2DFX(model, 0, -3.5, 0.25, "escalator", props) then
-        return false
-    end
-    S.rememberTouchedModel(model)
-    return true
 end
 
 function S.captureVanillaLight()
@@ -247,8 +224,7 @@ function S.captureVanillaLight()
     local coronaSize = getModel2DFXProperty(state.vanillaModel, index, "coronaSize")
     local lightRange = getModel2DFXProperty(state.vanillaModel, index, "lightRange")
     local r, g, b, a = getModel2DFXProperty(state.vanillaModel, index, "color")
-    if type(drawDistance) ~= "number" or type(coronaSize) ~= "number" or
-       type(lightRange) ~= "number" or type(r) ~= "number" then
+    if type(drawDistance) ~= "number" or type(coronaSize) ~= "number" or type(lightRange) ~= "number" or type(r) ~= "number" then
         return false
     end
 
@@ -262,55 +238,39 @@ function S.captureVanillaLight()
 end
 
 function S.addEffects()
-    for row, model in ipairs(state.lampModels) do
-        local index = S.addCustomLight(model, PALETTE[row])
-        if index == false then
-            return false, "failed to add custom light row " .. row
+    for segment = 1, SEGMENTS do
+        state.edgeEffects.left[segment] = S.addLight(state.edgeModels.left[segment], PALETTE[segment], 0.035, 0)
+        state.edgeEffects.right[segment] = S.addLight(state.edgeModels.right[segment], PALETTE[7 - segment], 0.035, 0)
+        state.centerEffects[segment] = S.addLight(state.centerModels[segment], PALETTE[6], 0.025, 0)
+        if state.edgeEffects.left[segment] == false or state.edgeEffects.right[segment] == false or state.centerEffects[segment] == false then
+            return false, "failed to add runway light segment " .. segment
         end
-        state.lampEffects[row] = index
     end
 
-    state.heroEffect = S.addCustomLight(state.heroModel, PALETTE[1])
-    if state.heroEffect == false then
-        return false, "failed to add hero light"
+    state.thresholdEffects[1] = S.addLight(state.thresholdModels[1], tocolor(45, 255, 150, 255), 0.035, 0)
+    state.thresholdEffects[2] = S.addLight(state.thresholdModels[2], tocolor(255, 55, 85, 255), 0.035, 0)
+    if state.thresholdEffects[1] == false or state.thresholdEffects[2] == false then
+        return false, "failed to add threshold lights"
     end
 
-    if not addModel2DFX(state.particleModels[1], 0, 0, 0.3, "particle", { name = "fire" }) then
-        return false, "failed to add fire particle"
+    if not addModel2DFX(state.particleModels[1], 0, 0, 0.2, "particle", { name = "smoke_flare" }) then
+        return false, "failed to add smoke_flare particle"
     end
     S.rememberTouchedModel(state.particleModels[1])
 
-    if not addModel2DFX(state.particleModels[2], 0, 0, 0.3, "particle", { name = "smoke_flare" }) then
-        return false, "failed to add smoke particle"
+    if not addModel2DFX(state.particleModels[2], 0, 0, 0.2, "particle", { name = "fire" }) then
+        return false, "failed to add fire particle"
     end
     S.rememberTouchedModel(state.particleModels[2])
 
-    if not S.addRoadsign(state.roadsignModels[1], { 0, 0, 3.3 }, { 5.5, 2.8 }, 4,
-        { "NEON_BOULEVARD", "NATIVE_GTA_2DFX", "SCRIPTED_IN_LUA", "NO_CUSTOM_ASSETS" }) then
-        return false, "failed to add main roadsign"
+    if not S.addRoadsign(state.roadsignModels[1], { "NATIVE_GTA_2DFX", "SCRIPTED_IN_LUA" }, false) or
+       not S.addRoadsign(state.roadsignModels[2], { "NO_SHADERS", "NO_CUSTOM_ASSETS" }, true) then
+        return false, "failed to add runway roadsigns"
     end
 
-    if not S.addRoadsign(state.roadsignModels[2], { 0, 0, 2.6 }, { 3.2, 1.0 }, 1,
-        { "LIGHTS_FROM_LUA", "", "", "" }) then
-        return false, "failed to add left roadsign"
-    end
-
-    if not S.addRoadsign(state.roadsignModels[3], { 0, 0, 2.6 }, { 3.2, 1.0 }, 1,
-        { "NATIVE_2DFX", "", "", "" }) then
-        return false, "failed to add right roadsign"
-    end
-
-    if not S.addEscalator(state.escalatorModels[1], 0) or
-       not S.addEscalator(state.escalatorModels[2], 1) then
-        return false, "failed to add escalators"
-    end
-
-    for step = 0, 7 do
-        local angle = math.rad(step * 45)
-        local x = math.cos(angle) * 12.0
-        local y = math.sin(angle) * 12.0
-        local z = (step % 2 == 0) and 3.0 or 6.0
-        if not addModel2DFX(state.sunModel, x, y, z, "sun_glare", {}) then
+    for step = 0, 5 do
+        local angle = math.rad(step * 60)
+        if not addModel2DFX(state.sunModel, math.cos(angle) * 5.0, math.sin(angle) * 5.0, 3.0 + (step % 2) * 2.0, "sun_glare", {}) then
             return false, "failed to add sun glare"
         end
     end
@@ -320,7 +280,7 @@ function S.addEffects()
         return false, "could not find vanilla model 1226 light 2DFX"
     end
 
-    S.setLampRowsOff()
+    S.allLightsOff()
     return true
 end
 
@@ -330,10 +290,11 @@ function S.mutateVanillaLight()
     end
     local model = state.vanillaModel
     local index = state.vanillaEffect
-    setModel2DFXProperty(model, index, "drawDistance", state.vanillaBaseline.drawDistance + 120)
-    setModel2DFXProperty(model, index, "coronaSize", math.max(2.8, state.vanillaBaseline.coronaSize * 2.5))
-    setModel2DFXProperty(model, index, "lightRange", state.vanillaBaseline.lightRange + 20)
-    setModel2DFXProperty(model, index, "color", tocolor(35, 240, 255, 255))
+    setModel2DFXProperty(model, index, "drawDistance", state.vanillaBaseline.drawDistance + 180)
+    setModel2DFXProperty(model, index, "coronaSize", math.max(3.2, state.vanillaBaseline.coronaSize * 3.0))
+    setModel2DFXProperty(model, index, "lightRange", state.vanillaBaseline.lightRange + 28)
+    setModel2DFXProperty(model, index, "color", tocolor(30, 245, 255, 255))
+    setModel2DFXProperty(model, index, "showMode", "warnlight")
     S.rememberTouchedModel(model)
 end
 
@@ -347,4 +308,5 @@ function S.restoreVanillaLight()
     resetModel2DFXProperty(model, index, "coronaSize")
     resetModel2DFXProperty(model, index, "lightRange")
     resetModel2DFXProperty(model, index, "color")
+    resetModel2DFXProperty(model, index, "showMode")
 end

--- a/test-resources/2dfx-showcase/client_scene.lua
+++ b/test-resources/2dfx-showcase/client_scene.lua
@@ -5,10 +5,52 @@ local PALETTE = S.PALETTE
 local SEGMENTS = 6
 local EDGE_STATIONS = 30
 local CENTER_STATIONS = 24
+local MOON_COUNT = 7
 
-function S.lightProperties(color, size, range, showMode)
+function S.findFirstLight(model)
+    local count = getModel2DFXCount(model, false)
+    for index = 0, count - 1 do
+        if getModel2DFXType(model, index) == "light" then
+            return index
+        end
+    end
+    return nil
+end
+
+function S.captureLightTemplate()
+    local index = S.findFirstLight(1226)
+    if index == nil then
+        return false
+    end
+
+    local x, y, z = getModel2DFXPosition(1226, index)
+    local coronaName = getModel2DFXProperty(1226, index, "coronaName")
+    local shadowName = getModel2DFXProperty(1226, index, "shadowName")
+    local drawDistance = getModel2DFXProperty(1226, index, "drawDistance")
+    local coronaSize = getModel2DFXProperty(1226, index, "coronaSize")
+    local lightRange = getModel2DFXProperty(1226, index, "lightRange")
+
+    if type(x) ~= "number" or type(coronaName) ~= "string" or coronaName == "" then
+        return false
+    end
+
+    state.lightTemplate = {
+        position = { x, y, z },
+        coronaName = coronaName,
+        shadowName = type(shadowName) == "string" and shadowName or "shad_exp",
+        drawDistance = type(drawDistance) == "number" and drawDistance or 180,
+        coronaSize = type(coronaSize) == "number" and coronaSize or 1.0,
+        lightRange = type(lightRange) == "number" and lightRange or 12,
+    }
+    S.log(string.format("lamp template corona=%s shadow=%s", state.lightTemplate.coronaName, state.lightTemplate.shadowName))
+    return true
+end
+
+function S.lightProperties(color, size, range, showMode, coronaName, position)
+    local template = state.lightTemplate or {}
+    position = position or template.position or { 0, 0, 0.22 }
     return {
-        drawDistance = 260,
+        drawDistance = math.max(260, template.drawDistance or 0),
         lightRange = range or 0,
         coronaSize = size or 0.04,
         shadowSize = 0,
@@ -20,17 +62,27 @@ function S.lightProperties(color, size, range, showMode)
         shadowDistance = 0,
         offset = { 0, 0, 0 },
         color = color,
-        coronaName = "coronamoon",
-        shadowName = "shad_exp",
-    }
+        coronaName = coronaName or template.coronaName or "coronastar",
+        shadowName = template.shadowName or "shad_exp",
+    }, position
 end
 
-function S.addLight(model, color, size, range, showMode)
-    if not addModel2DFX(model, 0, 0, 0.22, "light", S.lightProperties(color, size, range, showMode)) then
+function S.addCustomLight(model, color, size, range, showMode, coronaName, position)
+    local props, effectPosition = S.lightProperties(color, size, range, showMode, coronaName, position)
+    if not addModel2DFX(model, effectPosition[1], effectPosition[2], effectPosition[3], "light", props) then
         return false
     end
     S.rememberTouchedModel(model)
     return getModel2DFXCount(model, true) - 1
+end
+
+function S.ensureLampLight(model, color)
+    local index = S.findFirstLight(model)
+    if index ~= nil then
+        S.rememberTouchedModel(model)
+        return index
+    end
+    return S.addCustomLight(model, color, 0.04, 0, "default")
 end
 
 function S.setLight(model, effect, color, size, range, showMode)
@@ -40,10 +92,10 @@ function S.setLight(model, effect, color, size, range, showMode)
     if color then
         setModel2DFXProperty(model, effect, "color", color)
     end
-    if size then
+    if size ~= nil then
         setModel2DFXProperty(model, effect, "coronaSize", size)
     end
-    if range then
+    if range ~= nil then
         setModel2DFXProperty(model, effect, "lightRange", range)
     end
     if showMode then
@@ -52,9 +104,7 @@ function S.setLight(model, effect, color, size, range, showMode)
 end
 
 function S.setEdgeSegment(side, segment, color, size, range, showMode)
-    local model = state.edgeModels[side][segment]
-    local effect = state.edgeEffects[side][segment]
-    S.setLight(model, effect, color, size, range, showMode)
+    S.setLight(state.edgeModels[side][segment], state.edgeEffects[side][segment], color, size, range, showMode)
 end
 
 function S.setCenterSegment(segment, color, size, range, showMode)
@@ -65,14 +115,21 @@ function S.setThreshold(index, color, size, range, showMode)
     S.setLight(state.thresholdModels[index], state.thresholdEffects[index], color, size, range, showMode)
 end
 
+function S.setMoon(index, color, size, showMode)
+    S.setLight(state.moonModels[index], state.moonEffects[index], color, size, 0, showMode or "default")
+end
+
 function S.allLightsOff()
     for segment = 1, SEGMENTS do
-        S.setEdgeSegment("left", segment, PALETTE[1], 0.035, 0, "default")
-        S.setEdgeSegment("right", segment, PALETTE[1], 0.035, 0, "default")
-        S.setCenterSegment(segment, PALETTE[6], 0.025, 0, "default")
+        S.setEdgeSegment("left", segment, PALETTE[1], 0.03, 0, "default")
+        S.setEdgeSegment("right", segment, PALETTE[1], 0.03, 0, "default")
+        S.setCenterSegment(segment, PALETTE[6], 0.02, 0, "default")
     end
-    S.setThreshold(1, tocolor(40, 255, 150, 255), 0.035, 0, "default")
-    S.setThreshold(2, tocolor(255, 65, 90, 255), 0.035, 0, "default")
+    S.setThreshold(1, tocolor(40, 255, 150, 255), 0.03, 0, "default")
+    S.setThreshold(2, tocolor(255, 65, 90, 255), 0.03, 0, "default")
+    for index = 1, MOON_COUNT do
+        S.setMoon(index, PALETTE[((index - 1) % #PALETTE) + 1], 0.03, "default")
+    end
 end
 
 function S.applyFinalLights(step)
@@ -80,18 +137,22 @@ function S.applyFinalLights(step)
     for segment = 1, SEGMENTS do
         local leftColor = PALETTE[((segment + step - 2) % #PALETTE) + 1]
         local rightColor = PALETTE[((#PALETTE - segment + step) % #PALETTE) + 1]
-        S.setEdgeSegment("left", segment, leftColor, 1.55, 4, "default")
-        S.setEdgeSegment("right", segment, rightColor, 1.55, 4, "default")
-        S.setCenterSegment(segment, PALETTE[6], 0.72, 0, "default")
+        S.setEdgeSegment("left", segment, leftColor, 1.55, 18, "default")
+        S.setEdgeSegment("right", segment, rightColor, 1.55, 18, "default")
+        S.setCenterSegment(segment, PALETTE[6], 0.62, 0, "default")
     end
-    S.setThreshold(1, tocolor(45, 255, 150, 255), 1.25, 0, "default")
-    S.setThreshold(2, tocolor(255, 55, 85, 255), 1.25, 0, "default")
+    S.setThreshold(1, tocolor(45, 255, 150, 255), 1.20, 0, "default")
+    S.setThreshold(2, tocolor(255, 55, 85, 255), 1.20, 0, "default")
 end
 
 function S.buildRuntimeModels()
+    if not S.captureLightTemplate() then
+        return false, "could not read model 1226 native light template"
+    end
+
     for segment = 1, SEGMENTS do
-        state.edgeModels.left[segment] = S.requestObjectModel(1337)
-        state.edgeModels.right[segment] = S.requestObjectModel(1337)
+        state.edgeModels.left[segment] = S.requestObjectModel(1226)
+        state.edgeModels.right[segment] = S.requestObjectModel(1226)
         state.centerModels[segment] = S.requestObjectModel(1337)
         if not state.edgeModels.left[segment] or not state.edgeModels.right[segment] or not state.centerModels[segment] then
             return false, "could not allocate runway light model group " .. segment
@@ -104,6 +165,13 @@ function S.buildRuntimeModels()
         state.roadsignModels[index] = S.requestObjectModel(1337)
         if not state.thresholdModels[index] or not state.particleModels[index] or not state.roadsignModels[index] then
             return false, "could not allocate showcase model group " .. index
+        end
+    end
+
+    for index = 1, MOON_COUNT do
+        state.moonModels[index] = S.requestObjectModel(1337)
+        if not state.moonModels[index] then
+            return false, "could not allocate moon model " .. index
         end
     end
 
@@ -128,9 +196,9 @@ function S.buildRunwayAnchors()
     for index = 1, EDGE_STATIONS do
         local segment = segmentForStation(index, EDGE_STATIONS)
         local t = 0.045 + ((index - 1) / (EDGE_STATIONS - 1)) * 0.91
-        if not S.spawnOnRunway(state.edgeModels.left[segment], t, -S.RUNWAY_HALF_WIDTH, 0.12, 0, 0.08) or
-           not S.spawnOnRunway(state.edgeModels.right[segment], t, S.RUNWAY_HALF_WIDTH, 0.12, 0, 0.08) then
-            return false, "could not create runway edge anchors"
+        if not S.spawnOnRunway(state.edgeModels.left[segment], t, -S.RUNWAY_HALF_WIDTH - 2.0, 0, 255, 1.0, 90) or
+           not S.spawnOnRunway(state.edgeModels.right[segment], t, S.RUNWAY_HALF_WIDTH + 2.0, 0, 255, 1.0, -90) then
+            return false, "could not create runway lamp posts"
         end
     end
 
@@ -170,9 +238,19 @@ function S.buildRunwayAnchors()
         return false, "could not create sun-glare anchor"
     end
 
-    state.vanillaObject = S.spawnOnRunway(state.vanillaModel, 0.53, -24.0, 0, 255, 1.0)
+    local moonLayout = {
+        { 0.62, -58, 24 }, { 0.67, -40, 35 }, { 0.72, -21, 43 },
+        { 0.76,   0, 48 }, { 0.80,  21, 43 }, { 0.85,  40, 35 }, { 0.90, 58, 24 },
+    }
+    for index, moon in ipairs(moonLayout) do
+        if not S.spawnOnRunway(state.moonModels[index], moon[1], moon[2], moon[3], 0, 0.05) then
+            return false, "could not create moon sky anchor"
+        end
+    end
+
+    state.vanillaObject = S.spawnOnRunway(state.vanillaModel, 0.53, -27.0, 0, 255, 1.0, 90)
     if not state.vanillaObject then
-        return false, "could not create vanilla lamp"
+        return false, "could not create hero vanilla lamp"
     end
 
     return true
@@ -196,25 +274,8 @@ function S.addRoadsign(model, text, reverse)
     return true
 end
 
-function S.findFirstLight(model)
-    local count = getModel2DFXCount(model, false)
-    for index = 0, count - 1 do
-        if getModel2DFXType(model, index) == "light" then
-            return index
-        end
-    end
-    return nil
-end
-
 function S.captureVanillaLight()
     local index = S.findFirstLight(state.vanillaModel)
-    if index == nil and state.vanillaModel ~= 1226 then
-        state.vanillaModel = 1226
-        if isElement(state.vanillaObject) then
-            setElementModel(state.vanillaObject, 1226)
-        end
-        index = S.findFirstLight(1226)
-    end
     if index == nil then
         return false
     end
@@ -234,23 +295,32 @@ function S.captureVanillaLight()
         lightRange = lightRange,
         color = tocolor(r, g, b, a),
     }
+    S.rememberTouchedModel(state.vanillaModel)
     return true
 end
 
 function S.addEffects()
     for segment = 1, SEGMENTS do
-        state.edgeEffects.left[segment] = S.addLight(state.edgeModels.left[segment], PALETTE[segment], 0.035, 0)
-        state.edgeEffects.right[segment] = S.addLight(state.edgeModels.right[segment], PALETTE[7 - segment], 0.035, 0)
-        state.centerEffects[segment] = S.addLight(state.centerModels[segment], PALETTE[6], 0.025, 0)
+        state.edgeEffects.left[segment] = S.ensureLampLight(state.edgeModels.left[segment], PALETTE[segment])
+        state.edgeEffects.right[segment] = S.ensureLampLight(state.edgeModels.right[segment], PALETTE[7 - segment])
+        state.centerEffects[segment] = S.addCustomLight(state.centerModels[segment], PALETTE[6], 0.02, 0)
         if state.edgeEffects.left[segment] == false or state.edgeEffects.right[segment] == false or state.centerEffects[segment] == false then
-            return false, "failed to add runway light segment " .. segment
+            return false, "failed to prepare runway light segment " .. segment
         end
     end
 
-    state.thresholdEffects[1] = S.addLight(state.thresholdModels[1], tocolor(45, 255, 150, 255), 0.035, 0)
-    state.thresholdEffects[2] = S.addLight(state.thresholdModels[2], tocolor(255, 55, 85, 255), 0.035, 0)
+    state.thresholdEffects[1] = S.addCustomLight(state.thresholdModels[1], tocolor(45, 255, 150, 255), 0.03, 0)
+    state.thresholdEffects[2] = S.addCustomLight(state.thresholdModels[2], tocolor(255, 55, 85, 255), 0.03, 0)
     if state.thresholdEffects[1] == false or state.thresholdEffects[2] == false then
         return false, "failed to add threshold lights"
+    end
+
+    for index = 1, MOON_COUNT do
+        local color = PALETTE[((index - 1) % #PALETTE) + 1]
+        state.moonEffects[index] = S.addCustomLight(state.moonModels[index], color, 0.03, 0, "default", "coronamoon", { 0, 0, 0 })
+        if state.moonEffects[index] == false then
+            return false, "failed to add moon sprite " .. index
+        end
     end
 
     if not addModel2DFX(state.particleModels[1], 0, 0, 0.2, "particle", { name = "smoke_flare" }) then
@@ -276,9 +346,10 @@ function S.addEffects()
     end
     S.rememberTouchedModel(state.sunModel)
 
-    if not S.captureVanillaLight() then
-        return false, "could not find vanilla model 1226 light 2DFX"
-    end
+    -- A requested 1226 model normally carries the native lamp effect. If this
+    -- build does not clone native 2DFX, the hero shot is skipped instead of
+    -- touching global model 1226 and affecting unrelated world lamps.
+    S.captureVanillaLight()
 
     S.allLightsOff()
     return true
@@ -295,7 +366,6 @@ function S.mutateVanillaLight()
     setModel2DFXProperty(model, index, "lightRange", state.vanillaBaseline.lightRange + 28)
     setModel2DFXProperty(model, index, "color", tocolor(30, 245, 255, 255))
     setModel2DFXProperty(model, index, "showMode", "warnlight")
-    S.rememberTouchedModel(model)
 end
 
 function S.restoreVanillaLight()

--- a/test-resources/2dfx-showcase/client_show.lua
+++ b/test-resources/2dfx-showcase/client_show.lua
@@ -3,6 +3,7 @@ local state = S.state
 local PALETTE = S.PALETTE
 
 local SEGMENTS = 6
+local MOON_COUNT = 7
 
 function S.cue(key, condition, callback)
     if condition and not state.cues[key] then
@@ -27,9 +28,32 @@ function S.updateChase(t)
         local leftColor = PALETTE[phase + 1]
         local rightColor = PALETTE[((#PALETTE - phase) % #PALETTE) + 1]
         local pulse = ((segment + step) % SEGMENTS == 0)
-        S.setEdgeSegment("left", segment, leftColor, pulse and 2.15 or 1.35, pulse and 10 or 2, "default")
-        S.setEdgeSegment("right", segment, rightColor, pulse and 2.15 or 1.35, pulse and 10 or 2, "default")
-        S.setCenterSegment(segment, PALETTE[6], pulse and 1.15 or 0.58, 0, "default")
+        local leftMode = ((segment + step) % 4 == 0) and "warnlight" or "default"
+        local rightMode = ((segment + step + 2) % 4 == 0) and "trafficlight" or "default"
+        S.setEdgeSegment("left", segment, leftColor, pulse and 2.25 or 1.35, pulse and 26 or 14, leftMode)
+        S.setEdgeSegment("right", segment, rightColor, pulse and 2.25 or 1.35, pulse and 26 or 14, rightMode)
+        S.setCenterSegment(segment, PALETTE[6], pulse and 1.05 or 0.55, 0, "default")
+    end
+end
+
+function S.updateMoonBurst(t)
+    if t < 22000 or t >= 27000 then
+        return
+    end
+
+    local step = math.floor((t - 22000) / 260)
+    if step == state.moonStep then
+        return
+    end
+    state.moonStep = step
+
+    for index = 1, MOON_COUNT do
+        local intro = S.clamp((t - (22000 + (index - 1) * 180)) / 800, 0, 1)
+        local outro = S.clamp((27000 - t) / 900, 0, 1)
+        local pulse = 0.85 + 0.25 * math.sin((step + index) * 0.7)
+        local size = intro * outro * (3.7 + index * 0.22) * pulse
+        local color = PALETTE[((index + math.floor(step / 3) - 2) % #PALETTE) + 1]
+        S.setMoon(index, color, math.max(0.03, size), "default")
     end
 end
 
@@ -48,7 +72,9 @@ function S.updateFinal(t)
     local hot = (step % 2 == 0)
     for segment = 1, SEGMENTS do
         if ((segment + step) % 3) == 0 then
-            S.setCenterSegment(segment, PALETTE[6], hot and 1.35 or 0.72, 0, hot and "warnlight" or "default")
+            S.setEdgeSegment("left", segment, nil, hot and 2.05 or 1.55, hot and 25 or 18, hot and "warnlight" or "default")
+            S.setEdgeSegment("right", segment, nil, hot and 2.05 or 1.55, hot and 25 or 18, hot and "trafficlight" or "default")
+            S.setCenterSegment(segment, PALETTE[6], hot and 1.25 or 0.62, 0, hot and "on_off_at_5" or "default")
         end
     end
 end
@@ -63,39 +89,55 @@ function S.updateSceneCues(t)
         local orderCopy = order
         local segment = SEGMENTS - order + 1
         S.cue("edge_segment_" .. segment, t >= 3900 + (orderCopy - 1) * 480, function()
-            S.setEdgeSegment("left", segment, PALETTE[segment], 1.55, 3, "default")
-            S.setEdgeSegment("right", segment, PALETTE[7 - segment], 1.55, 3, "default")
+            S.setEdgeSegment("left", segment, PALETTE[segment], 1.55, 18, "default")
+            S.setEdgeSegment("right", segment, PALETTE[7 - segment], 1.55, 18, "default")
         end)
     end
 
     S.cue("thresholds", t >= 6900, function()
-        S.setThreshold(1, tocolor(45, 255, 150, 255), 1.25, 0, "default")
-        S.setThreshold(2, tocolor(255, 55, 85, 255), 1.25, 0, "default")
+        S.setThreshold(1, tocolor(45, 255, 150, 255), 1.20, 0, "default")
+        S.setThreshold(2, tocolor(255, 55, 85, 255), 1.20, 0, "default")
     end)
 
     for segment = 1, SEGMENTS do
         local segmentCopy = segment
         S.cue("center_segment_" .. segmentCopy, t >= 7600 + (segmentCopy - 1) * 330, function()
-            S.setCenterSegment(segmentCopy, PALETTE[6], 0.72, 0, "default")
+            S.setCenterSegment(segmentCopy, PALETTE[6], 0.62, 0, "default")
         end)
     end
 
-    S.cue("center_blink", t >= 11200, function()
+    S.cue("left_right_demo", t >= 11600, function()
         for segment = 1, SEGMENTS do
-            S.setCenterSegment(segment, PALETTE[6], 0.85, 0, "on_off_at_5")
+            S.setEdgeSegment("left", segment, nil, 1.65, 19, segment % 2 == 0 and "warnlight" or "default")
+            S.setEdgeSegment("right", segment, nil, 1.65, 19, segment % 2 == 1 and "trafficlight" or "default")
         end
     end)
 
-    S.cue("center_normal", t >= 15000, function()
+    S.cue("center_blink", t >= 12400, function()
         for segment = 1, SEGMENTS do
-            S.setCenterSegment(segment, PALETTE[6], 0.72, 0, "default")
+            S.setCenterSegment(segment, PALETTE[6], 0.78, 0, "on_off_at_5")
+        end
+    end)
+
+    S.cue("all_normal", t >= 16400, function()
+        for segment = 1, SEGMENTS do
+            S.setEdgeSegment("left", segment, nil, 1.45, 17, "default")
+            S.setEdgeSegment("right", segment, nil, 1.45, 17, "default")
+            S.setCenterSegment(segment, PALETTE[6], 0.62, 0, "default")
         end
     end)
 
     S.cue("vanilla_mutate", t >= 17300, S.mutateVanillaLight)
     S.cue("vanilla_restore", t >= 20800, S.restoreVanillaLight)
 
+    S.cue("moon_cleanup", t >= 27000, function()
+        for index = 1, MOON_COUNT do
+            S.setMoon(index, PALETTE[((index - 1) % #PALETTE) + 1], 0.03, "default")
+        end
+    end)
+
     S.updateChase(t)
+    S.updateMoonBurst(t)
     S.updateFinal(t)
 end
 
@@ -114,26 +156,26 @@ function S.setCameraForTimeline(t)
         )
     elseif t < 17000 then
         S.cameraLerp(
-            S.cameraPoint(0.20, -30, 9.5, 0.58, 0, 1.4, 72),
-            S.cameraPoint(0.60, 29, 8.0, 0.82, 0, 1.2, 70),
+            S.cameraPoint(0.20, -30, 9.5, 0.58, 0, 2.0, 72),
+            S.cameraPoint(0.60, 29, 8.0, 0.82, 0, 2.0, 70),
             (t - 10500) / 6500
         )
     elseif t < 22000 then
         S.cameraLerp(
-            S.cameraPoint(0.49, -31, 4.0, 0.53, -24, 5.5, 55),
-            S.cameraPoint(0.56, -28, 6.0, 0.53, -24, 5.5, 48),
+            S.cameraPoint(0.47, -34, 4.2, 0.53, -27, 6.0, 55),
+            S.cameraPoint(0.58, -31, 6.2, 0.53, -27, 6.0, 48),
             (t - 17000) / 5000
         )
     elseif t < 27000 then
         S.cameraLerp(
-            S.cameraPoint(0.70, -24, 7.5, 0.90, 0, 2.5, 66),
-            S.cameraPoint(0.82, 19, 5.5, 0.93, 0, 2.0, 60),
+            S.cameraPoint(0.48, -10, 4.0, 0.76, 0, 34.0, 72),
+            S.cameraPoint(0.59, 18, 9.5, 0.78, 0, 39.0, 76),
             (t - 22000) / 5000
         )
     elseif t < 32000 then
         S.cameraLerp(
-            S.cameraPoint(-0.005, -12, 3.4, 0.10, 0, 3.0, 58),
-            S.cameraPoint(0.14, 10, 4.8, 0.22, 0, 2.5, 62),
+            S.cameraPoint(0.70, -24, 7.5, 0.90, 0, 2.5, 66),
+            S.cameraPoint(0.93, 20, 5.5, 0.91, 0, 2.0, 60),
             (t - 27000) / 5000
         )
     else
@@ -196,6 +238,7 @@ function S.beginShow(mode, shot)
     state.shot = shot
     state.cues = {}
     state.chaseStep = -1
+    state.moonStep = -1
     state.finalStep = -1
     state.startedAt = getTickCount()
     state.active = true
@@ -253,7 +296,8 @@ function S.prepareShow(_, _, _, dimension)
         end
 
         -- Particle and roadsign models perform their targeted restream while the
-        -- screen is still black. The recorded timeline itself stays restream-free.
+        -- screen is still black. LIGHT/SUN_GLARE property animation during the
+        -- recorded timeline stays restream-free.
         S.later(2300, function()
             local cam = S.cameraPoint(-0.04, 0, 3.0, 0.8, 0, 1.2, 72)
             setCameraMatrix(cam[1], cam[2], cam[3], cam[4], cam[5], cam[6], 0, cam[7])

--- a/test-resources/2dfx-showcase/client_show.lua
+++ b/test-resources/2dfx-showcase/client_show.lua
@@ -2,6 +2,8 @@ local S = DFXShowcase
 local state = S.state
 local PALETTE = S.PALETTE
 
+local SEGMENTS = 6
+
 function S.cue(key, condition, callback)
     if condition and not state.cues[key] then
         state.cues[key] = true
@@ -9,105 +11,148 @@ function S.cue(key, condition, callback)
     end
 end
 
-function S.updateSceneCues(t)
-    S.cue("night", t >= 5000, function()
-        setTime(23, 0)
-        setWeather(0)
-    end)
-
-    for row = 1, 6 do
-        S.cue("row" .. row, t >= 5200 + (row - 1) * 900, function()
-            S.activateLampRow(row)
-        end)
+function S.updateChase(t)
+    if t < 10500 or t >= 17000 then
+        return
     end
 
-    S.cue("hero_on", t >= 10800, function()
-        S.setLight(state.heroModel, state.heroEffect, tocolor(80, 245, 255, 255), 2.5, 30)
-    end)
+    local step = math.floor((t - 10500) / 320)
+    if step == state.chaseStep then
+        return
+    end
+    state.chaseStep = step
 
-    S.cue("hero_flash", t >= 11900, function()
-        if state.heroModel and state.heroEffect then
-            setModel2DFXProperty(state.heroModel, state.heroEffect, "showMode", "random_flashing")
-        end
-    end)
+    for segment = 1, SEGMENTS do
+        local phase = (segment + step) % #PALETTE
+        local leftColor = PALETTE[phase + 1]
+        local rightColor = PALETTE[((#PALETTE - phase) % #PALETTE) + 1]
+        local pulse = ((segment + step) % SEGMENTS == 0)
+        S.setEdgeSegment("left", segment, leftColor, pulse and 2.15 or 1.35, pulse and 10 or 2, "default")
+        S.setEdgeSegment("right", segment, rightColor, pulse and 2.15 or 1.35, pulse and 10 or 2, "default")
+        S.setCenterSegment(segment, PALETTE[6], pulse and 1.15 or 0.58, 0, "default")
+    end
+end
 
-    S.cue("hero_normal", t >= 12900, function()
-        if state.heroModel and state.heroEffect then
-            setModel2DFXProperty(state.heroModel, state.heroEffect, "showMode", "default")
-        end
-    end)
+function S.updateFinal(t)
+    if t < 32000 then
+        return
+    end
 
-    S.cue("vanilla_mutate", t >= 13600, S.mutateVanillaLight)
-    S.cue("vanilla_restore", t >= 16500, S.restoreVanillaLight)
+    local step = math.floor((t - 32000) / 430)
+    if step == state.finalStep then
+        return
+    end
+    state.finalStep = step
+    S.applyFinalLights(step)
 
-    if t >= 35000 then
-        local step = math.floor((t - 35000) / 700)
-        if step ~= state.lastFinalStep then
-            state.lastFinalStep = step
-            for row, model in ipairs(state.lampModels) do
-                local color = PALETTE[((row + step - 1) % #PALETTE) + 1]
-                S.setLight(model, state.lampEffects[row], color, 1.8, 24)
-            end
+    local hot = (step % 2 == 0)
+    for segment = 1, SEGMENTS do
+        if ((segment + step) % 3) == 0 then
+            S.setCenterSegment(segment, PALETTE[6], hot and 1.35 or 0.72, 0, hot and "warnlight" or "default")
         end
     end
 end
 
-function S.setCameraForTimeline(t)
-    local cx, cy, cz = state.cx, state.cy, state.cz
+function S.updateSceneCues(t)
+    S.cue("night", t >= 3500, function()
+        setTime(23, 0)
+        setWeather(0)
+    end)
 
-    if t < 5000 then
+    for order = 1, SEGMENTS do
+        local orderCopy = order
+        local segment = SEGMENTS - order + 1
+        S.cue("edge_segment_" .. segment, t >= 3900 + (orderCopy - 1) * 480, function()
+            S.setEdgeSegment("left", segment, PALETTE[segment], 1.55, 3, "default")
+            S.setEdgeSegment("right", segment, PALETTE[7 - segment], 1.55, 3, "default")
+        end)
+    end
+
+    S.cue("thresholds", t >= 6900, function()
+        S.setThreshold(1, tocolor(45, 255, 150, 255), 1.25, 0, "default")
+        S.setThreshold(2, tocolor(255, 55, 85, 255), 1.25, 0, "default")
+    end)
+
+    for segment = 1, SEGMENTS do
+        local segmentCopy = segment
+        S.cue("center_segment_" .. segmentCopy, t >= 7600 + (segmentCopy - 1) * 330, function()
+            S.setCenterSegment(segmentCopy, PALETTE[6], 0.72, 0, "default")
+        end)
+    end
+
+    S.cue("center_blink", t >= 11200, function()
+        for segment = 1, SEGMENTS do
+            S.setCenterSegment(segment, PALETTE[6], 0.85, 0, "on_off_at_5")
+        end
+    end)
+
+    S.cue("center_normal", t >= 15000, function()
+        for segment = 1, SEGMENTS do
+            S.setCenterSegment(segment, PALETTE[6], 0.72, 0, "default")
+        end
+    end)
+
+    S.cue("vanilla_mutate", t >= 17300, S.mutateVanillaLight)
+    S.cue("vanilla_restore", t >= 20800, S.restoreVanillaLight)
+
+    S.updateChase(t)
+    S.updateFinal(t)
+end
+
+function S.setCameraForTimeline(t)
+    if t < 3500 then
         S.cameraLerp(
-            { cx - 18, cy - 34, cz + 8, cx, cy + 35, cz + 8, 76 },
-            { cx + 5, cy - 24, cz + 6, cx, cy + 42, cz + 10, 68 },
-            t / 5000
+            S.cameraPoint(-0.055, -24, 7.5, 0.72, 0, 3.5, 72),
+            S.cameraPoint(-0.015, 9, 4.5, 0.88, 0, 4.0, 64),
+            t / 3500
         )
-    elseif t < 13000 then
+    elseif t < 10500 then
         S.cameraLerp(
-            { cx - 12, cy - 27, cz + 3.5, cx, cy + 18, cz + 4.5, 78 },
-            { cx + 8, cy - 10, cz + 4.5, cx, cy + 22, cz + 5.5, 66 },
-            (t - 5000) / 8000
+            S.cameraPoint(-0.035, 0, 2.2, 0.88, 0, 1.4, 78),
+            S.cameraPoint(0.17, -12, 4.8, 0.94, 0, 1.5, 68),
+            (t - 3500) / 7000
         )
-    elseif t < 18000 then
+    elseif t < 17000 then
         S.cameraLerp(
-            { cx + 19, cy - 4, cz + 3.2, cx + 12, cy + 3, cz + 5.5, 58 },
-            { cx + 8, cy + 2, cz + 4.5, cx + 12, cy + 3, cz + 5.5, 50 },
-            (t - 13000) / 5000
+            S.cameraPoint(0.20, -30, 9.5, 0.58, 0, 1.4, 72),
+            S.cameraPoint(0.60, 29, 8.0, 0.82, 0, 1.2, 70),
+            (t - 10500) / 6500
         )
-    elseif t < 23000 then
+    elseif t < 22000 then
         S.cameraLerp(
-            { cx - 19, cy + 4, cz + 8.5, cx - 11, cy + 14, cz + 5.5, 62 },
-            { cx + 18, cy + 8, cz + 9.0, cx + 11, cy + 16, cz + 6.0, 64 },
-            (t - 18000) / 5000
+            S.cameraPoint(0.49, -31, 4.0, 0.53, -24, 5.5, 55),
+            S.cameraPoint(0.56, -28, 6.0, 0.53, -24, 5.5, 48),
+            (t - 17000) / 5000
         )
-    elseif t < 29000 then
+    elseif t < 27000 then
         S.cameraLerp(
-            { cx, cy + 9, cz + 3.4, cx, cy + 28, cz + 4.0, 58 },
-            { cx - 9, cy + 16, cz + 4.8, cx, cy + 28, cz + 4.2, 52 },
-            (t - 23000) / 6000
+            S.cameraPoint(0.70, -24, 7.5, 0.90, 0, 2.5, 66),
+            S.cameraPoint(0.82, 19, 5.5, 0.93, 0, 2.0, 60),
+            (t - 22000) / 5000
         )
-    elseif t < 35000 then
+    elseif t < 32000 then
         S.cameraLerp(
-            { cx - 16, cy + 24, cz + 2.8, cx, cy + 35, cz + 3.2, 64 },
-            { cx + 13, cy + 27, cz + 5.5, cx, cy + 35, cz + 3.5, 60 },
-            (t - 29000) / 6000
+            S.cameraPoint(-0.005, -12, 3.4, 0.10, 0, 3.0, 58),
+            S.cameraPoint(0.14, 10, 4.8, 0.22, 0, 2.5, 62),
+            (t - 27000) / 5000
         )
     else
         S.cameraLerp(
-            { cx + 17, cy - 10, cz + 7.0, cx, cy + 20, cz + 5.0, 76 },
-            { cx, cy - 39, cz + 14.5, cx, cy + 18, cz + 5.5, 82 },
-            S.clamp((t - 35000) / 7000, 0, 1)
+            S.cameraPoint(0.08, 0, 3.2, 0.90, 0, 1.5, 72),
+            S.cameraPoint(-0.09, 0, 16.0, 0.62, 0, 1.0, 84),
+            S.clamp((t - 32000) / 6000, 0, 1)
         )
     end
 end
 
 S.SHOT_WINDOWS = {
-    [1] = { offset = 0, duration = 5200 },
-    [2] = { offset = 5000, duration = 8200 },
-    [3] = { offset = 13000, duration = 5200 },
-    [4] = { offset = 18000, duration = 5200 },
-    [5] = { offset = 23000, duration = 6200 },
-    [6] = { offset = 29000, duration = 6200 },
-    [7] = { offset = 35000, duration = 7200 },
+    [1] = { offset = 0, duration = 3700 },
+    [2] = { offset = 3500, duration = 7200 },
+    [3] = { offset = 10500, duration = 6700 },
+    [4] = { offset = 17000, duration = 5200 },
+    [5] = { offset = 22000, duration = 5200 },
+    [6] = { offset = 27000, duration = 5200 },
+    [7] = { offset = 32000, duration = 6200 },
 }
 
 function S.timelineTime()
@@ -125,13 +170,10 @@ function S.renderShow()
     end
 
     if state.mode == "setup" or state.mode == "final" then
-        S.applyAllLights()
+        S.applyFinalLights(state.finalStep < 0 and 0 or state.finalStep)
         setTime(23, 0)
-        setCameraMatrix(
-            state.cx, state.cy - 38, state.cz + 13,
-            state.cx, state.cy + 18, state.cz + 5.5,
-            0, 82
-        )
+        local cam = S.cameraPoint(-0.08, 0, 17.0, 0.62, 0, 1.2, 84)
+        setCameraMatrix(cam[1], cam[2], cam[3], cam[4], cam[5], cam[6], 0, cam[7])
         return
     end
 
@@ -153,39 +195,42 @@ function S.beginShow(mode, shot)
     state.mode = mode or "full"
     state.shot = shot
     state.cues = {}
-    state.lastFinalStep = -1
+    state.chaseStep = -1
+    state.finalStep = -1
     state.startedAt = getTickCount()
     state.active = true
 
     S.setPresentationUI(state.mode == "setup")
+    removeEventHandler("onClientRender", root, S.renderShow)
     addEventHandler("onClientRender", root, S.renderShow)
 
     if state.mode == "setup" or state.mode == "final" then
-        S.applyAllLights()
+        S.applyFinalLights(0)
         setTime(23, 0)
+        setWeather(0)
     else
-        S.setLampRowsOff()
-        setTime(18, 30)
+        S.allLightsOff()
+        S.restoreVanillaLight()
+        setTime(18, 20)
         setWeather(0)
     end
 
-    S.log(string.format("started mode=%s shot=%s", tostring(state.mode), tostring(state.shot)))
+    S.log(string.format("started runway mode=%s shot=%s", tostring(state.mode), tostring(state.shot)))
 end
 
-function S.prepareShow(cx, cy, cz, dimension)
+function S.prepareShow(_, _, _, dimension)
     S.cleanupLocal()
 
     state.prepared = true
-    state.cx, state.cy, state.cz = cx, cy, cz
     state.dimension = dimension
+    S.configureRunway()
 
     local hour, minute = getTime()
     state.savedTime = { hour = hour, minute = minute }
-    local weather = getWeather()
-    state.savedWeather = weather
+    state.savedWeather = getWeather()
 
     S.setPresentationUI(false)
-    setTime(18, 30)
+    setTime(18, 20)
     setWeather(0)
 
     local ok, reason = S.buildRuntimeModels()
@@ -194,31 +239,25 @@ function S.prepareShow(cx, cy, cz, dimension)
         return
     end
 
-    ok, reason = S.buildDecor()
+    ok, reason = S.buildRunwayAnchors()
     if not ok then
         S.failSetup(reason)
         return
     end
 
-    S.later(1400, function()
+    S.later(1200, function()
         local effectsOk, effectsReason = S.addEffects()
         if not effectsOk then
             S.failSetup(effectsReason)
             return
         end
 
-        -- Particle, roadsign and escalator additions restream only their own
-        -- requested models. Prewarm the native escalator steps while the server
-        -- still holds the camera behind a black fade.
-        S.later(1500, function()
-            setCameraMatrix(
-                state.cx - 8, state.cy + 28, state.cz + 4,
-                state.cx, state.cy + 35, state.cz + 3.5,
-                0, 68
-            )
-            S.later(1200, function()
-                triggerServerEvent("2dfxShowcase:ready", resourceRoot)
-            end)
+        -- Particle and roadsign models perform their targeted restream while the
+        -- screen is still black. The recorded timeline itself stays restream-free.
+        S.later(2300, function()
+            local cam = S.cameraPoint(-0.04, 0, 3.0, 0.8, 0, 1.2, 72)
+            setCameraMatrix(cam[1], cam[2], cam[3], cam[4], cam[5], cam[6], 0, cam[7])
+            triggerServerEvent("2dfxShowcase:ready", resourceRoot)
         end)
     end)
 end

--- a/test-resources/2dfx-showcase/client_show.lua
+++ b/test-resources/2dfx-showcase/client_show.lua
@@ -201,9 +201,8 @@ function S.beginShow(mode, shot)
     state.active = true
 
     S.setPresentationUI(state.mode == "setup")
-    if not isEventHandlerAdded or not isEventHandlerAdded("onClientRender", root, S.renderShow) then
-        addEventHandler("onClientRender", root, S.renderShow)
-    end
+    removeEventHandler("onClientRender", root, S.renderShow)
+    addEventHandler("onClientRender", root, S.renderShow)
 
     if state.mode == "setup" or state.mode == "final" then
         S.applyFinalLights(0)

--- a/test-resources/2dfx-showcase/client_show.lua
+++ b/test-resources/2dfx-showcase/client_show.lua
@@ -201,8 +201,9 @@ function S.beginShow(mode, shot)
     state.active = true
 
     S.setPresentationUI(state.mode == "setup")
-    removeEventHandler("onClientRender", root, S.renderShow)
-    addEventHandler("onClientRender", root, S.renderShow)
+    if not isEventHandlerAdded or not isEventHandlerAdded("onClientRender", root, S.renderShow) then
+        addEventHandler("onClientRender", root, S.renderShow)
+    end
 
     if state.mode == "setup" or state.mode == "final" then
         S.applyFinalLights(0)

--- a/test-resources/2dfx-showcase/client_show.lua
+++ b/test-resources/2dfx-showcase/client_show.lua
@@ -1,0 +1,237 @@
+local S = DFXShowcase
+local state = S.state
+local PALETTE = S.PALETTE
+
+function S.cue(key, condition, callback)
+    if condition and not state.cues[key] then
+        state.cues[key] = true
+        callback()
+    end
+end
+
+function S.updateSceneCues(t)
+    S.cue("night", t >= 5000, function()
+        setTime(23, 0)
+        setWeather(0)
+    end)
+
+    for row = 1, 6 do
+        S.cue("row" .. row, t >= 5200 + (row - 1) * 900, function()
+            S.activateLampRow(row)
+        end)
+    end
+
+    S.cue("hero_on", t >= 10800, function()
+        S.setLight(state.heroModel, state.heroEffect, tocolor(80, 245, 255, 255), 2.5, 30)
+    end)
+
+    S.cue("hero_flash", t >= 11900, function()
+        if state.heroModel and state.heroEffect then
+            setModel2DFXProperty(state.heroModel, state.heroEffect, "showMode", "random_flashing")
+        end
+    end)
+
+    S.cue("hero_normal", t >= 12900, function()
+        if state.heroModel and state.heroEffect then
+            setModel2DFXProperty(state.heroModel, state.heroEffect, "showMode", "default")
+        end
+    end)
+
+    S.cue("vanilla_mutate", t >= 13600, S.mutateVanillaLight)
+    S.cue("vanilla_restore", t >= 16500, S.restoreVanillaLight)
+
+    if t >= 35000 then
+        local step = math.floor((t - 35000) / 700)
+        if step ~= state.lastFinalStep then
+            state.lastFinalStep = step
+            for row, model in ipairs(state.lampModels) do
+                local color = PALETTE[((row + step - 1) % #PALETTE) + 1]
+                S.setLight(model, state.lampEffects[row], color, 1.8, 24)
+            end
+        end
+    end
+end
+
+function S.setCameraForTimeline(t)
+    local cx, cy, cz = state.cx, state.cy, state.cz
+
+    if t < 5000 then
+        S.cameraLerp(
+            { cx - 18, cy - 34, cz + 8, cx, cy + 35, cz + 8, 76 },
+            { cx + 5, cy - 24, cz + 6, cx, cy + 42, cz + 10, 68 },
+            t / 5000
+        )
+    elseif t < 13000 then
+        S.cameraLerp(
+            { cx - 12, cy - 27, cz + 3.5, cx, cy + 18, cz + 4.5, 78 },
+            { cx + 8, cy - 10, cz + 4.5, cx, cy + 22, cz + 5.5, 66 },
+            (t - 5000) / 8000
+        )
+    elseif t < 18000 then
+        S.cameraLerp(
+            { cx + 19, cy - 4, cz + 3.2, cx + 12, cy + 3, cz + 5.5, 58 },
+            { cx + 8, cy + 2, cz + 4.5, cx + 12, cy + 3, cz + 5.5, 50 },
+            (t - 13000) / 5000
+        )
+    elseif t < 23000 then
+        S.cameraLerp(
+            { cx - 19, cy + 4, cz + 8.5, cx - 11, cy + 14, cz + 5.5, 62 },
+            { cx + 18, cy + 8, cz + 9.0, cx + 11, cy + 16, cz + 6.0, 64 },
+            (t - 18000) / 5000
+        )
+    elseif t < 29000 then
+        S.cameraLerp(
+            { cx, cy + 9, cz + 3.4, cx, cy + 28, cz + 4.0, 58 },
+            { cx - 9, cy + 16, cz + 4.8, cx, cy + 28, cz + 4.2, 52 },
+            (t - 23000) / 6000
+        )
+    elseif t < 35000 then
+        S.cameraLerp(
+            { cx - 16, cy + 24, cz + 2.8, cx, cy + 35, cz + 3.2, 64 },
+            { cx + 13, cy + 27, cz + 5.5, cx, cy + 35, cz + 3.5, 60 },
+            (t - 29000) / 6000
+        )
+    else
+        S.cameraLerp(
+            { cx + 17, cy - 10, cz + 7.0, cx, cy + 20, cz + 5.0, 76 },
+            { cx, cy - 39, cz + 14.5, cx, cy + 18, cz + 5.5, 82 },
+            S.clamp((t - 35000) / 7000, 0, 1)
+        )
+    end
+end
+
+S.SHOT_WINDOWS = {
+    [1] = { offset = 0, duration = 5200 },
+    [2] = { offset = 5000, duration = 8200 },
+    [3] = { offset = 13000, duration = 5200 },
+    [4] = { offset = 18000, duration = 5200 },
+    [5] = { offset = 23000, duration = 6200 },
+    [6] = { offset = 29000, duration = 6200 },
+    [7] = { offset = 35000, duration = 7200 },
+}
+
+function S.timelineTime()
+    local elapsed = getTickCount() - state.startedAt
+    if state.mode == "shot" and S.SHOT_WINDOWS[state.shot] then
+        local shot = S.SHOT_WINDOWS[state.shot]
+        return elapsed + shot.offset, elapsed, shot.duration
+    end
+    return elapsed, elapsed, S.FULL_DURATION
+end
+
+function S.renderShow()
+    if not state.active then
+        return
+    end
+
+    if state.mode == "setup" or state.mode == "final" then
+        S.applyAllLights()
+        setTime(23, 0)
+        setCameraMatrix(
+            state.cx, state.cy - 38, state.cz + 13,
+            state.cx, state.cy + 18, state.cz + 5.5,
+            0, 82
+        )
+        return
+    end
+
+    local t, elapsed, duration = S.timelineTime()
+    S.updateSceneCues(t)
+    S.setCameraForTimeline(t)
+
+    if elapsed >= duration then
+        state.active = false
+        triggerServerEvent("2dfxShowcase:finished", resourceRoot)
+    end
+end
+
+function S.beginShow(mode, shot)
+    if not state.prepared then
+        return
+    end
+
+    state.mode = mode or "full"
+    state.shot = shot
+    state.cues = {}
+    state.lastFinalStep = -1
+    state.startedAt = getTickCount()
+    state.active = true
+
+    S.setPresentationUI(state.mode == "setup")
+    addEventHandler("onClientRender", root, S.renderShow)
+
+    if state.mode == "setup" or state.mode == "final" then
+        S.applyAllLights()
+        setTime(23, 0)
+    else
+        S.setLampRowsOff()
+        setTime(18, 30)
+        setWeather(0)
+    end
+
+    S.log(string.format("started mode=%s shot=%s", tostring(state.mode), tostring(state.shot)))
+end
+
+function S.prepareShow(cx, cy, cz, dimension)
+    S.cleanupLocal()
+
+    state.prepared = true
+    state.cx, state.cy, state.cz = cx, cy, cz
+    state.dimension = dimension
+
+    local hour, minute = getTime()
+    state.savedTime = { hour = hour, minute = minute }
+    local weather = getWeather()
+    state.savedWeather = weather
+
+    S.setPresentationUI(false)
+    setTime(18, 30)
+    setWeather(0)
+
+    local ok, reason = S.buildRuntimeModels()
+    if not ok then
+        S.failSetup(reason)
+        return
+    end
+
+    ok, reason = S.buildDecor()
+    if not ok then
+        S.failSetup(reason)
+        return
+    end
+
+    S.later(1400, function()
+        local effectsOk, effectsReason = S.addEffects()
+        if not effectsOk then
+            S.failSetup(effectsReason)
+            return
+        end
+
+        -- Particle, roadsign and escalator additions restream only their own
+        -- requested models. Prewarm the native escalator steps while the server
+        -- still holds the camera behind a black fade.
+        S.later(1500, function()
+            setCameraMatrix(
+                state.cx - 8, state.cy + 28, state.cz + 4,
+                state.cx, state.cy + 35, state.cz + 3.5,
+                0, 68
+            )
+            S.later(1200, function()
+                triggerServerEvent("2dfxShowcase:ready", resourceRoot)
+            end)
+        end)
+    end)
+end
+
+addEvent("2dfxShowcase:prepare", true)
+addEventHandler("2dfxShowcase:prepare", resourceRoot, function(cx, cy, cz, dimension)
+    S.prepareShow(cx, cy, cz, dimension)
+end)
+
+addEvent("2dfxShowcase:begin", true)
+addEventHandler("2dfxShowcase:begin", resourceRoot, S.beginShow)
+
+addEvent("2dfxShowcase:stop", true)
+addEventHandler("2dfxShowcase:stop", resourceRoot, S.cleanupLocal)
+
+addEventHandler("onClientResourceStop", resourceRoot, S.cleanupLocal)

--- a/test-resources/2dfx-showcase/client_state.lua
+++ b/test-resources/2dfx-showcase/client_state.lua
@@ -1,0 +1,205 @@
+DFXShowcase = DFXShowcase or {}
+
+local S = DFXShowcase
+
+S.FULL_DURATION = 42000
+S.PALETTE = {
+    tocolor(40, 235, 255, 255),
+    tocolor(60, 125, 255, 255),
+    tocolor(125, 70, 255, 255),
+    tocolor(220, 65, 255, 255),
+    tocolor(255, 70, 175, 255),
+    tocolor(235, 245, 255, 255),
+}
+
+S.state = {
+    prepared = false,
+    active = false,
+    mode = "full",
+    shot = nil,
+    startedAt = 0,
+    cx = 0, cy = 0, cz = 0,
+    dimension = 0,
+    allocatedModels = {},
+    touchedModels = {},
+    objects = {},
+    timers = {},
+    lampModels = {},
+    lampEffects = {},
+    heroModel = nil,
+    heroEffect = nil,
+    vanillaModel = nil,
+    vanillaObject = nil,
+    vanillaEffect = nil,
+    vanillaBaseline = nil,
+    particleModels = {},
+    roadsignModels = {},
+    escalatorModels = {},
+    sunModel = nil,
+    cues = {},
+    lastFinalStep = -1,
+    savedTime = nil,
+    savedWeather = nil,
+}
+
+local state = S.state
+
+function S.log(message, level)
+    outputDebugString("[2dfx-showcase] " .. tostring(message), level or 3)
+end
+
+function S.chat(message, r, g, b)
+    outputChatBox("[2DFX SHOWCASE] " .. tostring(message), r or 100, g or 220, b or 255)
+end
+
+function S.clamp(value, minimum, maximum)
+    return math.max(minimum, math.min(maximum, value))
+end
+
+function S.smoothstep(value)
+    value = S.clamp(value, 0, 1)
+    return value * value * (3 - 2 * value)
+end
+
+function S.lerp(a, b, t)
+    return a + (b - a) * t
+end
+
+function S.cameraLerp(a, b, t)
+    t = S.smoothstep(t)
+    setCameraMatrix(
+        S.lerp(a[1], b[1], t), S.lerp(a[2], b[2], t), S.lerp(a[3], b[3], t),
+        S.lerp(a[4], b[4], t), S.lerp(a[5], b[5], t), S.lerp(a[6], b[6], t),
+        0, S.lerp(a[7] or 70, b[7] or 70, t)
+    )
+end
+
+function S.setPresentationUI(visible)
+    showPlayerHudComponent("all", visible)
+    showChat(visible)
+end
+
+function S.rememberTimer(timer)
+    state.timers[#state.timers + 1] = timer
+    return timer
+end
+
+function S.later(delay, callback)
+    return S.rememberTimer(setTimer(function()
+        if state.prepared then
+            callback()
+        end
+    end, delay, 1))
+end
+
+function S.clearTimers()
+    for _, timer in ipairs(state.timers) do
+        if isTimer(timer) then
+            killTimer(timer)
+        end
+    end
+    state.timers = {}
+end
+
+function S.destroyObjects()
+    for _, object in ipairs(state.objects) do
+        if isElement(object) then
+            destroyElement(object)
+        end
+    end
+    state.objects = {}
+end
+
+function S.rememberTouchedModel(model)
+    state.touchedModels[model] = true
+end
+
+function S.resetTouchedModels()
+    for model in pairs(state.touchedModels) do
+        resetModel2DFXEffects(model)
+    end
+    state.touchedModels = {}
+end
+
+function S.freeRuntimeModels()
+    for _, model in ipairs(state.allocatedModels) do
+        engineFreeModel(model)
+    end
+    state.allocatedModels = {}
+end
+
+function S.restoreEnvironment()
+    if state.savedTime then
+        setTime(state.savedTime.hour, state.savedTime.minute)
+    end
+    if type(state.savedWeather) == "number" then
+        setWeather(state.savedWeather)
+    end
+end
+
+function S.cleanupLocal()
+    S.clearTimers()
+    state.active = false
+    state.prepared = false
+    if S.renderShow then
+        removeEventHandler("onClientRender", root, S.renderShow)
+    end
+    S.resetTouchedModels()
+    S.destroyObjects()
+    S.freeRuntimeModels()
+    S.restoreEnvironment()
+    setCameraTarget(localPlayer)
+    S.setPresentationUI(true)
+
+    state.lampModels = {}
+    state.lampEffects = {}
+    state.heroModel = nil
+    state.heroEffect = nil
+    state.vanillaModel = nil
+    state.vanillaObject = nil
+    state.vanillaEffect = nil
+    state.vanillaBaseline = nil
+    state.particleModels = {}
+    state.roadsignModels = {}
+    state.escalatorModels = {}
+    state.sunModel = nil
+    state.cues = {}
+    state.lastFinalStep = -1
+    state.savedTime = nil
+    state.savedWeather = nil
+end
+
+function S.failSetup(reason)
+    S.log("setup failed: " .. tostring(reason), 1)
+    triggerServerEvent("2dfxShowcase:failed", resourceRoot, tostring(reason))
+end
+
+function S.requestObjectModel(parent)
+    local model = engineRequestModel("object", parent)
+    if not model then
+        return false
+    end
+    state.allocatedModels[#state.allocatedModels + 1] = model
+    return model
+end
+
+function S.spawn(model, ox, oy, oz, rz, scale, alpha)
+    local object = createObject(model, state.cx + ox, state.cy + oy, state.cz + oz, 0, 0, rz or 0)
+    if not isElement(object) then
+        return false
+    end
+
+    setElementDimension(object, state.dimension)
+    setElementInterior(object, 0)
+    setElementCollisionsEnabled(object, false)
+    setElementFrozen(object, true)
+    if scale then
+        setObjectScale(object, scale)
+    end
+    if alpha then
+        setElementAlpha(object, alpha)
+    end
+
+    state.objects[#state.objects + 1] = object
+    return object
+end

--- a/test-resources/2dfx-showcase/client_state.lua
+++ b/test-resources/2dfx-showcase/client_state.lua
@@ -32,6 +32,8 @@ S.state = {
     centerEffects = {},
     thresholdModels = {},
     thresholdEffects = {},
+    moonModels = {},
+    moonEffects = {},
     particleModels = {},
     roadsignModels = {},
     sunModel = nil,
@@ -39,8 +41,10 @@ S.state = {
     vanillaObject = nil,
     vanillaEffect = nil,
     vanillaBaseline = nil,
+    lightTemplate = nil,
     cues = {},
     chaseStep = -1,
+    moonStep = -1,
     finalStep = -1,
     savedTime = nil,
     savedWeather = nil,
@@ -201,6 +205,8 @@ function S.cleanupLocal()
     state.centerEffects = {}
     state.thresholdModels = {}
     state.thresholdEffects = {}
+    state.moonModels = {}
+    state.moonEffects = {}
     state.particleModels = {}
     state.roadsignModels = {}
     state.sunModel = nil
@@ -208,8 +214,10 @@ function S.cleanupLocal()
     state.vanillaObject = nil
     state.vanillaEffect = nil
     state.vanillaBaseline = nil
+    state.lightTemplate = nil
     state.cues = {}
     state.chaseStep = -1
+    state.moonStep = -1
     state.finalStep = -1
     state.savedTime = nil
     state.savedWeather = nil
@@ -251,7 +259,8 @@ function S.spawnWorld(model, x, y, z, rz, scale, alpha)
     return object
 end
 
-function S.spawnOnRunway(model, t, lateral, height, alpha, scale)
+function S.spawnOnRunway(model, t, lateral, height, alpha, scale, yawOffset)
     local x, y, z = S.runwayPoint(t, lateral, height)
-    return S.spawnWorld(model, x, y, z, state.basis and state.basis.yaw or 270, scale, alpha)
+    local yaw = (state.basis and state.basis.yaw or 270) + (yawOffset or 0)
+    return S.spawnWorld(model, x, y, z, yaw, scale, alpha)
 end

--- a/test-resources/2dfx-showcase/client_state.lua
+++ b/test-resources/2dfx-showcase/client_state.lua
@@ -2,14 +2,17 @@ DFXShowcase = DFXShowcase or {}
 
 local S = DFXShowcase
 
-S.FULL_DURATION = 42000
+S.FULL_DURATION = 38000
+S.RUNWAY_START = { 100.74450, 2501.11401, 16.48438 }
+S.RUNWAY_END = { 424.00473, 2503.03442, 16.48438 }
+S.RUNWAY_HALF_WIDTH = 17.0
 S.PALETTE = {
-    tocolor(40, 235, 255, 255),
-    tocolor(60, 125, 255, 255),
-    tocolor(125, 70, 255, 255),
-    tocolor(220, 65, 255, 255),
-    tocolor(255, 70, 175, 255),
-    tocolor(235, 245, 255, 255),
+    tocolor(35, 235, 255, 255),
+    tocolor(55, 130, 255, 255),
+    tocolor(120, 75, 255, 255),
+    tocolor(220, 70, 255, 255),
+    tocolor(255, 75, 175, 255),
+    tocolor(240, 248, 255, 255),
 }
 
 S.state = {
@@ -18,28 +21,30 @@ S.state = {
     mode = "full",
     shot = nil,
     startedAt = 0,
-    cx = 0, cy = 0, cz = 0,
     dimension = 0,
     allocatedModels = {},
     touchedModels = {},
     objects = {},
     timers = {},
-    lampModels = {},
-    lampEffects = {},
-    heroModel = nil,
-    heroEffect = nil,
+    edgeModels = { left = {}, right = {} },
+    edgeEffects = { left = {}, right = {} },
+    centerModels = {},
+    centerEffects = {},
+    thresholdModels = {},
+    thresholdEffects = {},
+    particleModels = {},
+    roadsignModels = {},
+    sunModel = nil,
     vanillaModel = nil,
     vanillaObject = nil,
     vanillaEffect = nil,
     vanillaBaseline = nil,
-    particleModels = {},
-    roadsignModels = {},
-    escalatorModels = {},
-    sunModel = nil,
     cues = {},
-    lastFinalStep = -1,
+    chaseStep = -1,
+    finalStep = -1,
     savedTime = nil,
     savedWeather = nil,
+    basis = nil,
 }
 
 local state = S.state
@@ -72,6 +77,41 @@ function S.cameraLerp(a, b, t)
         S.lerp(a[4], b[4], t), S.lerp(a[5], b[5], t), S.lerp(a[6], b[6], t),
         0, S.lerp(a[7] or 70, b[7] or 70, t)
     )
+end
+
+function S.configureRunway()
+    local sx, sy, sz = S.RUNWAY_START[1], S.RUNWAY_START[2], S.RUNWAY_START[3]
+    local ex, ey, ez = S.RUNWAY_END[1], S.RUNWAY_END[2], S.RUNWAY_END[3]
+    local dx, dy = ex - sx, ey - sy
+    local length = math.sqrt(dx * dx + dy * dy)
+    local ux, uy = dx / length, dy / length
+    state.basis = {
+        sx = sx, sy = sy, sz = sz,
+        ex = ex, ey = ey, ez = ez,
+        ux = ux, uy = uy,
+        px = -uy, py = ux,
+        length = length,
+        yaw = math.deg(math.atan2(-ux, uy)),
+    }
+end
+
+function S.runwayPoint(t, lateral, height)
+    if not state.basis then
+        S.configureRunway()
+    end
+    local b = state.basis
+    lateral = lateral or 0
+    height = height or 0
+    local x = b.sx + (b.ex - b.sx) * t + b.px * lateral
+    local y = b.sy + (b.ey - b.sy) * t + b.py * lateral
+    local z = b.sz + (b.ez - b.sz) * t + height
+    return x, y, z
+end
+
+function S.cameraPoint(t, lateral, height, lookT, lookLateral, lookHeight, fov)
+    local x, y, z = S.runwayPoint(t, lateral, height)
+    local lx, ly, lz = S.runwayPoint(lookT, lookLateral or 0, lookHeight or 0)
+    return { x, y, z, lx, ly, lz, fov or 70 }
 end
 
 function S.setPresentationUI(visible)
@@ -151,22 +191,25 @@ function S.cleanupLocal()
     setCameraTarget(localPlayer)
     S.setPresentationUI(true)
 
-    state.lampModels = {}
-    state.lampEffects = {}
-    state.heroModel = nil
-    state.heroEffect = nil
+    state.edgeModels = { left = {}, right = {} }
+    state.edgeEffects = { left = {}, right = {} }
+    state.centerModels = {}
+    state.centerEffects = {}
+    state.thresholdModels = {}
+    state.thresholdEffects = {}
+    state.particleModels = {}
+    state.roadsignModels = {}
+    state.sunModel = nil
     state.vanillaModel = nil
     state.vanillaObject = nil
     state.vanillaEffect = nil
     state.vanillaBaseline = nil
-    state.particleModels = {}
-    state.roadsignModels = {}
-    state.escalatorModels = {}
-    state.sunModel = nil
     state.cues = {}
-    state.lastFinalStep = -1
+    state.chaseStep = -1
+    state.finalStep = -1
     state.savedTime = nil
     state.savedWeather = nil
+    state.basis = nil
 end
 
 function S.failSetup(reason)
@@ -183,8 +226,8 @@ function S.requestObjectModel(parent)
     return model
 end
 
-function S.spawn(model, ox, oy, oz, rz, scale, alpha)
-    local object = createObject(model, state.cx + ox, state.cy + oy, state.cz + oz, 0, 0, rz or 0)
+function S.spawnWorld(model, x, y, z, rz, scale, alpha)
+    local object = createObject(model, x, y, z, 0, 0, rz or 0)
     if not isElement(object) then
         return false
     end
@@ -196,10 +239,15 @@ function S.spawn(model, ox, oy, oz, rz, scale, alpha)
     if scale then
         setObjectScale(object, scale)
     end
-    if alpha then
+    if alpha ~= nil then
         setElementAlpha(object, alpha)
     end
 
     state.objects[#state.objects + 1] = object
     return object
+end
+
+function S.spawnOnRunway(model, t, lateral, height, alpha, scale)
+    local x, y, z = S.runwayPoint(t, lateral, height)
+    return S.spawnWorld(model, x, y, z, state.basis and state.basis.yaw or 270, scale, alpha)
 end

--- a/test-resources/2dfx-showcase/client_state.lua
+++ b/test-resources/2dfx-showcase/client_state.lua
@@ -85,13 +85,17 @@ function S.configureRunway()
     local dx, dy = ex - sx, ey - sy
     local length = math.sqrt(dx * dx + dy * dy)
     local ux, uy = dx / length, dy / length
+    local yaw = math.deg(math.atan2(-ux, uy))
+    if yaw < 0 then
+        yaw = yaw + 360
+    end
     state.basis = {
         sx = sx, sy = sy, sz = sz,
         ex = ex, ey = ey, ez = ez,
         ux = ux, uy = uy,
         px = -uy, py = ux,
         length = length,
-        yaw = math.deg(math.atan2(-ux, uy)),
+        yaw = yaw,
     }
 end
 

--- a/test-resources/2dfx-showcase/meta.xml
+++ b/test-resources/2dfx-showcase/meta.xml
@@ -1,0 +1,5 @@
+<meta>
+    <info author="Dryxio" name="2DFX cinematic showcase" type="script" />
+    <script src="server.lua" type="server" />
+    <script src="client.lua" type="client" cache="false" />
+</meta>

--- a/test-resources/2dfx-showcase/meta.xml
+++ b/test-resources/2dfx-showcase/meta.xml
@@ -1,5 +1,7 @@
 <meta>
     <info author="Dryxio" name="2DFX cinematic showcase" type="script" />
     <script src="server.lua" type="server" />
-    <script src="client.lua" type="client" cache="false" />
+    <script src="client_state.lua" type="client" cache="false" />
+    <script src="client_scene.lua" type="client" cache="false" />
+    <script src="client_show.lua" type="client" cache="false" />
 </meta>

--- a/test-resources/2dfx-showcase/meta.xml
+++ b/test-resources/2dfx-showcase/meta.xml
@@ -1,5 +1,5 @@
 <meta>
-    <info author="Dryxio" name="2DFX cinematic showcase" type="script" />
+    <info author="Dryxio" name="2DFX runway showcase" type="script" />
     <script src="server.lua" type="server" />
     <script src="client_state.lua" type="client" cache="false" />
     <script src="client_scene.lua" type="client" cache="false" />

--- a/test-resources/2dfx-showcase/server.lua
+++ b/test-resources/2dfx-showcase/server.lua
@@ -1,0 +1,167 @@
+local SHOW_DIMENSION = 64991
+local CENTER_X, CENTER_Y, CENTER_Z = 405.0, 2535.0, 16.4
+
+local active = {}
+
+local function chat(player, message, r, g, b)
+    if isElement(player) then
+        outputChatBox("[2DFX SHOWCASE] " .. message, player, r or 100, g or 220, b or 255)
+    end
+end
+
+local function rememberPlayer(player)
+    local x, y, z = getElementPosition(player)
+    local rx, ry, rz = getElementRotation(player)
+    return {
+        x = x, y = y, z = z,
+        rx = rx, ry = ry, rz = rz,
+        dimension = getElementDimension(player),
+        interior = getElementInterior(player),
+        alpha = getElementAlpha(player),
+        frozen = isElementFrozen(player),
+    }
+end
+
+local function restorePlayer(player, saved)
+    if not isElement(player) or not saved then
+        return
+    end
+    setElementInterior(player, saved.interior)
+    setElementDimension(player, saved.dimension)
+    setElementPosition(player, saved.x, saved.y, saved.z)
+    setElementRotation(player, saved.rx, saved.ry, saved.rz)
+    setElementAlpha(player, saved.alpha)
+    setElementFrozen(player, saved.frozen)
+end
+
+local function finishShow(player, instant)
+    local entry = active[player]
+    if not entry then
+        return
+    end
+
+    active[player] = nil
+    entry.serial = entry.serial + 1
+
+    if not isElement(player) then
+        return
+    end
+
+    local function restoreNow()
+        if isElement(player) then
+            triggerClientEvent(player, "2dfxShowcase:stop", resourceRoot)
+            restorePlayer(player, entry.saved)
+            fadeCamera(player, true, 0.45)
+        end
+    end
+
+    if instant then
+        restoreNow()
+    else
+        fadeCamera(player, false, 0.25)
+        setTimer(restoreNow, 300, 1)
+    end
+end
+
+local function startShow(player, mode, shot)
+    if active[player] then
+        finishShow(player, true)
+    end
+
+    local serial = getTickCount()
+    active[player] = {
+        saved = rememberPlayer(player),
+        serial = serial,
+        mode = mode,
+        shot = shot,
+    }
+
+    fadeCamera(player, false, 0.25)
+    setElementInterior(player, 0)
+    setElementDimension(player, SHOW_DIMENSION)
+    setElementPosition(player, CENTER_X, CENTER_Y - 34.0, CENTER_Z + 1.0)
+    setElementRotation(player, 0, 0, 0)
+    setElementAlpha(player, 0)
+    setElementFrozen(player, true)
+
+    setTimer(function()
+        local entry = active[player]
+        if not entry or entry.serial ~= serial or not isElement(player) then
+            return
+        end
+        triggerClientEvent(
+            player,
+            "2dfxShowcase:prepare",
+            resourceRoot,
+            CENTER_X, CENTER_Y, CENTER_Z,
+            SHOW_DIMENSION, mode, shot
+        )
+    end, 350, 1)
+end
+
+addCommandHandler("2dfxshow", function(player, _, first, second)
+    local mode = first or "full"
+    local shot = nil
+
+    if mode == "stop" then
+        finishShow(player, true)
+        return
+    end
+
+    if mode == "shot" then
+        shot = math.floor(tonumber(second) or 0)
+        if shot < 1 or shot > 7 then
+            chat(player, "Usage: /2dfxshow shot 1-7", 255, 120, 120)
+            return
+        end
+    elseif mode ~= "full" and mode ~= "setup" and mode ~= "final" then
+        chat(player, "Usage: /2dfxshow [full|setup|final|shot 1-7|stop]", 255, 120, 120)
+        return
+    end
+
+    startShow(player, mode, shot)
+end)
+
+addEvent("2dfxShowcase:ready", true)
+addEventHandler("2dfxShowcase:ready", resourceRoot, function()
+    local player = client
+    local entry = active[player]
+    if not entry then
+        return
+    end
+
+    fadeCamera(player, true, 0.8)
+    setTimer(function()
+        local current = active[player]
+        if current ~= entry or not isElement(player) then
+            return
+        end
+        triggerClientEvent(player, "2dfxShowcase:begin", resourceRoot, entry.mode, entry.shot)
+    end, 250, 1)
+end)
+
+addEvent("2dfxShowcase:failed", true)
+addEventHandler("2dfxShowcase:failed", resourceRoot, function(reason)
+    local player = client
+    chat(player, "Setup failed: " .. tostring(reason), 255, 100, 100)
+    finishShow(player, true)
+end)
+
+addEvent("2dfxShowcase:finished", true)
+addEventHandler("2dfxShowcase:finished", resourceRoot, function()
+    finishShow(client, false)
+end)
+
+addEventHandler("onPlayerQuit", root, function()
+    active[source] = nil
+end)
+
+addEventHandler("onResourceStop", resourceRoot, function()
+    for player, entry in pairs(active) do
+        if isElement(player) then
+            restorePlayer(player, entry.saved)
+            fadeCamera(player, true, 0)
+        end
+    end
+    active = {}
+end)

--- a/test-resources/2dfx-showcase/server.lua
+++ b/test-resources/2dfx-showcase/server.lua
@@ -1,5 +1,8 @@
 local SHOW_DIMENSION = 64991
-local CENTER_X, CENTER_Y, CENTER_Z = 405.0, 2535.0, 16.4
+local RUNWAY_START_X, RUNWAY_START_Y, RUNWAY_Z = 100.74450, 2501.11401, 16.48438
+local RUNWAY_END_X, RUNWAY_END_Y = 424.00473, 2503.03442
+local CENTER_X = (RUNWAY_START_X + RUNWAY_END_X) * 0.5
+local CENTER_Y = (RUNWAY_START_Y + RUNWAY_END_Y) * 0.5
 
 local active = {}
 
@@ -79,8 +82,8 @@ local function startShow(player, mode, shot)
     fadeCamera(player, false, 0.25)
     setElementInterior(player, 0)
     setElementDimension(player, SHOW_DIMENSION)
-    setElementPosition(player, CENTER_X, CENTER_Y - 34.0, CENTER_Z + 1.0)
-    setElementRotation(player, 0, 0, 0)
+    setElementPosition(player, CENTER_X, CENTER_Y, RUNWAY_Z + 1.0)
+    setElementRotation(player, 0, 0, 270)
     setElementAlpha(player, 0)
     setElementFrozen(player, true)
 
@@ -93,7 +96,7 @@ local function startShow(player, mode, shot)
             player,
             "2dfxShowcase:prepare",
             resourceRoot,
-            CENTER_X, CENTER_Y, CENTER_Z,
+            CENTER_X, CENTER_Y, RUNWAY_Z,
             SHOW_DIMENSION, mode, shot
         )
     end, 350, 1)

--- a/test-resources/2dfx-test/README.md
+++ b/test-resources/2dfx-test/README.md
@@ -8,19 +8,25 @@ Client-side regression/showcase resource for the Neon 2DFX API.
 - rejects a missing `flags` field without crashing;
 - rejects 24-byte particle names (native storage is `char[24]`, so usable C-string length is 23);
 - adds light, particle and roadsign effects to model 1337;
+- sequences streaming-sensitive custom additions instead of issuing them while the model is still being rebuilt;
 - exercises custom property set/get/reset;
 - confirms `getModel2DFXCount(model, false)` excludes custom effects;
-- modifies a native light on model 1226, runs `engineRestreamWorld`, and verifies the override survives;
-- removes/restores a native effect;
-- provides repeated restream stress coverage.
+- modifies/resets a native light on model 1226;
+- removes/restores a native effect while waiting for the targeted model restream to settle;
+- provides explicit single and repeated global-restream coverage.
 
-The suite intentionally leaves its custom effects alive after completing. Stop/restart the resource: the next start begins by asserting that the previous resource-owned effects were cleaned up.
+The automatic suite intentionally leaves its custom effects alive after completing. Stop/restart the resource: the next start begins by asserting that the previous resource-owned effects were cleaned up.
+
+`engineRestreamWorld()` is deliberately **not** run by the automatic startup suite because it can cause a noticeable global streaming hitch. Global restream coverage is manual.
 
 ## Commands
 
-- `/2dfxtest` — recreate showcase objects and run the regression suite.
-- `/2dfxstress [count]` — run 1–50 `engineRestreamWorld` cycles and verify the custom count/type remains stable.
+- `/2dfxtest` — recreate showcase objects and run the normal regression suite.
+- `/2dfxrestream` — run one explicit `engineRestreamWorld()` and verify custom/native override persistence. A noticeable hitch during this command is expected.
+- `/2dfxstress [count]` — run 1–50 explicit `engineRestreamWorld()` cycles and verify the custom count/type remains stable. Repeated hitches are expected while this stress test runs.
 - `/2dfxcleanup` — explicitly reset this resource's model changes and destroy the showcase objects.
+
+PASS/FAIL/SKIP results are printed directly in the in-game chat and are also mirrored to `outputDebugString`.
 
 ## Manual resource-lifecycle check
 
@@ -28,6 +34,7 @@ The suite intentionally leaves its custom effects alive after completing. Stop/r
 2. Confirm the custom light/particle/roadsign remain visible/active.
 3. Restart `2dfx-test` without running `/2dfxcleanup`.
 4. The first assertion on the new run must report `PASS: resource-stop cleanup from previous run`.
+5. Run `/2dfxrestream` separately when you want to exercise the expensive global-restream path.
 
 ## Notes
 

--- a/test-resources/2dfx-test/README.md
+++ b/test-resources/2dfx-test/README.md
@@ -1,0 +1,34 @@
+# 2DFX regression harness
+
+Client-side regression/showcase resource for the Neon 2DFX API.
+
+## What it covers
+
+- verifies that custom 2DFX from a previous resource run were removed on resource stop;
+- rejects a missing `flags` field without crashing;
+- rejects 24-byte particle names (native storage is `char[24]`, so usable C-string length is 23);
+- adds light, particle and roadsign effects to model 1337;
+- exercises custom property set/get/reset;
+- confirms `getModel2DFXCount(model, false)` excludes custom effects;
+- modifies a native light on model 1226, runs `engineRestreamWorld`, and verifies the override survives;
+- removes/restores a native effect;
+- provides repeated restream stress coverage.
+
+The suite intentionally leaves its custom effects alive after completing. Stop/restart the resource: the next start begins by asserting that the previous resource-owned effects were cleaned up.
+
+## Commands
+
+- `/2dfxtest` — recreate showcase objects and run the regression suite.
+- `/2dfxstress [count]` — run 1–50 `engineRestreamWorld` cycles and verify the custom count/type remains stable.
+- `/2dfxcleanup` — explicitly reset this resource's model changes and destroy the showcase objects.
+
+## Manual resource-lifecycle check
+
+1. Start `2dfx-test` and let the automatic suite finish.
+2. Confirm the custom light/particle/roadsign remain visible/active.
+3. Restart `2dfx-test` without running `/2dfxcleanup`.
+4. The first assertion on the new run must report `PASS: resource-stop cleanup from previous run`.
+
+## Notes
+
+The API is model-level by design, matching GTA SA's RenderWare 2DFX plugin. Resource ownership applies to Neon state management: custom effects are owned by their creator resource, while overrides/removals of original GTA effects are stacked per resource and rolled back when that resource stops.

--- a/test-resources/2dfx-test/client.lua
+++ b/test-resources/2dfx-test/client.lua
@@ -14,6 +14,11 @@ local function log(message, level)
     outputDebugString("[2dfx-test] " .. tostring(message), level or 3)
 end
 
+local function info(message)
+    log(message, 3)
+    outputChatBox("[2dfx-test] " .. tostring(message), 170, 220, 255)
+end
+
 local function pass(name)
     local message = "PASS: " .. name
     log(message, 3)
@@ -24,6 +29,12 @@ local function fail(name, detail)
     local message = "FAIL: " .. name .. (detail and (" - " .. tostring(detail)) or "")
     log(message, 1)
     outputChatBox("[2dfx-test] " .. message, 255, 90, 90)
+end
+
+local function skip(name, detail)
+    local message = "SKIP: " .. name .. (detail and (" - " .. tostring(detail)) or "")
+    log(message, 2)
+    outputChatBox("[2dfx-test] " .. message, 255, 210, 90)
 end
 
 local function check(name, condition, detail)
@@ -40,6 +51,36 @@ local function almostEqual(a, b, epsilon)
         return false
     end
     return math.abs(a - b) <= (epsilon or 0.001)
+end
+
+local function waitUntil(predicate, callback, timeoutMs, intervalMs)
+    timeoutMs = timeoutMs or 4000
+    intervalMs = intervalMs or 150
+    local deadline = getTickCount() + timeoutMs
+
+    local function poll()
+        local ok, result = pcall(predicate)
+        if ok and result then
+            callback(true)
+            return
+        end
+
+        if getTickCount() >= deadline then
+            callback(false)
+            return
+        end
+
+        setTimer(poll, intervalMs, 1)
+    end
+
+    poll()
+end
+
+local function retryAction(action, callback, timeoutMs, intervalMs)
+    waitUntil(function()
+        local ok, result = pcall(action)
+        return ok and result == true
+    end, callback, timeoutMs, intervalMs)
 end
 
 local function lightProperties(color)
@@ -96,6 +137,16 @@ local function createSuiteObjects()
     end
 end
 
+local function findVanillaLight()
+    local count = getModel2DFXCount(VANILLA_MODEL, false)
+    for index = 0, count - 1 do
+        if getModel2DFXType(VANILLA_MODEL, index) == "light" then
+            return index
+        end
+    end
+    return nil
+end
+
 local function verifyPreviousResourceCleanup()
     local allCount = getModel2DFXCount(CUSTOM_MODEL, true)
     local nativeCount = getModel2DFXCount(CUSTOM_MODEL, false)
@@ -119,7 +170,7 @@ local function testInvalidInputs()
     check("invalid calls do not mutate model count", before == after, string.format("before=%d after=%d", before, after))
 end
 
-local function testCustomEffects()
+local function testCustomEffects(done)
     suiteState.customBase = getModel2DFXCount(CUSTOM_MODEL, true)
 
     local addedLight = addModel2DFX(CUSTOM_MODEL, 0, 0, 1.2, "light", lightProperties())
@@ -138,31 +189,38 @@ local function testCustomEffects()
     suiteState.customParticleIndex = getModel2DFXCount(CUSTOM_MODEL, true) - 1
     check("custom particle getter", getModel2DFXProperty(CUSTOM_MODEL, suiteState.customParticleIndex, "name") == "fire")
 
-    local addedRoadsign = addModel2DFX(CUSTOM_MODEL, 0, 0, 1.8, "roadsign", roadsignProperties())
-    check("add custom roadsign", addedRoadsign == true)
-    suiteState.customRoadsignIndex = getModel2DFXCount(CUSTOM_MODEL, true) - 1
-    check("roadsign text getter", getModel2DFXProperty(CUSTOM_MODEL, suiteState.customRoadsignIndex, "text1") == "____NEON 2DFX")
+    -- Particle creation restreams this model. Do not immediately issue another
+    -- streaming-sensitive add while GTA is still rebuilding model 1337.
+    retryAction(function()
+        return addModel2DFX(CUSTOM_MODEL, 0, 0, 1.8, "roadsign", roadsignProperties())
+    end, function(addedRoadsign)
+        check("add custom roadsign", addedRoadsign, "model did not become ready again after particle restream")
 
-    check("custom count increment", getModel2DFXCount(CUSTOM_MODEL, true) == suiteState.customBase + 3)
-    check("native-only count unchanged", getModel2DFXCount(CUSTOM_MODEL, false) == suiteState.customBase)
+        if addedRoadsign then
+            suiteState.customRoadsignIndex = getModel2DFXCount(CUSTOM_MODEL, true) - 1
+            check("roadsign text getter", getModel2DFXProperty(CUSTOM_MODEL, suiteState.customRoadsignIndex, "text1") == "____NEON 2DFX")
+        else
+            fail("roadsign text getter", "roadsign was not created")
+        end
+
+        check("custom count increment", getModel2DFXCount(CUSTOM_MODEL, true) == suiteState.customBase + 3)
+        check("native-only count unchanged", getModel2DFXCount(CUSTOM_MODEL, false) == suiteState.customBase)
+        done()
+    end, 5000, 200)
 end
 
-local function testVanillaOverride()
+local function testVanillaOverride(done)
     suiteState.vanillaBase = getModel2DFXCount(VANILLA_MODEL, false)
     if suiteState.vanillaBase == 0 then
-        log("SKIP: model 1226 has no native 2DFX in this game state", 2)
+        skip("vanilla 2DFX checks", "model 1226 has no native 2DFX in this game state")
+        done()
         return
     end
 
-    local lightIndex = nil
-    for index = 0, suiteState.vanillaBase - 1 do
-        if getModel2DFXType(VANILLA_MODEL, index) == "light" then
-            lightIndex = index
-            break
-        end
-    end
+    local lightIndex = findVanillaLight()
     if lightIndex == nil then
-        log("SKIP: model 1226 has no light 2DFX", 2)
+        skip("vanilla light checks", "model 1226 has no light 2DFX")
+        done()
         return
     end
 
@@ -172,51 +230,102 @@ local function testVanillaOverride()
     check("override vanilla property", setModel2DFXProperty(VANILLA_MODEL, lightIndex, "drawDistance", baseline + 17) == true)
     check("vanilla override visible", almostEqual(getModel2DFXProperty(VANILLA_MODEL, lightIndex, "drawDistance"), baseline + 17))
 
-    engineRestreamWorld()
-    setTimer(function()
-        check("vanilla override survives engineRestreamWorld", almostEqual(getModel2DFXProperty(VANILLA_MODEL, lightIndex, "drawDistance"), baseline + 17))
-        resetModel2DFXProperty(VANILLA_MODEL, lightIndex, "drawDistance")
-        check("vanilla property reset", almostEqual(getModel2DFXProperty(VANILLA_MODEL, lightIndex, "drawDistance"), baseline))
+    resetModel2DFXProperty(VANILLA_MODEL, lightIndex, "drawDistance")
+    check("vanilla property reset", almostEqual(getModel2DFXProperty(VANILLA_MODEL, lightIndex, "drawDistance"), baseline))
 
-        removeModel2DFX(VANILLA_MODEL, lightIndex)
-        check("remove vanilla effect", getModel2DFXType(VANILLA_MODEL, lightIndex) == "unknown")
-        restoreModel2DFX(VANILLA_MODEL, lightIndex)
-        setTimer(function()
-            check("restore vanilla effect", getModel2DFXType(VANILLA_MODEL, lightIndex) == "light")
-        end, 250, 1)
-    end, 350, 1)
+    local removed = removeModel2DFX(VANILLA_MODEL, lightIndex)
+    check("remove vanilla effect", removed == true and getModel2DFXType(VANILLA_MODEL, lightIndex) == "unknown")
+
+    -- removeModel2DFX restreams the model. Give that targeted restream time to
+    -- settle before restoring, then wait for the restored type to become live.
+    setTimer(function()
+        retryAction(function()
+            return restoreModel2DFX(VANILLA_MODEL, lightIndex)
+        end, function(restored)
+            if not restored then
+                fail("restore vanilla effect", "restore call never succeeded after model restream")
+                done()
+                return
+            end
+
+            waitUntil(function()
+                return getModel2DFXType(VANILLA_MODEL, lightIndex) == "light"
+            end, function(typeRestored)
+                check("restore vanilla effect", typeRestored, "effect stayed unavailable after restore")
+                done()
+            end, 5000, 200)
+        end, 5000, 200)
+    end, 600, 1)
+end
+
+local function finishSuite()
+    info("suite complete; custom effects are intentionally left owned by this resource")
+    info("restart this resource to verify automatic resource-stop cleanup")
+    info("global restream is NOT run automatically; use /2dfxrestream or /2dfxstress")
 end
 
 local function runSuite()
-    log("starting 2DFX regression suite")
+    info("starting 2DFX regression suite")
     verifyPreviousResourceCleanup()
     testInvalidInputs()
-    testCustomEffects()
-    testVanillaOverride()
-    log("suite complete; custom effects are intentionally left owned by this resource")
-    log("restart this resource to verify automatic resource-stop cleanup")
+    testCustomEffects(function()
+        testVanillaOverride(finishSuite)
+    end)
+end
+
+local function runRestreamOnce()
+    local expectedCount = getModel2DFXCount(CUSTOM_MODEL, true)
+    local lightIndex = findVanillaLight()
+    local baseline = lightIndex and getModel2DFXProperty(VANILLA_MODEL, lightIndex, "drawDistance") or nil
+
+    if lightIndex and type(baseline) == "number" then
+        check("prepare vanilla override for restream", setModel2DFXProperty(VANILLA_MODEL, lightIndex, "drawDistance", baseline + 17) == true)
+    end
+
+    info("running one engineRestreamWorld now; a noticeable hitch is expected for this MANUAL test")
+    engineRestreamWorld()
+
+    setTimer(function()
+        check("global restream custom count stable", getModel2DFXCount(CUSTOM_MODEL, true) == expectedCount,
+            string.format("expected=%d actual=%d", expectedCount, getModel2DFXCount(CUSTOM_MODEL, true)))
+        if suiteState.customLightIndex then
+            check("global restream custom light type", getModel2DFXType(CUSTOM_MODEL, suiteState.customLightIndex) == "light")
+        end
+        if lightIndex and type(baseline) == "number" then
+            check("vanilla override survives engineRestreamWorld", almostEqual(getModel2DFXProperty(VANILLA_MODEL, lightIndex, "drawDistance"), baseline + 17))
+            resetModel2DFXProperty(VANILLA_MODEL, lightIndex, "drawDistance")
+        else
+            skip("vanilla override survives engineRestreamWorld", "no vanilla light available")
+        end
+        info("single global restream test finished")
+    end, 900, 1)
 end
 
 local function runStress(iterations)
     iterations = math.max(1, math.min(tonumber(iterations) or 10, 50))
     local expectedCount = getModel2DFXCount(CUSTOM_MODEL, true)
     local completed = 0
-    local timer
-    timer = setTimer(function()
+
+    info(string.format("starting %d MANUAL engineRestreamWorld cycles; repeated hitches are expected", iterations))
+
+    local function cycle()
         engineRestreamWorld()
         completed = completed + 1
         if completed >= iterations then
-            if isTimer(timer) then killTimer(timer) end
             setTimer(function()
                 check("restream stress count stable", getModel2DFXCount(CUSTOM_MODEL, true) == expectedCount,
                     string.format("expected=%d actual=%d", expectedCount, getModel2DFXCount(CUSTOM_MODEL, true)))
                 if suiteState.customLightIndex then
                     check("restream stress custom light type", getModel2DFXType(CUSTOM_MODEL, suiteState.customLightIndex) == "light")
                 end
-                log(string.format("restream stress finished (%d cycles)", iterations))
-            end, 400, 1)
+                info(string.format("restream stress finished (%d cycles)", iterations))
+            end, 900, 1)
+            return
         end
-    end, 250, iterations)
+        setTimer(cycle, 1000, 1)
+    end
+
+    cycle()
 end
 
 local function cleanup()
@@ -225,13 +334,15 @@ local function cleanup()
     destroySuiteObjects()
     setTimer(function()
         check("explicit cleanup custom count", getModel2DFXCount(CUSTOM_MODEL, true) == getModel2DFXCount(CUSTOM_MODEL, false))
-    end, 300, 1)
+    end, 500, 1)
 end
 
 addCommandHandler("2dfxtest", function()
     createSuiteObjects()
     setTimer(runSuite, 900, 1)
 end)
+
+addCommandHandler("2dfxrestream", runRestreamOnce)
 
 addCommandHandler("2dfxstress", function(_, iterations)
     runStress(iterations)

--- a/test-resources/2dfx-test/client.lua
+++ b/test-resources/2dfx-test/client.lua
@@ -1,0 +1,245 @@
+local CUSTOM_MODEL = 1337
+local VANILLA_MODEL = 1226
+local suiteObjects = {}
+local suiteState = {
+    customBase = 0,
+    vanillaBase = 0,
+    vanillaDrawDistance = nil,
+    customLightIndex = nil,
+    customParticleIndex = nil,
+    customRoadsignIndex = nil,
+}
+
+local function log(message, level)
+    outputDebugString("[2dfx-test] " .. tostring(message), level or 3)
+end
+
+local function pass(name)
+    log("PASS: " .. name, 3)
+end
+
+local function fail(name, detail)
+    log("FAIL: " .. name .. (detail and (" - " .. tostring(detail)) or ""), 1)
+end
+
+local function check(name, condition, detail)
+    if condition then
+        pass(name)
+        return true
+    end
+    fail(name, detail)
+    return false
+end
+
+local function almostEqual(a, b, epsilon)
+    if type(a) ~= "number" or type(b) ~= "number" then
+        return false
+    end
+    return math.abs(a - b) <= (epsilon or 0.001)
+end
+
+local function lightProperties(color)
+    return {
+        drawDistance = 90,
+        lightRange = 18,
+        coronaSize = 1.6,
+        shadowSize = 8,
+        shadowMultiplier = 40,
+        showMode = "default",
+        coronaReflection = false,
+        flareType = 0,
+        flags = { atDay = true, atNight = true, checkObstacles = true },
+        shadowDistance = 0,
+        offset = { 0, 0, 0 },
+        color = color or tocolor(70, 180, 255, 255),
+        coronaName = "coronamoon",
+        shadowName = "shad_exp",
+    }
+end
+
+local function roadsignProperties()
+    return {
+        size = { 2.6, 1.2 },
+        rotation = { 0, 0, 0 },
+        flags = { lines = 2, charactersPerLine = 16 },
+        color = tocolor(90, 220, 255, 255),
+        text1 = "____NEON 2DFX",
+        text2 = "___TEST HARNESS",
+        text3 = "",
+        text4 = "",
+    }
+end
+
+local function destroySuiteObjects()
+    for _, object in ipairs(suiteObjects) do
+        if isElement(object) then
+            destroyElement(object)
+        end
+    end
+    suiteObjects = {}
+end
+
+local function createSuiteObjects()
+    destroySuiteObjects()
+    local x, y, z = getElementPosition(localPlayer)
+    suiteObjects[#suiteObjects + 1] = createObject(CUSTOM_MODEL, x + 3.0, y + 1.0, z - 0.8)
+    suiteObjects[#suiteObjects + 1] = createObject(VANILLA_MODEL, x + 7.0, y + 1.0, z - 1.0)
+    for _, object in ipairs(suiteObjects) do
+        if isElement(object) then
+            setElementDimension(object, getElementDimension(localPlayer))
+            setElementInterior(object, getElementInterior(localPlayer))
+        end
+    end
+end
+
+local function verifyPreviousResourceCleanup()
+    local allCount = getModel2DFXCount(CUSTOM_MODEL, true)
+    local nativeCount = getModel2DFXCount(CUSTOM_MODEL, false)
+    check("resource-stop cleanup from previous run", allCount == nativeCount,
+        string.format("all=%s native=%s", tostring(allCount), tostring(nativeCount)))
+end
+
+local function testInvalidInputs()
+    local before = getModel2DFXCount(CUSTOM_MODEL, true)
+
+    local missingFlags = lightProperties()
+    missingFlags.flags = nil
+    local missingFlagsResult = addModel2DFX(CUSTOM_MODEL, 0, 0, 1, "light", missingFlags)
+    check("missing flags returns false instead of crashing", missingFlagsResult == false)
+
+    local tooLongParticle = string.rep("a", 24)
+    local longParticleResult = addModel2DFX(CUSTOM_MODEL, 0, 0, 1, "particle", { name = tooLongParticle })
+    check("24-byte particle name rejected", longParticleResult == false)
+
+    local after = getModel2DFXCount(CUSTOM_MODEL, true)
+    check("invalid calls do not mutate model count", before == after, string.format("before=%d after=%d", before, after))
+end
+
+local function testCustomEffects()
+    suiteState.customBase = getModel2DFXCount(CUSTOM_MODEL, true)
+
+    local addedLight = addModel2DFX(CUSTOM_MODEL, 0, 0, 1.2, "light", lightProperties())
+    check("add custom light", addedLight == true)
+    suiteState.customLightIndex = getModel2DFXCount(CUSTOM_MODEL, true) - 1
+    check("custom light type", getModel2DFXType(CUSTOM_MODEL, suiteState.customLightIndex) == "light")
+
+    local originalDistance = getModel2DFXProperty(CUSTOM_MODEL, suiteState.customLightIndex, "drawDistance")
+    check("set custom light property", setModel2DFXProperty(CUSTOM_MODEL, suiteState.customLightIndex, "drawDistance", 143) == true)
+    check("get custom light property", almostEqual(getModel2DFXProperty(CUSTOM_MODEL, suiteState.customLightIndex, "drawDistance"), 143))
+    resetModel2DFXProperty(CUSTOM_MODEL, suiteState.customLightIndex, "drawDistance")
+    check("reset custom light property", almostEqual(getModel2DFXProperty(CUSTOM_MODEL, suiteState.customLightIndex, "drawDistance"), originalDistance))
+
+    local addedParticle = addModel2DFX(CUSTOM_MODEL, 0, 0, 1.0, "particle", { name = "fire" })
+    check("add custom particle", addedParticle == true)
+    suiteState.customParticleIndex = getModel2DFXCount(CUSTOM_MODEL, true) - 1
+    check("custom particle getter", getModel2DFXProperty(CUSTOM_MODEL, suiteState.customParticleIndex, "name") == "fire")
+
+    local addedRoadsign = addModel2DFX(CUSTOM_MODEL, 0, 0, 1.8, "roadsign", roadsignProperties())
+    check("add custom roadsign", addedRoadsign == true)
+    suiteState.customRoadsignIndex = getModel2DFXCount(CUSTOM_MODEL, true) - 1
+    check("roadsign text getter", getModel2DFXProperty(CUSTOM_MODEL, suiteState.customRoadsignIndex, "text1") == "____NEON 2DFX")
+
+    check("custom count increment", getModel2DFXCount(CUSTOM_MODEL, true) == suiteState.customBase + 3)
+    check("native-only count unchanged", getModel2DFXCount(CUSTOM_MODEL, false) == suiteState.customBase)
+end
+
+local function testVanillaOverride()
+    suiteState.vanillaBase = getModel2DFXCount(VANILLA_MODEL, false)
+    if suiteState.vanillaBase == 0 then
+        log("SKIP: model 1226 has no native 2DFX in this game state", 2)
+        return
+    end
+
+    local lightIndex = nil
+    for index = 0, suiteState.vanillaBase - 1 do
+        if getModel2DFXType(VANILLA_MODEL, index) == "light" then
+            lightIndex = index
+            break
+        end
+    end
+    if lightIndex == nil then
+        log("SKIP: model 1226 has no light 2DFX", 2)
+        return
+    end
+
+    local baseline = getModel2DFXProperty(VANILLA_MODEL, lightIndex, "drawDistance")
+    suiteState.vanillaDrawDistance = baseline
+    check("read vanilla light", type(baseline) == "number")
+    check("override vanilla property", setModel2DFXProperty(VANILLA_MODEL, lightIndex, "drawDistance", baseline + 17) == true)
+    check("vanilla override visible", almostEqual(getModel2DFXProperty(VANILLA_MODEL, lightIndex, "drawDistance"), baseline + 17))
+
+    engineRestreamWorld()
+    setTimer(function()
+        check("vanilla override survives engineRestreamWorld", almostEqual(getModel2DFXProperty(VANILLA_MODEL, lightIndex, "drawDistance"), baseline + 17))
+        resetModel2DFXProperty(VANILLA_MODEL, lightIndex, "drawDistance")
+        check("vanilla property reset", almostEqual(getModel2DFXProperty(VANILLA_MODEL, lightIndex, "drawDistance"), baseline))
+
+        removeModel2DFX(VANILLA_MODEL, lightIndex)
+        check("remove vanilla effect", getModel2DFXType(VANILLA_MODEL, lightIndex) == "unknown")
+        restoreModel2DFX(VANILLA_MODEL, lightIndex)
+        setTimer(function()
+            check("restore vanilla effect", getModel2DFXType(VANILLA_MODEL, lightIndex) == "light")
+        end, 250, 1)
+    end, 350, 1)
+end
+
+local function runSuite()
+    log("starting 2DFX regression suite")
+    verifyPreviousResourceCleanup()
+    testInvalidInputs()
+    testCustomEffects()
+    testVanillaOverride()
+    log("suite complete; custom effects are intentionally left owned by this resource")
+    log("restart this resource to verify automatic resource-stop cleanup")
+end
+
+local function runStress(iterations)
+    iterations = math.max(1, math.min(tonumber(iterations) or 10, 50))
+    local expectedCount = getModel2DFXCount(CUSTOM_MODEL, true)
+    local completed = 0
+    local timer
+    timer = setTimer(function()
+        engineRestreamWorld()
+        completed = completed + 1
+        if completed >= iterations then
+            if isTimer(timer) then killTimer(timer) end
+            setTimer(function()
+                check("restream stress count stable", getModel2DFXCount(CUSTOM_MODEL, true) == expectedCount,
+                    string.format("expected=%d actual=%d", expectedCount, getModel2DFXCount(CUSTOM_MODEL, true)))
+                if suiteState.customLightIndex then
+                    check("restream stress custom light type", getModel2DFXType(CUSTOM_MODEL, suiteState.customLightIndex) == "light")
+                end
+                log(string.format("restream stress finished (%d cycles)", iterations))
+            end, 400, 1)
+        end
+    end, 250, iterations)
+end
+
+local function cleanup()
+    resetModel2DFXEffects(CUSTOM_MODEL)
+    resetModel2DFXEffects(VANILLA_MODEL)
+    destroySuiteObjects()
+    setTimer(function()
+        check("explicit cleanup custom count", getModel2DFXCount(CUSTOM_MODEL, true) == getModel2DFXCount(CUSTOM_MODEL, false))
+    end, 300, 1)
+end
+
+addCommandHandler("2dfxtest", function()
+    createSuiteObjects()
+    setTimer(runSuite, 900, 1)
+end)
+
+addCommandHandler("2dfxstress", function(_, iterations)
+    runStress(iterations)
+end)
+
+addCommandHandler("2dfxcleanup", cleanup)
+
+addEventHandler("onClientResourceStart", resourceRoot, function()
+    createSuiteObjects()
+    setTimer(runSuite, 900, 1)
+end)
+
+addEventHandler("onClientResourceStop", resourceRoot, function()
+    destroySuiteObjects()
+end)

--- a/test-resources/2dfx-test/client.lua
+++ b/test-resources/2dfx-test/client.lua
@@ -15,11 +15,15 @@ local function log(message, level)
 end
 
 local function pass(name)
-    log("PASS: " .. name, 3)
+    local message = "PASS: " .. name
+    log(message, 3)
+    outputChatBox("[2dfx-test] " .. message, 90, 255, 120)
 end
 
 local function fail(name, detail)
-    log("FAIL: " .. name .. (detail and (" - " .. tostring(detail)) or ""), 1)
+    local message = "FAIL: " .. name .. (detail and (" - " .. tostring(detail)) or "")
+    log(message, 1)
+    outputChatBox("[2dfx-test] " .. message, 255, 90, 90)
 end
 
 local function check(name, condition, detail)

--- a/test-resources/2dfx-test/meta.xml
+++ b/test-resources/2dfx-test/meta.xml
@@ -1,0 +1,4 @@
+<meta>
+    <info author="Dryxio" name="2DFX API regression harness" type="script" />
+    <script src="client.lua" type="client" cache="false" />
+</meta>


### PR DESCRIPTION
## Summary

Adapts the model 2DFX work from multitheftauto/mtasa-blue#3741 by @FileEX for the Neon fork, while keeping GTA SA's native model-level 2DFX semantics.

This implementation intentionally does not copy the upstream lifetime/state model verbatim. Neon tracks 2DFX mutations per resource and rolls them back when that resource stops.

## Neon integration

- keeps 2DFX model-level, matching GTA SA / RenderWare geometry ownership;
- adds resource-owned custom 2DFX effects;
- stacks property overrides on original GTA effects per resource (latest active override wins);
- tracks removals per resource, restoring an original effect only after all removing resources release it;
- automatically cleans a resource's custom effects, overrides and removals on resource teardown;
- keeps the public API close to PR #3741 (`addModel2DFX`, `removeModel2DFX`, property setters/getters, reset/restore helpers);
- keeps the integration local to the deathmatch layer and installs only the required `Get2dEffect` and post-`CreateEffects` hooks.

## Safety changes vs upstream PR head

- validates GTA-facing layouts with `static_assert` against the reversed SA layouts;
- loads replacement light textures before releasing the currently live texture;
- handles null texture pointers when reading effect state;
- limits particle names to 23 usable characters for the native `char[24]` buffer;
- validates Lua fields before dereferencing them (including missing `flags`);
- validates finite values and native integer/range constraints before writing GTA structures;
- avoids iterator-after-erase reset logic from the upstream implementation;
- uses the native unknown/missing 2DFX type as an inert removed-effect sentinel so the rest of GTA's effect loops do not require a broad set of null-pointer patches.

## API

- `addModel2DFX`
- `removeModel2DFX`
- `restoreModel2DFX`
- `resetModel2DFXEffects`
- `setModel2DFXPosition`
- `setModel2DFXProperty`
- `resetModel2DFXProperty`
- `resetModel2DFXPosition`
- `getModel2DFXPosition`
- `getModel2DFXProperty`
- `getModel2DFXEffects`
- `getModel2DFXCount`
- `getModel2DFXType`

## Regression resource

Adds `test-resources/2dfx-test`.

It covers resource-stop cleanup, malformed/missing fields, particle-name boundaries, custom light/particle/roadsign creation, property set/get/reset, native-only vs custom-inclusive counts, vanilla light override/reset, `engineRestreamWorld` persistence, original effect remove/restore and repeated restream stress.

Commands:

- `/2dfxtest`
- `/2dfxrestream`
- `/2dfxstress [count]`
- `/2dfxcleanup`

## Cinematic showcase

Adds `test-resources/2dfx-showcase`, built directly on the Verdant Meadows runway between `100.74450, 2501.11401, 16.48438` and `424.00473, 2503.03442, 16.48438`.

The main runway show now uses 60 visible GTA lamp posts (model 1226), split into six model-level groups per side. Centerline/threshold lights reuse the corona texture read from the native 1226 light instead of hard-coding `coronamoon`. Tiny invisible runtime models remain only as carriers for centerline, threshold, particle, roadsign, sun-glare and deliberate sky-moon effects. Model allocation plus targeted particle/roadsign restream work happens behind a black fade; the recorded timeline does not call `engineRestreamWorld()`.

The seven shots cover:

1. clean sunset runway with native `SUN_GLARE`;
2. night transition and far-to-near ignition of the physical lamp-post rows;
3. model-level color chases across left/right lamp groups, centerline animation, corona pulses and `warnlight` / `trafficlight` / `on_off_at_5` modes;
4. close-up mutation/restoration of a cloned GTA lamp's native light when the runtime clone exposes it;
5. a deliberate seven-sprite multicolor `coronamoon` arc in the sky, isolated from ordinary runway lighting;
6. native `smoke_flare` / `fire` particle gates plus generated native `ROADSIGN` text (`NATIVE_GTA_2DFX / SCRIPTED_IN_LUA` and `NO_SHADERS / NO_CUSTOM_ASSETS`);
7. a full-runway finale with 60 lamp posts, 24 centerline lights, threshold bars, blinking modes and cycling colors.

Recording/development commands:

- `/2dfxshow` or `/2dfxshow full`
- `/2dfxshow shot 1` ... `/2dfxshow shot 7`
- `/2dfxshow setup`
- `/2dfxshow final`
- `/2dfxshow stop`

The showcase deliberately uses no custom DFF, TXD, shader or texture. Lamp visuals and corona texture names are sourced from GTA itself; `coronamoon` is retained only as an intentional showcase effect.

## Notes

This remains a draft until the lamp-row alignment/orientation and camera positions are visually checked in-game. The regression harness is passing on the current implementation.