### PR TITLE
test(physics): add clean basketball showcase

### DIFF
--- a/test-resources/dynamic-object-physics-showcase/README.md
+++ b/test-resources/dynamic-object-physics-showcase/README.md
@@ -10,8 +10,26 @@ Clean basketball-throw showcase for recording Neon's generic dynamic-object phys
 - `/showcasethrow [0..1]`: throw immediately at a fixed power while using the current reticle direction.
 - `/showcaseclear`: remove your spawned showcase balls.
 - `/showcaseclearall`: remove all showcase balls.
+- `/showcasemarker [distance]`: place a non-solid orange marker along the reticle (default 8 m).
+- `/showcasering [distance]`: place a non-solid floating orange ring along the reticle (default 10 m).
+- `/showcasetargetclear`: remove the local marker and ring targets.
 
 Each throw creates a new dynamic object, so previous basketballs remain in the world and continue rolling, bouncing and colliding. Up to 150 balls per player are kept alive; the oldest are recycled beyond that limit.
+
+## Showcase targets
+
+The marker and ring are presentation-only local targets. They do not collide with or redirect the basketballs, so they cannot fake the physical result.
+
+Both targets are orange normally and flash green for about 650 ms when a showcase basketball reaches them. Hit detection uses the ball's previous and current positions so a fast-moving ball can still register while crossing a target between rendered frames.
+
+The marker behaves as a spherical target. The floating ring is oriented toward the camera when it is placed and registers a hit when a basketball passes through its opening.
+
+Examples:
+
+- `/showcasemarker 6`
+- `/showcasering 12`
+
+Aim the reticle where you want the target and run the command. Re-running the same command moves/replaces that target.
 
 ## Aim presentation
 

--- a/test-resources/dynamic-object-physics-showcase/README.md
+++ b/test-resources/dynamic-object-physics-showcase/README.md
@@ -1,0 +1,30 @@
+# Dynamic object physics showcase
+
+Clean basketball-throw showcase for recording Neon's generic dynamic-object physics without the harness debug gizmos.
+
+## Controls
+
+- `A`: toggle aim mode.
+- Hold `E`: charge the throw. The reticle shrinks as power increases.
+- Release `E`: spawn and throw a new basketball through the reticle.
+- `/showcasethrow [0..1]`: throw immediately at a fixed power while using the current reticle direction.
+- `/showcaseclear`: remove your spawned showcase balls.
+- `/showcaseclearall`: remove all showcase balls.
+
+Each throw creates a new dynamic object, so previous basketballs remain in the world and continue rolling, bouncing and colliding. Up to 150 balls per player are kept alive; the oldest are recycled beyond that limit.
+
+## Aim presentation
+
+The resource keeps GTA's normal third-person camera and mouse-look instead of replacing it with a scripted camera. The reticle is placed to the right of the player, in an over-the-shoulder screen position. `getWorldFromScreenPosition` converts that exact reticle position into the world-space throw direction, so the reticle indicates where the ball is actually aimed while keeping the character out of the center of the sight picture.
+
+## Physics
+
+The showcase uses the same runtime sphere collision and physical basketball properties validated by `dynamic-object-physics-harness`:
+
+- radius `0.12`
+- mass `0.62`
+- solid-sphere turn mass `0.4 * mass * radius^2`
+- air resistance `0.995`
+- elasticity `0.72`
+
+There is intentionally no velocity overlay, collision-axis gizmo, scoring, hoop logic or gameplay-specific assistance.

--- a/test-resources/dynamic-object-physics-showcase/client.lua
+++ b/test-resources/dynamic-object-physics-showcase/client.lua
@@ -12,10 +12,20 @@ local RETICLE_SEGMENTS = 40
 local RETICLE_X_RATIO = 0.61
 local RETICLE_Y_RATIO = 0.46
 
+local TARGET_HIT_MS = 650
+local MARKER_RADIUS = 0.80
+local RING_RADIUS = 1.00
+local RING_SEGMENTS = 48
+local TARGET_ORANGE = { 255, 145, 40 }
+local TARGET_GREEN = { 80, 235, 120 }
+
 local ballCol = false
 local aiming = false
 local charging = false
 local chargeStart = 0
+local markerTarget = false
+local ringTarget = false
+local previousBallPositions = {}
 local screenW, screenH = guiGetScreenSize()
 
 local function clamp(value, minimum, maximum)
@@ -99,6 +109,16 @@ local function getAimDirection()
     return dx, dy, clamp(dz, -0.75, 0.85)
 end
 
+local function getReticleWorldPoint(distance)
+    distance = clamp(tonumber(distance) or 10, 2, 60)
+    local reticleX, reticleY = getReticlePosition()
+    local x, y, z = getWorldFromScreenPosition(reticleX, reticleY, distance)
+    if not x then
+        return false
+    end
+    return x, y, z, distance
+end
+
 local function throwBall(power)
     local dirX, dirY, dirZ = getAimDirection()
     if not dirX then
@@ -136,6 +156,195 @@ local function drawReticle()
 
     drawCircle(centerX, centerY, radius, color)
     dxDrawRectangle(centerX - 1.5, centerY - 1.5, 3, 3, color)
+end
+
+local function destroyMarkerTarget()
+    if markerTarget and isElement(markerTarget.element) then
+        destroyElement(markerTarget.element)
+    end
+    markerTarget = false
+end
+
+local function clearTargets()
+    destroyMarkerTarget()
+    ringTarget = false
+    previousBallPositions = {}
+end
+
+local function placeMarkerTarget(distance)
+    local x, y, z, resolvedDistance = getReticleWorldPoint(distance or 8)
+    if not x then
+        outputChatBox("[physics-showcase] could not resolve reticle position", 255, 120, 120)
+        return
+    end
+
+    destroyMarkerTarget()
+    local marker = createMarker(x, y, z, "corona", MARKER_RADIUS * 2, TARGET_ORANGE[1], TARGET_ORANGE[2], TARGET_ORANGE[3], 180)
+    if not isElement(marker) then
+        outputChatBox("[physics-showcase] failed to create marker target", 255, 120, 120)
+        return
+    end
+
+    setElementInterior(marker, getElementInterior(localPlayer))
+    setElementDimension(marker, getElementDimension(localPlayer))
+    markerTarget = { element = marker, x = x, y = y, z = z, hitUntil = 0 }
+    outputChatBox(("[physics-showcase] marker placed %.1fm along reticle"):format(resolvedDistance), 255, 180, 90)
+end
+
+local function makeRingBasis(nx, ny, nz)
+    local rx, ry, rz = ny, -nx, 0
+    local rightLength = math.sqrt(rx * rx + ry * ry + rz * rz)
+    if rightLength < 0.001 then
+        rx, ry, rz = 1, 0, 0
+    else
+        rx, ry, rz = rx / rightLength, ry / rightLength, rz / rightLength
+    end
+
+    local ux = ny * rz - nz * ry
+    local uy = nz * rx - nx * rz
+    local uz = nx * ry - ny * rx
+    local upLength = math.sqrt(ux * ux + uy * uy + uz * uz)
+    if upLength < 0.001 then
+        return false
+    end
+    return rx, ry, rz, ux / upLength, uy / upLength, uz / upLength
+end
+
+local function placeRingTarget(distance)
+    local x, y, z, resolvedDistance = getReticleWorldPoint(distance or 10)
+    if not x then
+        outputChatBox("[physics-showcase] could not resolve reticle position", 255, 120, 120)
+        return
+    end
+
+    local cameraX, cameraY, cameraZ = getCameraMatrix()
+    local nx, ny, nz = cameraX - x, cameraY - y, cameraZ - z
+    local normalLength = math.sqrt(nx * nx + ny * ny + nz * nz)
+    if normalLength < 0.001 then
+        return
+    end
+    nx, ny, nz = nx / normalLength, ny / normalLength, nz / normalLength
+
+    local rx, ry, rz, ux, uy, uz = makeRingBasis(nx, ny, nz)
+    if not rx then
+        return
+    end
+
+    ringTarget = {
+        x = x, y = y, z = z,
+        nx = nx, ny = ny, nz = nz,
+        rx = rx, ry = ry, rz = rz,
+        ux = ux, uy = uy, uz = uz,
+        hitUntil = 0
+    }
+    outputChatBox(("[physics-showcase] ring placed %.1fm along reticle"):format(resolvedDistance), 255, 180, 90)
+end
+
+local function segmentHitsSphere(ax, ay, az, bx, by, bz, cx, cy, cz, radius)
+    local abx, aby, abz = bx - ax, by - ay, bz - az
+    local acx, acy, acz = cx - ax, cy - ay, cz - az
+    local lengthSquared = abx * abx + aby * aby + abz * abz
+    local t = 0
+    if lengthSquared > 0.000001 then
+        t = clamp((acx * abx + acy * aby + acz * abz) / lengthSquared, 0, 1)
+    end
+
+    local px = ax + abx * t
+    local py = ay + aby * t
+    local pz = az + abz * t
+    local dx, dy, dz = px - cx, py - cy, pz - cz
+    return dx * dx + dy * dy + dz * dz <= radius * radius
+end
+
+local function segmentHitsRing(ax, ay, az, bx, by, bz, target)
+    local adx, ady, adz = ax - target.x, ay - target.y, az - target.z
+    local bdx, bdy, bdz = bx - target.x, by - target.y, bz - target.z
+    local da = adx * target.nx + ady * target.ny + adz * target.nz
+    local db = bdx * target.nx + bdy * target.ny + bdz * target.nz
+
+    local denominator = da - db
+    local t
+    if math.abs(denominator) > 0.000001 then
+        t = da / denominator
+        if t < 0 or t > 1 then
+            return false
+        end
+    elseif math.abs(db) <= BALL_RADIUS then
+        t = 1
+    else
+        return false
+    end
+
+    local px = ax + (bx - ax) * t - target.x
+    local py = ay + (by - ay) * t - target.y
+    local pz = az + (bz - az) * t - target.z
+    local planeDistance = px * target.nx + py * target.ny + pz * target.nz
+    px, py, pz = px - planeDistance * target.nx, py - planeDistance * target.ny, pz - planeDistance * target.nz
+    local radialSquared = px * px + py * py + pz * pz
+    local hitRadius = RING_RADIUS - BALL_RADIUS * 0.25
+    return radialSquared <= hitRadius * hitRadius
+end
+
+local function updateTargets()
+    if not markerTarget and not ringTarget then
+        return
+    end
+
+    local now = getTickCount()
+    for _, object in ipairs(getElementsByType("object", root, true)) do
+        if getElementData(object, "dynamicPhysicsShowcase") then
+            local x, y, z = getElementPosition(object)
+            local previous = previousBallPositions[object]
+            local ax, ay, az = x, y, z
+            if previous then
+                ax, ay, az = previous[1], previous[2], previous[3]
+            end
+
+            if markerTarget and segmentHitsSphere(ax, ay, az, x, y, z, markerTarget.x, markerTarget.y, markerTarget.z, MARKER_RADIUS + BALL_RADIUS) then
+                markerTarget.hitUntil = now + TARGET_HIT_MS
+            end
+            if ringTarget and segmentHitsRing(ax, ay, az, x, y, z, ringTarget) then
+                ringTarget.hitUntil = now + TARGET_HIT_MS
+            end
+
+            previousBallPositions[object] = { x, y, z }
+        end
+    end
+
+    if markerTarget and isElement(markerTarget.element) then
+        local color = now < markerTarget.hitUntil and TARGET_GREEN or TARGET_ORANGE
+        setMarkerColor(markerTarget.element, color[1], color[2], color[3], 180)
+    end
+end
+
+local function drawRingTarget()
+    if not ringTarget then
+        return
+    end
+
+    local now = getTickCount()
+    local rgb = now < ringTarget.hitUntil and TARGET_GREEN or TARGET_ORANGE
+    local color = tocolor(rgb[1], rgb[2], rgb[3], 230)
+    local firstX, firstY, firstZ
+    local previousX, previousY, previousZ
+
+    for segment = 0, RING_SEGMENTS do
+        local angle = math.pi * 2 * segment / RING_SEGMENTS
+        local c, s = math.cos(angle), math.sin(angle)
+        local x = ringTarget.x + (ringTarget.rx * c + ringTarget.ux * s) * RING_RADIUS
+        local y = ringTarget.y + (ringTarget.ry * c + ringTarget.uy * s) * RING_RADIUS
+        local z = ringTarget.z + (ringTarget.rz * c + ringTarget.uz * s) * RING_RADIUS
+        if previousX then
+            dxDrawLine3D(previousX, previousY, previousZ, x, y, z, color, 4)
+        else
+            firstX, firstY, firstZ = x, y, z
+        end
+        previousX, previousY, previousZ = x, y, z
+    end
+
+    if previousX and firstX then
+        dxDrawLine3D(previousX, previousY, previousZ, firstX, firstY, firstZ, color, 4)
+    end
 end
 
 bindKey("a", "down", function()
@@ -178,6 +387,16 @@ addCommandHandler("showcaseclear", function()
     triggerServerEvent("dynamicPhysicsShowcase:clear", resourceRoot)
 end)
 
+addCommandHandler("showcasemarker", function(_, distance)
+    placeMarkerTarget(tonumber(distance) or 8)
+end)
+
+addCommandHandler("showcasering", function(_, distance)
+    placeRingTarget(tonumber(distance) or 10)
+end)
+
+addCommandHandler("showcasetargetclear", clearTargets)
+
 addEventHandler("onClientResourceStart", resourceRoot, function()
     local collisionReady = installCollision()
     for _, object in ipairs(getElementsByType("object", root, true)) do
@@ -190,7 +409,7 @@ addEventHandler("onClientResourceStart", resourceRoot, function()
         outputChatBox("[physics-showcase] collision setup failed", 255, 100, 100)
     end
 
-    outputChatBox("[physics-showcase] A aim | hold/release E throw | /showcaseclear", 170, 220, 255)
+    outputChatBox("[physics-showcase] A aim | hold/release E throw | /showcasemarker [m] | /showcasering [m]", 170, 220, 255)
 end)
 
 addEventHandler("onClientElementStreamIn", root, function()
@@ -203,13 +422,20 @@ addEventHandler("onClientElementDataChange", root, function(key)
     end
 end)
 
+addEventHandler("onClientElementDestroy", root, function()
+    previousBallPositions[source] = nil
+end)
+
 addEventHandler("onClientRender", root, function()
+    updateTargets()
+    drawRingTarget()
     if aiming then
         drawReticle()
     end
 end)
 
 addEventHandler("onClientResourceStop", resourceRoot, function()
+    clearTargets()
     if isElement(ballCol) then
         destroyElement(ballCol)
     end

--- a/test-resources/dynamic-object-physics-showcase/client.lua
+++ b/test-resources/dynamic-object-physics-showcase/client.lua
@@ -1,0 +1,217 @@
+local BALL_MODEL = 2114
+local BALL_RADIUS = 0.12
+local BALL_MASS = 0.62
+local BALL_TURN_MASS = 0.4 * BALL_MASS * BALL_RADIUS * BALL_RADIUS
+local BALL_AIR_RESISTANCE = 0.995
+local BALL_ELASTICITY = 0.72
+
+local CHARGE_DURATION_MS = 1000
+local RETICLE_MAX_RADIUS = 38
+local RETICLE_MIN_RADIUS = 9
+local RETICLE_SEGMENTS = 40
+local RETICLE_X_RATIO = 0.61
+local RETICLE_Y_RATIO = 0.46
+
+local ballCol = false
+local aiming = false
+local charging = false
+local chargeStart = 0
+local screenW, screenH = guiGetScreenSize()
+
+local function clamp(value, minimum, maximum)
+    return math.max(minimum, math.min(maximum, value))
+end
+
+local function smoothstep(value)
+    value = clamp(value, 0, 1)
+    return value * value * (3 - 2 * value)
+end
+
+local function getChargePower()
+    if not charging then
+        return 0
+    end
+    return smoothstep((getTickCount() - chargeStart) / CHARGE_DURATION_MS)
+end
+
+local function configureBall(object)
+    if not isElement(object) or getElementType(object) ~= "object" or not getElementData(object, "dynamicPhysicsShowcase") then
+        return
+    end
+
+    setObjectProperty(object, "mass", BALL_MASS)
+    setObjectProperty(object, "turn_mass", BALL_TURN_MASS)
+    setObjectProperty(object, "air_resistance", BALL_AIR_RESISTANCE)
+    setObjectProperty(object, "elasticity", BALL_ELASTICITY)
+end
+
+local function installCollision()
+    ballCol = engineLoadCOL({
+        spheres = {
+            {
+                position = { 0, 0, 0 },
+                radius = BALL_RADIUS,
+                material = 1
+            }
+        }
+    })
+
+    if not isElement(ballCol) then
+        outputDebugString("[physics-showcase] engineLoadCOL(table) failed", 1)
+        return false
+    end
+
+    if not engineReplaceCOL(ballCol, BALL_MODEL) then
+        outputDebugString("[physics-showcase] engineReplaceCOL failed for basketball model", 1)
+        destroyElement(ballCol)
+        ballCol = false
+        return false
+    end
+
+    return true
+end
+
+local function getReticlePosition()
+    return screenW * RETICLE_X_RATIO, screenH * RETICLE_Y_RATIO
+end
+
+local function getAimDirection()
+    local reticleX, reticleY = getReticlePosition()
+    local targetX, targetY, targetZ = getWorldFromScreenPosition(reticleX, reticleY, 100)
+    if not targetX then
+        return false
+    end
+
+    local playerX, playerY, playerZ = getElementPosition(localPlayer)
+    local releaseZ = playerZ + 1.25
+    local dx, dy, dz = targetX - playerX, targetY - playerY, targetZ - releaseZ
+    local length = math.sqrt(dx * dx + dy * dy + dz * dz)
+    if length < 0.001 then
+        return false
+    end
+
+    dx, dy, dz = dx / length, dy / length, dz / length
+    local horizontalLength = math.sqrt(dx * dx + dy * dy)
+    if horizontalLength < 0.08 then
+        return false
+    end
+
+    return dx, dy, clamp(dz, -0.75, 0.85)
+end
+
+local function throwBall(power)
+    local dirX, dirY, dirZ = getAimDirection()
+    if not dirX then
+        return
+    end
+
+    triggerServerEvent("dynamicPhysicsShowcase:throw", resourceRoot, dirX, dirY, dirZ, clamp(power, 0, 1))
+end
+
+local function drawCircle(centerX, centerY, radius, color)
+    local previousX, previousY
+    local firstX, firstY
+    for segment = 0, RETICLE_SEGMENTS do
+        local angle = math.pi * 2 * segment / RETICLE_SEGMENTS
+        local x = centerX + math.cos(angle) * radius
+        local y = centerY + math.sin(angle) * radius
+        if previousX then
+            dxDrawLine(previousX, previousY, x, y, color, 2)
+        else
+            firstX, firstY = x, y
+        end
+        previousX, previousY = x, y
+    end
+
+    if previousX and firstX then
+        dxDrawLine(previousX, previousY, firstX, firstY, color, 2)
+    end
+end
+
+local function drawReticle()
+    local power = getChargePower()
+    local radius = RETICLE_MAX_RADIUS - (RETICLE_MAX_RADIUS - RETICLE_MIN_RADIUS) * power
+    local centerX, centerY = getReticlePosition()
+    local color = tocolor(245, 245, 245, 235)
+
+    drawCircle(centerX, centerY, radius, color)
+    dxDrawRectangle(centerX - 1.5, centerY - 1.5, 3, 3, color)
+end
+
+bindKey("a", "down", function()
+    aiming = not aiming
+    charging = false
+end)
+
+bindKey("e", "both", function(_, state)
+    if not aiming then
+        charging = false
+        return
+    end
+
+    if state == "down" then
+        charging = true
+        chargeStart = getTickCount()
+        return
+    end
+
+    if state == "up" and charging then
+        local power = getChargePower()
+        charging = false
+        throwBall(power)
+    end
+end)
+
+addCommandHandler("showcaseaim", function()
+    aiming = not aiming
+    charging = false
+end)
+
+addCommandHandler("showcasethrow", function(_, value)
+    if not aiming then
+        aiming = true
+    end
+    throwBall(clamp(tonumber(value) or 0.7, 0, 1))
+end)
+
+addCommandHandler("showcaseclear", function()
+    triggerServerEvent("dynamicPhysicsShowcase:clear", resourceRoot)
+end)
+
+addEventHandler("onClientResourceStart", resourceRoot, function()
+    local collisionReady = installCollision()
+    for _, object in ipairs(getElementsByType("object", root, true)) do
+        configureBall(object)
+    end
+
+    if collisionReady then
+        triggerServerEvent("dynamicPhysicsShowcase:clientReady", resourceRoot)
+    else
+        outputChatBox("[physics-showcase] collision setup failed", 255, 100, 100)
+    end
+
+    outputChatBox("[physics-showcase] A aim | hold/release E throw | /showcaseclear", 170, 220, 255)
+end)
+
+addEventHandler("onClientElementStreamIn", root, function()
+    configureBall(source)
+end)
+
+addEventHandler("onClientElementDataChange", root, function(key)
+    if key == "dynamicPhysicsShowcase" then
+        configureBall(source)
+    end
+end)
+
+addEventHandler("onClientRender", root, function()
+    if aiming then
+        drawReticle()
+    end
+end)
+
+addEventHandler("onClientResourceStop", resourceRoot, function()
+    if isElement(ballCol) then
+        destroyElement(ballCol)
+    end
+    ballCol = false
+end)

--- a/test-resources/dynamic-object-physics-showcase/meta.xml
+++ b/test-resources/dynamic-object-physics-showcase/meta.xml
@@ -1,0 +1,5 @@
+<meta>
+    <info author="MTA Neon" name="Dynamic object physics showcase" type="script" version="1.0" />
+    <script src="server.lua" type="server" />
+    <script src="client.lua" type="client" cache="false" />
+</meta>

--- a/test-resources/dynamic-object-physics-showcase/server.lua
+++ b/test-resources/dynamic-object-physics-showcase/server.lua
@@ -7,6 +7,9 @@ local SHOT_LIFT_MIN = 0.025
 local SHOT_LIFT_MAX = 0.085
 local SHOT_SPIN_MIN = 0.08
 local SHOT_SPIN_MAX = 0.18
+local RELEASE_FORWARD_OFFSET = 0.72
+local RELEASE_RIGHT_OFFSET = 0.38
+local RELEASE_HEIGHT = 1.25
 
 local readyPlayers = {}
 local playerBalls = {}
@@ -85,10 +88,11 @@ local function createThrownBall(player, dirX, dirY, dirZ, power)
     end
 
     local horizontalX, horizontalY = dirX / horizontalLength, dirY / horizontalLength
+    local rightX, rightY = horizontalY, -horizontalX
     local playerX, playerY, playerZ = getElementPosition(player)
-    local releaseX = playerX + horizontalX * 0.72
-    local releaseY = playerY + horizontalY * 0.72
-    local releaseZ = playerZ + 1.25
+    local releaseX = playerX + horizontalX * RELEASE_FORWARD_OFFSET + rightX * RELEASE_RIGHT_OFFSET
+    local releaseY = playerY + horizontalY * RELEASE_FORWARD_OFFSET + rightY * RELEASE_RIGHT_OFFSET
+    local releaseZ = playerZ + RELEASE_HEIGHT
 
     local object = createObject(BALL_MODEL, releaseX, releaseY, releaseZ)
     if not object then

--- a/test-resources/dynamic-object-physics-showcase/server.lua
+++ b/test-resources/dynamic-object-physics-showcase/server.lua
@@ -1,0 +1,171 @@
+local BALL_MODEL = 2114
+local MAX_BALLS_PER_PLAYER = 150
+
+local SHOT_SPEED_MIN = 0.10
+local SHOT_SPEED_MAX = 0.26
+local SHOT_LIFT_MIN = 0.025
+local SHOT_LIFT_MAX = 0.085
+local SHOT_SPIN_MIN = 0.08
+local SHOT_SPIN_MAX = 0.18
+
+local readyPlayers = {}
+local playerBalls = {}
+
+local function clamp(value, minimum, maximum)
+    return math.max(minimum, math.min(maximum, value))
+end
+
+local function finiteNumber(value)
+    value = tonumber(value)
+    if not value or value ~= value or value == math.huge or value == -math.huge then
+        return false
+    end
+    return value
+end
+
+local function getBallList(player)
+    local list = playerBalls[player]
+    if not list then
+        list = {}
+        playerBalls[player] = list
+    end
+    return list
+end
+
+local function pruneBallList(player)
+    local list = getBallList(player)
+    local compact = {}
+    for _, object in ipairs(list) do
+        if isElement(object) then
+            compact[#compact + 1] = object
+        end
+    end
+    playerBalls[player] = compact
+    return compact
+end
+
+local function clearPlayerBalls(player)
+    local list = playerBalls[player]
+    if not list then
+        return 0
+    end
+
+    local count = 0
+    for _, object in ipairs(list) do
+        if isElement(object) then
+            destroyElement(object)
+            count = count + 1
+        end
+    end
+    playerBalls[player] = {}
+    return count
+end
+
+local function createThrownBall(player, dirX, dirY, dirZ, power)
+    if not readyPlayers[player] then
+        return false
+    end
+
+    dirX, dirY, dirZ, power = finiteNumber(dirX), finiteNumber(dirY), finiteNumber(dirZ), finiteNumber(power)
+    if not dirX or not dirY or not dirZ or not power then
+        return false
+    end
+
+    local length = math.sqrt(dirX * dirX + dirY * dirY + dirZ * dirZ)
+    if length < 0.5 or length > 1.5 then
+        return false
+    end
+
+    dirX, dirY, dirZ = dirX / length, dirY / length, dirZ / length
+    power = clamp(power, 0, 1)
+
+    local horizontalLength = math.sqrt(dirX * dirX + dirY * dirY)
+    if horizontalLength < 0.08 then
+        return false
+    end
+
+    local horizontalX, horizontalY = dirX / horizontalLength, dirY / horizontalLength
+    local playerX, playerY, playerZ = getElementPosition(player)
+    local releaseX = playerX + horizontalX * 0.72
+    local releaseY = playerY + horizontalY * 0.72
+    local releaseZ = playerZ + 1.25
+
+    local object = createObject(BALL_MODEL, releaseX, releaseY, releaseZ)
+    if not object then
+        return false
+    end
+
+    setElementInterior(object, getElementInterior(player))
+    setElementDimension(object, getElementDimension(player))
+    setElementData(object, "dynamicPhysicsShowcase", true)
+    setElementData(object, "dynamicPhysicsShowcase:owner", player)
+    setElementCollisionsEnabled(object, true)
+    setElementFrozen(object, false)
+
+    if not setObjectDynamicPhysics(object, true) then
+        destroyElement(object)
+        return false
+    end
+
+    local speed = SHOT_SPEED_MIN + (SHOT_SPEED_MAX - SHOT_SPEED_MIN) * power
+    local lift = SHOT_LIFT_MIN + (SHOT_LIFT_MAX - SHOT_LIFT_MIN) * power
+    local spin = SHOT_SPIN_MIN + (SHOT_SPIN_MAX - SHOT_SPIN_MIN) * power
+
+    setElementVelocity(object, dirX * speed, dirY * speed, dirZ * speed + lift)
+    setElementAngularVelocity(object, -horizontalY * spin, horizontalX * spin, 0)
+
+    local list = pruneBallList(player)
+    list[#list + 1] = object
+    while #list > MAX_BALLS_PER_PLAYER do
+        local oldest = table.remove(list, 1)
+        if isElement(oldest) then
+            destroyElement(oldest)
+        end
+    end
+
+    return true
+end
+
+addEvent("dynamicPhysicsShowcase:clientReady", true)
+addEventHandler("dynamicPhysicsShowcase:clientReady", resourceRoot, function()
+    if client and isElement(client) then
+        readyPlayers[client] = true
+    end
+end)
+
+addEvent("dynamicPhysicsShowcase:throw", true)
+addEventHandler("dynamicPhysicsShowcase:throw", resourceRoot, function(dirX, dirY, dirZ, power)
+    if client and isElement(client) then
+        createThrownBall(client, dirX, dirY, dirZ, power)
+    end
+end)
+
+addEvent("dynamicPhysicsShowcase:clear", true)
+addEventHandler("dynamicPhysicsShowcase:clear", resourceRoot, function()
+    if client and isElement(client) then
+        local count = clearPlayerBalls(client)
+        outputChatBox("[physics-showcase] cleared " .. count .. " balls", client, 170, 220, 255)
+    end
+end)
+
+addCommandHandler("showcaseclearall", function(player)
+    local count = 0
+    for owner in pairs(playerBalls) do
+        count = count + clearPlayerBalls(owner)
+    end
+    outputChatBox("[physics-showcase] cleared " .. count .. " balls", player, 170, 220, 255)
+end)
+
+addEventHandler("onPlayerQuit", root, function()
+    clearPlayerBalls(source)
+    playerBalls[source] = nil
+    readyPlayers[source] = nil
+end)
+
+addEventHandler("onResourceStop", resourceRoot, function()
+    for player in pairs(playerBalls) do
+        clearPlayerBalls(player)
+    end
+    playerBalls = {}
+    readyPlayers = {}
+end)


### PR DESCRIPTION
## What changed

- add a clean `dynamic-object-physics-showcase` resource for recording the generic dynamic-object physics feature
- use the stock basketball model with the validated runtime sphere collision and physical properties
- keep GTA's normal third-person mouse-look and place the reticle at an over-the-shoulder screen position
- convert the exact reticle screen position to a world-space throw direction with `getWorldFromScreenPosition`
- shrink the reticle while charging and spawn a new dynamic basketball on every release
- keep up to 150 balls per player so repeated throws remain visible in the scene
- provide clear commands without the harness velocity overlay or XYZ collision gizmo

## Controls

- `A`: toggle aim
- hold/release `E`: charge and throw
- `/showcasethrow [0..1]`: immediate fixed-power throw
- `/showcaseclear`: clear your balls
- `/showcaseclearall`: clear all showcase balls

## Scope

This is presentation/test content only. It does not add basketball gameplay, hoop logic, scoring, aim assistance, or new core physics behavior.