### PR TITLE
Bridge GTA explosions into managed break profiles

### DIFF
--- a/Client/mods/deathmatch/logic/CClientExplosionManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientExplosionManager.cpp
@@ -10,10 +10,25 @@
 
 #include <StdInc.h>
 #include <game/CExplosionManager.h>
+#include "luadefs/CLuaBreakEffectDefs.h"
 
 extern CClientGame* g_pClientGame;
 
 CClientExplosionManager* g_pExplosionManager = NULL;
+
+namespace
+{
+    bool g_bSuppressManagedBreakExplosionDamage = false;
+
+    void HandleManagedBreakExplosionDamage(const CVector& position, eExplosionType explosionType, CEntity* gameCreator)
+    {
+        if (g_bSuppressManagedBreakExplosionDamage)
+            return;
+
+        CLuaBreakEffectDefs::HandleExplosionDamage(position, static_cast<int>(explosionType),
+                                                   gameCreator ? gameCreator->GetInterface() : nullptr);
+    }
+}
 
 CClientExplosionManager::CClientExplosionManager(CClientManager* pManager)
 {
@@ -86,7 +101,10 @@ bool CClientExplosionManager::Hook_ExplosionCreation(CEntity* pGameExplodingEnti
         arguments.PushNumber(vecPosition.fY);
         arguments.PushNumber(vecPosition.fZ);
         arguments.PushNumber(explosionWeaponType);
-        return localPlayer->CallEvent("onClientExplosion", arguments, true);
+        const bool allowExplosion = localPlayer->CallEvent("onClientExplosion", arguments, true);
+        if (allowExplosion)
+            HandleManagedBreakExplosionDamage(vecPosition, explosionType, pGameCreator);
+        return allowExplosion;
     }
 
     // Determine the used weapon
@@ -142,6 +160,8 @@ bool CClientExplosionManager::Hook_ExplosionCreation(CEntity* pGameExplodingEnti
             vehicle->SetBlowState(VehicleBlowState::BLOWN);
         }
 
+        if (allowExplosion)
+            HandleManagedBreakExplosionDamage(vecPosition, explosionType, pGameCreator);
         return allowExplosion;
     }
 
@@ -203,11 +223,16 @@ CExplosion* CClientExplosionManager::Create(eExplosionType explosionType, CVecto
     else
         m_LastWeaponType = GetWeaponTypeFromExplosionType(explosionType);
 
+    bool managedDamageHandledByHook = false;
     if (pCreator && pCreator->IsLocalEntity())
     {
+        const bool previousSuppress = g_bSuppressManagedBreakExplosionDamage;
+        g_bSuppressManagedBreakExplosionDamage = bNoDamage;
         bool allowExplosion = Hook_ExplosionCreation(nullptr, pGameCreator, vecPosition, explosionType);
+        g_bSuppressManagedBreakExplosionDamage = previousSuppress;
         if (!allowExplosion)
             return nullptr;
+        managedDamageHandledByHook = !bNoDamage;
     }
     else if (!pCreator)
     {
@@ -228,6 +253,9 @@ CExplosion* CClientExplosionManager::Create(eExplosionType explosionType, CVecto
                 return nullptr;
         }
     }
+
+    if (!bNoDamage && !managedDamageHandledByHook)
+        HandleManagedBreakExplosionDamage(vecPosition, explosionType, pGameCreator);
 
     CExplosion* pExplosion = g_pGame->GetExplosionManager()->AddExplosion(NULL, pGameCreator, explosionType, vecPosition, 0, bMakeSound, fCamShake, bNoDamage);
     return pExplosion;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaBreakEffectDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaBreakEffectDefs.cpp
@@ -8,6 +8,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include <game/CExplosion.h>
 #include "CLuaBreakEffectDefs.h"
 #include "../CClientBreakEffect.h"
 #include "../CClientBreakEffectManager.h"
@@ -37,6 +38,8 @@ namespace
 
         unsigned long long lastVehicleDamageTick = 0;
         CEntitySAInterface* lastVehicleAttacker = nullptr;
+        unsigned long long lastExplosionDamageTick = 0;
+        CEntitySAInterface* lastExplosionAttacker = nullptr;
         CVector             lastImpactPosition;
         CVector             lastImpactVelocity;
         bool                hasLastImpactPosition = false;
@@ -297,11 +300,32 @@ namespace
         if (!profile)
             return true;
 
+        const unsigned long long now = GetTickCount64_();
+
+        // Managed explosion damage is applied immediately before GTA enters
+        // CWorld::TriggerExplosion. If the vanilla path also reaches
+        // CObject::ObjectDamage, consume that synchronous callback so the
+        // profile is charged only once. Explosion-proof objects never reach
+        // this callback, and the short window expires before later gameplay damage.
+        if (profile->lastExplosionDamageTick != 0)
+        {
+            if (profile->lastExplosionAttacker == attackerInterface && now - profile->lastExplosionDamageTick <= 10)
+            {
+                profile->lastExplosionAttacker = nullptr;
+                profile->lastExplosionDamageTick = 0;
+                return false;
+            }
+            if (now - profile->lastExplosionDamageTick > 10)
+            {
+                profile->lastExplosionAttacker = nullptr;
+                profile->lastExplosionDamageTick = 0;
+            }
+        }
+
         // Vehicle collision is also hooked because arbitrary DFFs do not all
         // enter CObject::ObjectDamage from physical impacts. If GTA does call
         // ObjectDamage for the same collision, consume the callback without
         // charging managed health a second time.
-        const unsigned long long now = GetTickCount64_();
         if (profile->lastVehicleAttacker == attackerInterface && profile->lastVehicleDamageTick != 0 && now - profile->lastVehicleDamageTick <= 100)
         {
             profile->lastVehicleAttacker = nullptr;
@@ -504,6 +528,95 @@ namespace
         lua_pushboolean(luaVM, profile.fracture.disableOriginalCollision);
         lua_setfield(luaVM, -2, "disableOriginalCollision");
         lua_setfield(luaVM, -2, "fracture");
+    }
+}
+
+void CLuaBreakEffectDefs::HandleExplosionDamage(const CVector& position, int explosionType, CEntitySAInterface* attackerInterface)
+{
+    float radius = 0.0f;
+    float damageScale = 1.0f;
+
+    switch (static_cast<eExplosionType>(explosionType))
+    {
+        case EXP_TYPE_GRENADE:
+            radius = 9.0f;
+            break;
+        case EXP_TYPE_ROCKET:
+            radius = 10.0f;
+            break;
+        case EXP_TYPE_ROCKET_WEAK:
+            radius = 10.0f;
+            damageScale = 0.2f;
+            break;
+        case EXP_TYPE_CAR:
+        case EXP_TYPE_CAR_QUICK:
+            radius = 9.0f;
+            break;
+        case EXP_TYPE_BOAT:
+        case EXP_TYPE_HELI:
+            radius = 25.0f;
+            break;
+        case EXP_TYPE_MINE:
+        case EXP_TYPE_OBJECT:
+        case EXP_TYPE_TANK_GRENADE:
+            radius = 10.0f;
+            break;
+        case EXP_TYPE_SMALL:
+        case EXP_TYPE_TINY:
+            radius = 3.0f;
+            break;
+        case EXP_TYPE_MOLOTOV:
+        default:
+            return;
+    }
+
+    PruneObjectBreakProfiles();
+    if (g_ObjectBreakProfiles.empty())
+        return;
+
+    CClientEntity* attacker = nullptr;
+    if (attackerInterface && g_pGame && g_pGame->GetPools())
+        attacker = g_pGame->GetPools()->GetClientEntity(reinterpret_cast<DWORD*>(attackerInterface));
+
+    constexpr float BASE_OBJECT_EXPLOSION_DAMAGE = 300.0f;
+    const float radiusSq = radius * radius;
+
+    for (std::size_t index = 0; index < g_ObjectBreakProfiles.size();)
+    {
+        SObjectBreakProfile& profile = g_ObjectBreakProfiles[index];
+        CVector objectPosition;
+        profile.object->GetPosition(objectPosition);
+
+        const float dx = objectPosition.fX - position.fX;
+        const float dy = objectPosition.fY - position.fY;
+        const float dz = objectPosition.fZ - position.fZ;
+        const float distanceSq = dx * dx + dy * dy + dz * dz;
+        if (distanceSq >= radiusSq)
+        {
+            ++index;
+            continue;
+        }
+
+        const float distance = std::sqrt(std::max(0.0f, distanceSq));
+        const float falloff = std::clamp(2.0f * (radius - distance) / radius, 0.0f, 1.0f);
+        const float effectiveDamage = BASE_OBJECT_EXPLOSION_DAMAGE * falloff * damageScale;
+        if (effectiveDamage <= 0.0f)
+        {
+            ++index;
+            continue;
+        }
+
+        profile.lastExplosionDamageTick = GetTickCount64_();
+        profile.lastExplosionAttacker = attackerInterface;
+
+        CClientObject* object = profile.object;
+        if (ApplyManagedDamage(profile, effectiveDamage, attacker, &position))
+        {
+            EraseObjectBreakProfile(object);
+            continue;
+        }
+
+        ++index;
     }
 }
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaBreakEffectDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaBreakEffectDefs.h
@@ -15,11 +15,15 @@
 #define lua_absindex(L, i) ((i) > 0 || (i) <= LUA_REGISTRYINDEX ? (i) : lua_gettop(L) + (i) + 1)
 #endif
 
+class CEntitySAInterface;
+class CVector;
+
 class CLuaBreakEffectDefs : public CLuaDefs
 {
 public:
     static void LoadFunctions();
     static void AddClass(lua_State* luaVM);
+    static void HandleExplosionDamage(const CVector& position, int explosionType, CEntitySAInterface* attackerInterface);
 
     LUA_DECLARE(CreateObjectBreakEffect);
     LUA_DECLARE(GetBreakEffectFragmentCount);

--- a/test-resources/break-explosion-test/README.md
+++ b/test-resources/break-explosion-test/README.md
@@ -1,0 +1,30 @@
+# Managed break explosion regression harness
+
+Focused client-side coverage for explosion-driven `setObjectBreakProfile` damage.
+
+## Commands
+
+- `/breakexptest` runs the automated regression sequence.
+- `/breakexplosiontarget [model]` spawns one 250-health managed target in front of the player for a real rocket-launcher or Rhino-shell check.
+- `/breakexpreset` removes harness objects.
+
+## Automated coverage
+
+The sequence uses real `createExplosion` calls so damage goes through GTA's explosion implementation rather than calling the managed damage code directly.
+
+It checks:
+
+- an object without a managed profile does not create a managed break effect;
+- a near rocket applies one 300-point managed hit, catching duplicate native `ObjectDamage` charging;
+- rocket radial falloff;
+- no damage outside the explosion radius;
+- weak-rocket 0.2 damage scaling;
+- tank-shell explosion damage;
+- `damaging=false` remains non-damaging;
+- an explosion can drive managed health to zero and create a `break-effect`.
+
+Expected damage follows GTA's object explosion radial factor: `min(1, 2 * (radius - distance) / radius) * 300`, with the weak rocket multiplying damage by `0.2`.
+
+## Manual validation
+
+Run `/breakexplosiontarget`, then hit the target with the GTA rocket launcher. Repeat with a Rhino cannon. The object should fracture from the explosion position even when the source model's vanilla object data would otherwise make it explosion-proof.

--- a/test-resources/break-explosion-test/client.lua
+++ b/test-resources/break-explosion-test/client.lua
@@ -1,0 +1,207 @@
+local tracked = {}
+local serial = 0
+
+local ROCKET = 2
+local WEAK_ROCKET = 3
+local TANK = 10
+local MODEL = 1337
+
+local function log(kind, name, detail)
+    local suffix = detail and (": " .. tostring(detail)) or ""
+    local message = ("[BREAKEXP] %s %s%s"):format(kind, name, suffix)
+    outputDebugString(message, kind == "FAIL" and 1 or 3)
+    outputChatBox(message, kind == "FAIL" and 255 or 100, kind == "FAIL" and 80 or 255, 100)
+end
+
+local function check(name, condition, detail)
+    log(condition and "PASS" or "FAIL", name, detail)
+    return condition
+end
+
+local function destroyTracked()
+    for element in pairs(tracked) do
+        if isElement(element) then
+            if getElementType(element) == "object" then
+                clearObjectBreakProfile(element)
+            end
+            destroyElement(element)
+        end
+    end
+    tracked = {}
+end
+
+local function reset()
+    serial = serial + 1
+    destroyTracked()
+end
+
+local function track(element)
+    if isElement(element) then
+        tracked[element] = true
+    end
+    return element
+end
+
+local function forwardPosition(distance, side, height)
+    local x, y, z = getElementPosition(localPlayer)
+    local _, _, rz = getElementRotation(localPlayer)
+    local a = math.rad(rz)
+    local fx, fy = -math.sin(a), math.cos(a)
+    local rx, ry = fy, -fx
+    return x + fx * distance + rx * (side or 0), y + fy * distance + ry * (side or 0), z + (height or 0)
+end
+
+local function spawnTarget(health, withProfile, model)
+    local x, y, z = forwardPosition(9, 0, 0.8)
+    local object = track(createObject(model or MODEL, x, y, z))
+    if not isElement(object) then
+        return false
+    end
+
+    setElementFrozen(object, true)
+    if withProfile then
+        local ok = setObjectBreakProfile(object, {
+            native = false,
+            health = health,
+            fracture = {
+                fragments = 16,
+                force = 6.0,
+                randomness = 1.0,
+                lifetime = 5000,
+                seed = 20260819,
+            },
+        })
+        if not ok then
+            destroyElement(object)
+            tracked[object] = nil
+            return false
+        end
+    end
+
+    return object, x, y, z
+end
+
+local function approximate(value, expected, tolerance)
+    return type(value) == "number" and math.abs(value - expected) <= (tolerance or 0.75)
+end
+
+local function runDamageCase(runSerial, name, explosionType, distance, damaging, expectedHealth, done)
+    destroyTracked()
+    local object, x, y, z = spawnTarget(1000, true)
+    if not check(name .. ".spawn", isElement(object), tostring(object)) then
+        done()
+        return
+    end
+
+    setTimer(function()
+        if runSerial ~= serial or not isElement(object) then return end
+        check(name .. ".createExplosion", createExplosion(x + distance, y, z, explosionType, false, 0, damaging) == true)
+    end, 650, 1)
+
+    setTimer(function()
+        if runSerial ~= serial or not isElement(object) then return end
+        local health = getObjectBreakHealth(object)
+        check(name .. ".health", approximate(health, expectedHealth), ("expected=%.1f actual=%s"):format(expectedHealth, tostring(health)))
+        done()
+    end, 800, 1)
+end
+
+local function runNoProfileCase(runSerial, done)
+    destroyTracked()
+    local object, x, y, z = spawnTarget(1000, false)
+    if not check("no-profile.spawn", isElement(object), tostring(object)) then
+        done()
+        return
+    end
+
+    local before = #getElementsByType("break-effect")
+    setTimer(function()
+        if runSerial ~= serial or not isElement(object) then return end
+        check("no-profile.createExplosion", createExplosion(x + 1, y, z, ROCKET, false, 0, true) == true)
+    end, 650, 1)
+
+    setTimer(function()
+        if runSerial ~= serial then return end
+        check("no-profile.profile", isElement(object) and getObjectBreakProfile(object) == false)
+        check("no-profile.break-effect", #getElementsByType("break-effect") == before,
+            ("before=%d after=%d"):format(before, #getElementsByType("break-effect")))
+        done()
+    end, 800, 1)
+end
+
+local function runFractureCase(runSerial, done)
+    destroyTracked()
+    local object, x, y, z = spawnTarget(200, true)
+    if not check("fracture.spawn", isElement(object), tostring(object)) then
+        done()
+        return
+    end
+
+    local before = #getElementsByType("break-effect")
+    setTimer(function()
+        if runSerial ~= serial or not isElement(object) then return end
+        check("fracture.createExplosion", createExplosion(x + 1, y, z, ROCKET, false, 0, true) == true)
+    end, 650, 1)
+
+    setTimer(function()
+        if runSerial ~= serial then return end
+        local after = #getElementsByType("break-effect")
+        check("fracture.effect", after > before, ("before=%d after=%d"):format(before, after))
+        check("fracture.profile-cleared", not isElement(object) or getObjectBreakProfile(object) == false)
+        done()
+    end, 850, 1)
+end
+
+local function runAll()
+    reset()
+    local runSerial = serial
+    local cases = {
+        function(done) runNoProfileCase(runSerial, done) end,
+        -- GTA's object explosion branch uses a 300-point radial damage basis.
+        -- At <= half radius the falloff is capped at 1, so one rocket should
+        -- leave a native=false 1000-health managed profile at exactly 700.
+        function(done) runDamageCase(runSerial, "rocket-near-no-double", ROCKET, 1, true, 700, done) end,
+        function(done) runDamageCase(runSerial, "rocket-falloff", ROCKET, 8, true, 880, done) end,
+        function(done) runDamageCase(runSerial, "rocket-outside", ROCKET, 11, true, 1000, done) end,
+        function(done) runDamageCase(runSerial, "weak-rocket", WEAK_ROCKET, 1, true, 940, done) end,
+        function(done) runDamageCase(runSerial, "tank", TANK, 1, true, 700, done) end,
+        function(done) runDamageCase(runSerial, "no-damage", ROCKET, 1, false, 1000, done) end,
+        function(done) runFractureCase(runSerial, done) end,
+    }
+
+    local index = 0
+    local function nextCase()
+        if runSerial ~= serial then return end
+        index = index + 1
+        if not cases[index] then
+            outputChatBox("[BREAKEXP] DONE -- inspect PASS/FAIL above", 255, 200, 80)
+            return
+        end
+        cases[index](function()
+            setTimer(nextCase, 250, 1)
+        end)
+    end
+
+    nextCase()
+end
+
+addCommandHandler("breakexptest", runAll)
+
+addCommandHandler("breakexplosiontarget", function(_, modelArg)
+    reset()
+    local model = tonumber(modelArg) or MODEL
+    local object = spawnTarget(250, true, model)
+    if not isElement(object) then
+        log("FAIL", "manual-target.spawn", model)
+        return
+    end
+
+    outputChatBox(("[BREAKEXP] target model %d armed with 250 health. Hit it with a rocket or Rhino shell."):format(model), 255, 200, 80)
+end)
+
+addCommandHandler("breakexpreset", function()
+    reset()
+    log("PASS", "reset")
+end)
+
+addEventHandler("onClientResourceStop", resourceRoot, reset)

--- a/test-resources/break-explosion-test/meta.xml
+++ b/test-resources/break-explosion-test/meta.xml
@@ -1,0 +1,4 @@
+<meta>
+    <info author="Neon" name="Managed break explosion regression harness" type="script" version="1.0" />
+    <script src="client.lua" type="client" />
+</meta>


### PR DESCRIPTION
## Summary

- bridge damaging GTA/MTA explosions into managed `setObjectBreakProfile` durability before vanilla object immunity can suppress `CObject::ObjectDamage`
- mirror GTA object explosion radii/falloff, including weak-rocket damage scaling, while leaving Molotov/fire behavior out of scope
- preserve the explosion position as the fracture impact origin so chunks eject away from the blast
- suppress the immediate vanilla `ObjectDamage` callback for the same explosion to avoid charging managed health twice
- add a focused `break-explosion-test` resource plus a manual target command for real rocket-launcher and Rhino validation

## Root cause

Managed break profiles currently depend on MTA's `CObject::ObjectDamage` callback, except for the explicit vehicle-collision bridge. GTA's explosion world pass can reject an object via vanilla explosion-proof/object-data rules before `CObject::ObjectDamage` is reached, so a generic managed object can ignore rockets or tank shells even though its break profile is armed.

This change keeps vanilla object data and proof flags untouched. Objects without a managed break profile continue through the existing explosion path unchanged.

## Damage model

Managed explosion damage follows GTA's object explosion radial shape:

`min(1, 2 * (radius - distance) / radius) * 300`

Explosion-type radii follow GTA's existing values; weak rockets apply the native `0.2` damage scale.

## Test resource

`test-resources/break-explosion-test`

- `/breakexptest` covers no-profile behavior, near-hit damage, falloff, outside-radius behavior, weak rockets, tank explosions, `damaging=false`, duplicate-damage protection, and fracture-at-zero
- `/breakexplosiontarget [model]` arms a 250-health target for manual rocket-launcher/Rhino testing
- `/breakexpreset` cleans up

## Validation

- reviewed the generated diff and existing GTA/MTA explosion paths against `gta-reversed-dryxio`
- branch is a single focused commit on current `master`
- runtime harness is included but still requires in-game execution
- GitHub Actions were intentionally not awaited

## Scope

This PR only closes the explosion gap. Existing firearm and vehicle-collision behavior is left unchanged; Molotov/fire and melee are not broadened here.