### PR TITLE
feat(ropes): add managed scriptable rope API

### DIFF
--- a/Client/game_sa/CRopesSA.cpp
+++ b/Client/game_sa/CRopesSA.cpp
@@ -44,7 +44,17 @@ bool CRopesSA::RegisterRope(std::uint32_t uiId, eRopeType type, const CVector& v
 {
     using RegisterFn = bool(__cdecl*)(std::uint32_t, std::uint32_t, CVector, bool, std::uint8_t, std::uint8_t, CEntitySAInterface*, std::uint32_t);
     auto fn = reinterpret_cast<RegisterFn>(FUNC_CRopes_RegisterRope);
-    return fn(uiId, static_cast<std::uint32_t>(type), vecPosition, bExpires, ucFixedNode, bSitOnGround ? 1u : 0u, pHolder, uiLifetime);
+    if (!fn(uiId, static_cast<std::uint32_t>(type), vecPosition, bExpires, ucFixedNode, bSitOnGround ? 1u : 0u, pHolder, uiLifetime))
+        return false;
+
+    // Managed ropes use an explicit attachElementToRope contract. Several stock
+    // winch types otherwise scan nearby world entities and pick them up on their
+    // own. GTA's byte at 0x326 is the native pickup cooldown; refreshing it on
+    // every managed registration keeps autonomous pickup disabled while an
+    // explicitly carried entity still follows the normal carried-object path.
+    if (CRopesSAInterface* pRope = GetRope(uiId))
+        pRope->m_ucWinchDisabled = 0xFF;
+    return true;
 }
 
 CRopesSAInterface* CRopesSA::GetRope(std::uint32_t uiId)
@@ -84,7 +94,7 @@ void CRopesSA::RemoveEntityRope(CEntitySAInterface* pEntity)
     // Stock crane/object ropes use the holder pointer itself as their opaque ID.
     // Preserve that legacy cleanup behavior without assuming that every rope ID
     // is an entity pointer (managed ropes intentionally use generated IDs).
-    const std::uint32_t entityId = reinterpret_cast<std::uint32_t>(pEntity);
+    const std::uint32_t entityId = static_cast<std::uint32_t>(reinterpret_cast<std::uintptr_t>(pEntity));
     RemoveRope(entityId);
 }
 

--- a/Client/game_sa/CRopesSA.cpp
+++ b/Client/game_sa/CRopesSA.cpp
@@ -12,9 +12,11 @@
 #include "StdInc.h"
 #include "CRopesSA.h"
 
-DWORD dwDurationAddress = 0x558D1El;
+#include <algorithm>
 
-CRopesSAInterface (&CRopesSA::ms_aRopes)[8] = *(CRopesSAInterface (*)[8])0xB768B8;
+DWORD dwDurationAddress = 0x558D1E;
+
+CRopesSAInterface (&CRopesSA::ms_aRopes)[ROPES_COUNT] = *(CRopesSAInterface(*)[ROPES_COUNT])0xB768B8;
 
 int CRopesSA::CreateRopeForSwatPed(const CVector& vecPosition, DWORD dwDuration)
 {
@@ -32,27 +34,164 @@ int CRopesSA::CreateRopeForSwatPed(const CVector& vecPosition, DWORD dwDuration)
         mov     iReturn, eax
     }
     // clang-format on
-    //   Set it back for SA in case we ever do some other implementation.
+    // Set it back for SA in case we ever do some other implementation.
     MemPut((DWORD*)(dwDurationAddress), 4000);
     return iReturn;
 }
 
+bool CRopesSA::RegisterRope(std::uint32_t uiId, eRopeType type, const CVector& vecPosition, bool bExpires, std::uint8_t ucFixedNode,
+                            bool bSitOnGround, CEntitySAInterface* pHolder, std::uint32_t uiLifetime)
+{
+    using RegisterFn = bool(__cdecl*)(std::uint32_t, std::uint32_t, CVector, bool, std::uint8_t, std::uint8_t, CEntitySAInterface*, std::uint32_t);
+    auto fn = reinterpret_cast<RegisterFn>(FUNC_CRopes_RegisterRope);
+    return fn(uiId, static_cast<std::uint32_t>(type), vecPosition, bExpires, ucFixedNode, bSitOnGround ? 1u : 0u, pHolder, uiLifetime);
+}
+
+CRopesSAInterface* CRopesSA::GetRope(std::uint32_t uiId)
+{
+    const int index = FindRope(uiId);
+    return index >= 0 && index < ROPES_COUNT ? &ms_aRopes[index] : nullptr;
+}
+
+const CRopesSAInterface* CRopesSA::GetRope(std::uint32_t uiId) const
+{
+    const int index = FindRope(uiId);
+    return index >= 0 && index < ROPES_COUNT ? &ms_aRopes[index] : nullptr;
+}
+
+int CRopesSA::FindRope(std::uint32_t uiId) const
+{
+    using FindFn = int(__cdecl*)(std::uint32_t);
+    return reinterpret_cast<FindFn>(FUNC_CRopes_FindRope)(uiId);
+}
+
+bool CRopesSA::RemoveRope(std::uint32_t uiId)
+{
+    CRopesSAInterface* pRope = GetRope(uiId);
+    if (!pRope)
+        return false;
+
+    using RemoveFn = void(__thiscall*)(CRopesSAInterface*);
+    reinterpret_cast<RemoveFn>(FUNC_CRope_Remove)(pRope);
+    return true;
+}
+
 void CRopesSA::RemoveEntityRope(CEntitySAInterface* pEntity)
 {
-    CRopesSAInterface* pRope = nullptr;
+    if (!pEntity)
+        return;
 
-    for (uint i = 0; i < ROPES_COUNT; i++)
-    {
-        if (ms_aRopes[i].m_pRopeEntity == pEntity)
-        {
-            pRope = &ms_aRopes[i];
-            break;
-        }
-    }
+    // Stock crane/object ropes use the holder pointer itself as their opaque ID.
+    // Preserve that legacy cleanup behavior without assuming that every rope ID
+    // is an entity pointer (managed ropes intentionally use generated IDs).
+    const std::uint32_t entityId = reinterpret_cast<std::uint32_t>(pEntity);
+    RemoveRope(entityId);
+}
 
-    if (pRope)
+bool CRopesSA::FindCoorsAlongRope(std::uint32_t uiId, float fProgress, CVector& vecPosition, CVector* pVelocity) const
+{
+    using FindCoorsFn = bool(__cdecl*)(std::uint32_t, float, CVector*, CVector*);
+    return reinterpret_cast<FindCoorsFn>(FUNC_CRopes_FindCoorsAlongRope)(uiId, std::clamp(fProgress, 0.0f, 1.0f), &vecPosition, pVelocity);
+}
+
+bool CRopesSA::SetSpeedOfTopNode(std::uint32_t uiId, const CVector& vecVelocity)
+{
+    if (!GetRope(uiId))
+        return false;
+
+    using SetSpeedFn = void(__cdecl*)(std::uint32_t, CVector);
+    reinterpret_cast<SetSpeedFn>(FUNC_CRopes_SetSpeedOfTopNode)(uiId, vecVelocity);
+    return true;
+}
+
+bool CRopesSA::GetWinchHeight(std::uint32_t uiId, float& fHeight) const
+{
+    const CRopesSAInterface* pRope = GetRope(uiId);
+    if (!pRope)
+        return false;
+    fHeight = pRope->m_fWinchHeight;
+    return true;
+}
+
+bool CRopesSA::SetWinchHeight(std::uint32_t uiId, float fHeight)
+{
+    CRopesSAInterface* pRope = GetRope(uiId);
+    if (!pRope || fHeight < 0.01f)
+        return false;
+    pRope->m_fWinchHeight = fHeight;
+    return true;
+}
+
+bool CRopesSA::GetRopeLength(std::uint32_t uiId, float& fLength) const
+{
+    const CRopesSAInterface* pRope = GetRope(uiId);
+    if (!pRope)
+        return false;
+
+    const unsigned int nodeCount = std::max(1u, 31u - static_cast<unsigned int>(std::min<std::uint8_t>(pRope->m_ucFixedNode, 30u)));
+    fLength = pRope->m_fNativeSegmentLength * static_cast<float>(nodeCount);
+    return true;
+}
+
+bool CRopesSA::SetRopeLength(std::uint32_t uiId, float fLength)
+{
+    CRopesSAInterface* pRope = GetRope(uiId);
+    if (!pRope || fLength <= 0.0f)
+        return false;
+
+    const unsigned int nodeCount = std::max(1u, 31u - static_cast<unsigned int>(std::min<std::uint8_t>(pRope->m_ucFixedNode, 30u)));
+    pRope->m_fNativeSegmentLength = fLength / static_cast<float>(nodeCount);
+    return true;
+}
+
+bool CRopesSA::PickUpEntity(std::uint32_t uiId, CEntitySAInterface* pEntity)
+{
+    CRopesSAInterface* pRope = GetRope(uiId);
+    if (!pRope || !pEntity || !pRope->m_pHookObject)
+        return false;
+
+    using PickUpFn = void(__thiscall*)(CRopesSAInterface*, CEntitySAInterface*);
+    reinterpret_cast<PickUpFn>(FUNC_CRope_PickUpObject)(pRope, pEntity);
+    return pRope->m_pCarriedEntity == pEntity;
+}
+
+bool CRopesSA::ReleasePickedUpEntity(std::uint32_t uiId)
+{
+    CRopesSAInterface* pRope = GetRope(uiId);
+    if (!pRope)
+        return false;
+    if (!pRope->m_pCarriedEntity)
+        return true;
+
+    using ReleaseFn = void(__thiscall*)(CRopesSAInterface*);
+    reinterpret_cast<ReleaseFn>(FUNC_CRope_ReleasePickedUpObject)(pRope);
+    return pRope->m_pCarriedEntity == nullptr;
+}
+
+CEntitySAInterface* CRopesSA::GetPickedUpEntity(std::uint32_t uiId) const
+{
+    const CRopesSAInterface* pRope = GetRope(uiId);
+    return pRope ? pRope->m_pCarriedEntity : nullptr;
+}
+
+bool CRopesSA::GetNode(std::uint32_t uiId, std::uint8_t ucNode, CVector& vecPosition, CVector& vecVelocity) const
+{
+    const CRopesSAInterface* pRope = GetRope(uiId);
+    if (!pRope || ucNode >= 32)
+        return false;
+
+    vecPosition = pRope->m_vecNodes[ucNode];
+    vecVelocity = pRope->m_vecNodeSpeeds[ucNode];
+    return true;
+}
+
+unsigned int CRopesSA::GetFreeRopeCount() const
+{
+    unsigned int count = 0;
+    for (const CRopesSAInterface& rope : ms_aRopes)
     {
-        auto CRope_Remove = (void(__thiscall*)(CRopesSAInterface*))0x556780;
-        CRope_Remove(pRope);
+        if (rope.m_ucRopeType == static_cast<std::uint8_t>(eRopeType::NONE))
+            ++count;
     }
+    return count;
 }

--- a/Client/game_sa/CRopesSA.h
+++ b/Client/game_sa/CRopesSA.h
@@ -13,38 +13,84 @@
 
 #include <CVector.h>
 #include <game/CRopes.h>
+#include <cstddef>
+#include <cstdint>
 
 #define ROPES_COUNT 8
 
-#define FUNC_CRopes_CreateRopeForSwatPed 0x558d10
+#define FUNC_CRopes_CreateRopeForSwatPed 0x558D10
+#define FUNC_CRopes_FindCoorsAlongRope   0x555E40
+#define FUNC_CRopes_SetSpeedOfTopNode    0x555DF0
+#define FUNC_CRopes_FindRope             0x556000
+#define FUNC_CRope_ReleasePickedUpObject 0x556030
+#define FUNC_CRope_Remove                0x556780
+#define FUNC_CRope_PickUpObject          0x5569C0
+#define FUNC_CRopes_RegisterRope         0x556B40
 
 class CRopesSAInterface
 {
 public:
-    CVector             m_vecSegments[32];
-    CVector             m_vecSegmentsReleased[32];
-    CEntitySAInterface* m_pRopeEntity;
-    float               m_pad4;
-    float               m_fMass;
-    float               m_fSegmentLength;
-    CEntitySAInterface* m_pRopeHolder;
-    CEntitySAInterface* m_pRopeAttacherObject;
-    CEntitySAInterface* m_pAttachedEntity;
-    float               m_pad5;
-    uint32              m_uiHoldEntityExpireTime;
-    uint8               m_ucSegmentCount;
-    uint8               m_ucRopeType;
-    uint8               m_ucFlags1;
-    uint8               m_ucFlags2;
+    // The Android symbols and gta-reversed both establish the 0x328 layout.
+    // Older MTA names treated the second array and the ID as unrelated fields,
+    // which made generic rope scripting unsafe even though the byte layout was right.
+    CVector m_vecNodes[32];
+    CVector m_vecNodeSpeeds[32];
+
+    std::uint32_t m_uiId;
+    float         m_fGroundHeight;
+    float         m_fMassOrRopeLength;
+    float         m_fNativeSegmentLength;
+
+    CEntitySAInterface* m_pHolder;
+    CEntitySAInterface* m_pHookObject;
+    CEntitySAInterface* m_pCarriedEntity;
+
+    float         m_fWinchHeight;
+    std::uint32_t m_uiKeepAliveUntil;
+    std::uint8_t  m_ucFixedNode;
+    std::uint8_t  m_ucRopeType;
+    std::uint8_t  m_ucWinchDisabled;
+    std::uint8_t  m_ucFlags;
 };
 static_assert(sizeof(CRopesSAInterface) == 0x328, "Invalid size for CRopesSAInterface");
+static_assert(offsetof(CRopesSAInterface, m_vecNodeSpeeds) == 0x180, "Invalid rope speed offset");
+static_assert(offsetof(CRopesSAInterface, m_uiId) == 0x300, "Invalid rope ID offset");
+static_assert(offsetof(CRopesSAInterface, m_pHolder) == 0x310, "Invalid rope holder offset");
+static_assert(offsetof(CRopesSAInterface, m_pHookObject) == 0x314, "Invalid rope hook offset");
+static_assert(offsetof(CRopesSAInterface, m_pCarriedEntity) == 0x318, "Invalid carried entity offset");
+static_assert(offsetof(CRopesSAInterface, m_fWinchHeight) == 0x31C, "Invalid winch-height offset");
+static_assert(offsetof(CRopesSAInterface, m_ucFixedNode) == 0x324, "Invalid fixed-node offset");
+static_assert(offsetof(CRopesSAInterface, m_ucRopeType) == 0x325, "Invalid rope-type offset");
 
 class CRopesSA : public CRopes
 {
 public:
-    int  CreateRopeForSwatPed(const CVector& vecPosition, DWORD dwDuration = 4000);
-    void RemoveEntityRope(CEntitySAInterface* pObject);
+    int CreateRopeForSwatPed(const CVector& vecPosition, DWORD dwDuration = 4000) override;
+
+    bool RegisterRope(std::uint32_t uiId, eRopeType type, const CVector& vecPosition, bool bExpires, std::uint8_t ucFixedNode, bool bSitOnGround,
+                      CEntitySAInterface* pHolder, std::uint32_t uiLifetime) override;
+    bool RemoveRope(std::uint32_t uiId) override;
+    void RemoveEntityRope(CEntitySAInterface* pObject) override;
+
+    int  FindRope(std::uint32_t uiId) const override;
+    bool FindCoorsAlongRope(std::uint32_t uiId, float fProgress, CVector& vecPosition, CVector* pVelocity = nullptr) const override;
+    bool SetSpeedOfTopNode(std::uint32_t uiId, const CVector& vecVelocity) override;
+
+    bool GetWinchHeight(std::uint32_t uiId, float& fHeight) const override;
+    bool SetWinchHeight(std::uint32_t uiId, float fHeight) override;
+    bool GetRopeLength(std::uint32_t uiId, float& fLength) const override;
+    bool SetRopeLength(std::uint32_t uiId, float fLength) override;
+
+    bool PickUpEntity(std::uint32_t uiId, CEntitySAInterface* pEntity) override;
+    bool ReleasePickedUpEntity(std::uint32_t uiId) override;
+    CEntitySAInterface* GetPickedUpEntity(std::uint32_t uiId) const override;
+
+    bool GetNode(std::uint32_t uiId, std::uint8_t ucNode, CVector& vecPosition, CVector& vecVelocity) const override;
+    unsigned int GetFreeRopeCount() const override;
 
 private:
-    static CRopesSAInterface (&ms_aRopes)[8];
+    CRopesSAInterface* GetRope(std::uint32_t uiId);
+    const CRopesSAInterface* GetRope(std::uint32_t uiId) const;
+
+    static CRopesSAInterface (&ms_aRopes)[ROPES_COUNT];
 };

--- a/Client/mods/deathmatch/logic/CClientDummy.cpp
+++ b/Client/mods/deathmatch/logic/CClientDummy.cpp
@@ -10,6 +10,7 @@
 
 #include "StdInc.h"
 #include "CClientFireManager.h"
+#include "CClientRopeManager.h"
 
 CClientDummy::CClientDummy(CClientManager* pManager, ElementID ID, const char* szTypeName) : ClassInit(this), CClientEntity(ID)
 {
@@ -27,6 +28,8 @@ CClientDummy::CClientDummy(CClientManager* pManager, ElementID ID, const char* s
 
         if (pManager->GetFireManager() && GetTypeName() == "fire")
             pManager->GetFireManager()->Register(this);
+        else if (GetTypeName() == "rope")
+            CClientRopeManager::GetSingleton().Register(this);
     }
     else
     {
@@ -43,6 +46,8 @@ void CClientDummy::Unlink()
 {
     if (m_pManager && m_pManager->GetFireManager() && GetTypeName() == "fire")
         m_pManager->GetFireManager()->Unregister(this);
+    else if (GetTypeName() == "rope")
+        CClientRopeManager::GetSingleton().Unregister(this);
 
     if (m_pGroups)
     {

--- a/Client/mods/deathmatch/logic/CClientFireManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientFireManager.cpp
@@ -8,6 +8,7 @@
 
 #include "StdInc.h"
 #include "CClientFireManager.h"
+#include "CClientRopeManager.h"
 #include "CClientDummy.h"
 #include "CClientManager.h"
 #include <game/CFxManager.h>
@@ -312,6 +313,11 @@ void CClientFireManager::ProcessEntry(SFireEntry& entry, std::vector<CClientDumm
 
 void CClientFireManager::DoPulse()
 {
+    // Fire already owns an unconditional standard client pulse. Reuse that
+    // heartbeat for managed ropes so the rope subsystem does not need a second
+    // manager ownership chain or a frame hook of its own.
+    CClientRopeManager::GetSingleton().DoPulse(m_pManager);
+
     std::vector<CClientDummy*> expiredLocalFires;
 
     for (auto& fire : m_Fires)

--- a/Client/mods/deathmatch/logic/CClientRopeManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientRopeManager.cpp
@@ -72,8 +72,9 @@ CClientRopeManager::CClientRopeManager(CClientManager* pManager) : m_pManager(pM
 
 CClientRopeManager::~CClientRopeManager()
 {
-    for (auto& rope : m_Ropes)
-        ReleaseLease(rope);
+    // Resource/entity teardown unregisters every rope while the game layer is
+    // still alive. Do not touch GTA from this process-static destructor: the
+    // singleton may be destroyed after g_pGame and its pools are already gone.
     m_Ropes.clear();
 }
 
@@ -118,13 +119,14 @@ const CClientRopeManager::SRopeEntry* CClientRopeManager::FindEntry(const CClien
 bool CClientRopeManager::IsActive(const CClientEntity* pElement) const
 {
     const SRopeEntry* pEntry = FindEntry(pElement);
-    return pEntry && pEntry->bLeased && g_pGame->GetRopes()->FindRope(pEntry->uiNativeId) >= 0;
+    return pEntry && pEntry->bLeased && g_pGame && g_pGame->GetRopes() && g_pGame->GetRopes()->FindRope(pEntry->uiNativeId) >= 0;
 }
 
 bool CClientRopeManager::GetPositionAt(const CClientEntity* pElement, float fProgress, CVector& vecPosition, CVector* pVelocity) const
 {
     const SRopeEntry* pEntry = FindEntry(pElement);
-    return pEntry && pEntry->bLeased && g_pGame->GetRopes()->FindCoorsAlongRope(pEntry->uiNativeId, fProgress, vecPosition, pVelocity);
+    return pEntry && pEntry->bLeased && g_pGame && g_pGame->GetRopes() &&
+           g_pGame->GetRopes()->FindCoorsAlongRope(pEntry->uiNativeId, fProgress, vecPosition, pVelocity);
 }
 
 bool CClientRopeManager::ResolveAnchor(CClientDummy* pRope, CVector& vecAnchor, CClientEntity*& pHolder) const
@@ -151,7 +153,7 @@ bool CClientRopeManager::ResolveAnchor(CClientDummy* pRope, CVector& vecAnchor, 
 
     CMatrix matrix;
     if (pHolder->GetMatrix(matrix))
-        offset = matrix.TransformVector(offset);
+        offset = matrix.TransformVectorByRotation(offset);
 
     vecAnchor = CVector(holderPosition.fX + offset.fX, holderPosition.fY + offset.fY, holderPosition.fZ + offset.fZ);
     return true;
@@ -329,11 +331,11 @@ void CClientRopeManager::DoPulse()
 
     struct SCandidate
     {
-        SRopeEntry* pEntry{};
-        CVector     anchor;
+        SRopeEntry*    pEntry{};
+        CVector        anchor;
         CClientEntity* pHolder{};
-        float       distanceSq{};
-        bool        physicsCritical{};
+        float          distanceSq{};
+        bool           physicsCritical{};
     };
 
     std::vector<SCandidate> candidates;

--- a/Client/mods/deathmatch/logic/CClientRopeManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientRopeManager.cpp
@@ -222,14 +222,19 @@ bool CClientRopeManager::UpdateNative(SRopeEntry& entry, const CVector& vecAncho
     GetBool(pRope, KEY_SIT_ON_GROUND, sitOnGround);
     GetBool(pRope, KEY_PHYSICS, physics);
 
-    // A non-syncer may still render and simulate a rope, but it must not give GTA
-    // a physical holder pointer because CRope::Update applies reaction forces to it.
+    // GTA's winch/crane rope types (1..7) unconditionally dereference
+    // m_pRopeHolder in CRope::Update once the solver reaches its weight pass.
+    // Never register those types with a null or non-authoritative holder. SWAT
+    // is the only stock rope type that is safe as a free world-anchored rope.
     CEntitySAInterface* pNativeHolder = nullptr;
     if (physics && pHolder && ShouldOwnPhysics(pHolder))
     {
         CEntity* pGameEntity = pHolder->GetGameEntity();
         pNativeHolder = pGameEntity ? pGameEntity->GetInterface() : nullptr;
     }
+
+    if (ropeType != eRopeType::SWAT && !pNativeHolder)
+        return false;
 
     if (!g_pGame->GetRopes()->RegisterRope(entry.uiNativeId, ropeType, vecAnchor, false, fixedNode, sitOnGround, pNativeHolder, 20000))
         return false;
@@ -247,7 +252,7 @@ bool CClientRopeManager::UpdateNative(SRopeEntry& entry, const CVector& vecAncho
 
     CClientEntity* pCarried = GetElement(pRope, KEY_CARRIED);
     const bool carriedTypeAllowed = pCarried && (pCarried->GetType() == CCLIENTOBJECT || pCarried->GetType() == CCLIENTVEHICLE);
-    const bool canOwnCarried = physics && carriedTypeAllowed && ShouldOwnPhysics(pCarried) && (!pHolder || ShouldOwnPhysics(pHolder));
+    const bool canOwnCarried = ropeType != eRopeType::SWAT && physics && carriedTypeAllowed && ShouldOwnPhysics(pCarried) && pNativeHolder;
 
     CEntitySAInterface* pNativeCarried = nullptr;
     if (canOwnCarried)
@@ -379,7 +384,7 @@ void CClientRopeManager::DoPulse()
         bool physics = true;
         GetBool(pRope, KEY_PHYSICS, physics);
         CClientEntity* pCarried = GetElement(pRope, KEY_CARRIED);
-        const bool physicsCritical = physics && pCarried && ShouldOwnPhysics(pCarried) && (!pHolder || ShouldOwnPhysics(pHolder));
+        const bool physicsCritical = physics && pCarried && ShouldOwnPhysics(pCarried) && pHolder && ShouldOwnPhysics(pHolder);
 
         if (!contextMatches || (!physicsCritical && distanceSq > RELEASE_DISTANCE * RELEASE_DISTANCE))
         {
@@ -428,7 +433,7 @@ void CClientRopeManager::DoPulse()
                 GetBool(leased.pElement, KEY_PHYSICS, leasedPhysics);
                 CClientEntity* leasedCarried = GetElement(leased.pElement, KEY_CARRIED);
                 const bool leasedCritical = leasedPhysics && leasedCarried && ShouldOwnPhysics(leasedCarried) &&
-                                            (!leasedHolder || ShouldOwnPhysics(leasedHolder));
+                                            leasedHolder && ShouldOwnPhysics(leasedHolder);
                 if (leasedCritical)
                     continue;
 

--- a/Client/mods/deathmatch/logic/CClientRopeManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientRopeManager.cpp
@@ -1,0 +1,417 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  PURPOSE:     Managed rope presentation and native-slot leasing
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+#include "CClientRopeManager.h"
+#include "CClientDummy.h"
+#include "CClientManager.h"
+#include "CDeathmatchObject.h"
+#include "CDeathmatchVehicle.h"
+#include "CStaticFunctionDefinitions.h"
+#ifdef WITH_OBJECT_SYNC
+    #include "CObjectSync.h"
+#endif
+#include <game/CRopes.h>
+
+#include <algorithm>
+#include <cmath>
+
+namespace
+{
+constexpr float ACQUIRE_DISTANCE = 170.0f;
+constexpr float RELEASE_DISTANCE = 210.0f;
+
+bool GetNumber(CClientEntity* pElement, const char* szKey, double& dValue)
+{
+    CLuaArgument* pArgument = pElement ? pElement->GetCustomData(szKey, false) : nullptr;
+    if (!pArgument || pArgument->GetType() != LUA_TNUMBER)
+        return false;
+    dValue = pArgument->GetNumber();
+    return true;
+}
+
+bool GetBool(CClientEntity* pElement, const char* szKey, bool& bValue)
+{
+    CLuaArgument* pArgument = pElement ? pElement->GetCustomData(szKey, false) : nullptr;
+    if (!pArgument || pArgument->GetType() != LUA_TBOOLEAN)
+        return false;
+    bValue = pArgument->GetBoolean();
+    return true;
+}
+
+CClientEntity* GetElement(CClientEntity* pElement, const char* szKey)
+{
+    CLuaArgument* pArgument = pElement ? pElement->GetCustomData(szKey, false) : nullptr;
+    return pArgument ? pArgument->GetElement() : nullptr;
+}
+
+void SetLocalNumber(CClientEntity* pElement, const char* szKey, double dValue)
+{
+    CLuaArgument argument;
+    argument.ReadNumber(dValue);
+    pElement->SetCustomData(szKey, argument, false);
+}
+
+float DistanceSquared(const CVector& a, const CVector& b)
+{
+    const float x = a.fX - b.fX;
+    const float y = a.fY - b.fY;
+    const float z = a.fZ - b.fZ;
+    return x * x + y * y + z * z;
+}
+}  // namespace
+
+CClientRopeManager::CClientRopeManager(CClientManager* pManager) : m_pManager(pManager)
+{
+}
+
+CClientRopeManager::~CClientRopeManager()
+{
+    for (auto& rope : m_Ropes)
+        ReleaseLease(rope);
+    m_Ropes.clear();
+}
+
+bool CClientRopeManager::IsRopeElement(const CClientEntity* pElement)
+{
+    return pElement && pElement->GetType() == CCLIENTDUMMY && const_cast<CClientEntity*>(pElement)->GetTypeName() == "rope";
+}
+
+void CClientRopeManager::Register(CClientDummy* pRope)
+{
+    if (!pRope || !IsRopeElement(pRope) || FindEntry(pRope))
+        return;
+
+    SRopeEntry entry;
+    entry.pElement = pRope;
+    entry.ullLastPulse = GetTickCount64_();
+    m_Ropes.push_back(entry);
+}
+
+void CClientRopeManager::Unregister(CClientDummy* pRope)
+{
+    auto iter = std::find_if(m_Ropes.begin(), m_Ropes.end(), [pRope](const SRopeEntry& entry) { return entry.pElement == pRope; });
+    if (iter == m_Ropes.end())
+        return;
+
+    ReleaseLease(*iter);
+    m_Ropes.erase(iter);
+}
+
+CClientRopeManager::SRopeEntry* CClientRopeManager::FindEntry(const CClientEntity* pElement)
+{
+    auto iter = std::find_if(m_Ropes.begin(), m_Ropes.end(), [pElement](const SRopeEntry& entry) { return entry.pElement == pElement; });
+    return iter != m_Ropes.end() ? &*iter : nullptr;
+}
+
+const CClientRopeManager::SRopeEntry* CClientRopeManager::FindEntry(const CClientEntity* pElement) const
+{
+    auto iter = std::find_if(m_Ropes.begin(), m_Ropes.end(), [pElement](const SRopeEntry& entry) { return entry.pElement == pElement; });
+    return iter != m_Ropes.end() ? &*iter : nullptr;
+}
+
+bool CClientRopeManager::IsActive(const CClientEntity* pElement) const
+{
+    const SRopeEntry* pEntry = FindEntry(pElement);
+    return pEntry && pEntry->bLeased && g_pGame->GetRopes()->FindRope(pEntry->uiNativeId) >= 0;
+}
+
+bool CClientRopeManager::GetPositionAt(const CClientEntity* pElement, float fProgress, CVector& vecPosition, CVector* pVelocity) const
+{
+    const SRopeEntry* pEntry = FindEntry(pElement);
+    return pEntry && pEntry->bLeased && g_pGame->GetRopes()->FindCoorsAlongRope(pEntry->uiNativeId, fProgress, vecPosition, pVelocity);
+}
+
+bool CClientRopeManager::ResolveAnchor(CClientDummy* pRope, CVector& vecAnchor, CClientEntity*& pHolder) const
+{
+    if (!pRope)
+        return false;
+
+    pRope->GetPosition(vecAnchor);
+    pHolder = GetElement(pRope, KEY_HOLDER);
+    if (!pHolder || pHolder->IsBeingDeleted())
+    {
+        pHolder = nullptr;
+        return true;
+    }
+
+    CVector holderPosition;
+    pHolder->GetPosition(holderPosition);
+
+    double x = 0.0, y = 0.0, z = 0.0;
+    GetNumber(pRope, KEY_OFFSET_X, x);
+    GetNumber(pRope, KEY_OFFSET_Y, y);
+    GetNumber(pRope, KEY_OFFSET_Z, z);
+    CVector offset(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z));
+
+    CMatrix matrix;
+    if (pHolder->GetMatrix(matrix))
+        offset = matrix.TransformVector(offset);
+
+    vecAnchor = CVector(holderPosition.fX + offset.fX, holderPosition.fY + offset.fY, holderPosition.fZ + offset.fZ);
+    return true;
+}
+
+bool CClientRopeManager::ShouldOwnPhysics(CClientEntity* pEntity) const
+{
+    if (!pEntity)
+        return true;
+    if (pEntity->IsLocalEntity())
+        return true;
+
+    if (pEntity->GetType() == CCLIENTVEHICLE)
+    {
+        auto* pVehicle = dynamic_cast<CDeathmatchVehicle*>(pEntity);
+        return pVehicle && pVehicle->IsSyncing();
+    }
+
+    if (pEntity->GetType() == CCLIENTOBJECT)
+    {
+#ifdef WITH_OBJECT_SYNC
+        auto* pObject = dynamic_cast<CDeathmatchObject*>(pEntity);
+        return pObject && g_pClientGame && g_pClientGame->GetObjectSync() && g_pClientGame->GetObjectSync()->Exists(pObject);
+#else
+        return false;
+#endif
+    }
+
+    return false;
+}
+
+std::uint32_t CClientRopeManager::AllocateNativeId()
+{
+    for (unsigned int attempt = 0; attempt < 0x10000u; ++attempt)
+    {
+        const std::uint32_t candidate = m_uiNextNativeId++;
+        if (!candidate)
+            continue;
+        if (g_pGame->GetRopes()->FindRope(candidate) < 0)
+            return candidate;
+    }
+    return 0;
+}
+
+bool CClientRopeManager::UpdateNative(SRopeEntry& entry, const CVector& vecAnchor, CClientEntity* pHolder)
+{
+    CClientDummy* pRope = entry.pElement;
+    if (!pRope || !entry.uiNativeId)
+        return false;
+
+    double typeValue = static_cast<double>(static_cast<unsigned int>(eRopeType::SWAT));
+    double fixedNodeValue = 0.0;
+    double winchHeight = 0.5;
+    double length = 0.0;
+    GetNumber(pRope, KEY_TYPE, typeValue);
+    GetNumber(pRope, KEY_FIXED_NODE, fixedNodeValue);
+    GetNumber(pRope, KEY_WINCH_HEIGHT, winchHeight);
+    GetNumber(pRope, KEY_LENGTH, length);
+
+    const int typeNumber = std::clamp(static_cast<int>(typeValue), 1, 8);
+    const auto ropeType = static_cast<eRopeType>(typeNumber);
+    const std::uint8_t fixedNode = static_cast<std::uint8_t>(std::clamp(static_cast<int>(fixedNodeValue), 0, 30));
+
+    bool sitOnGround = false;
+    bool physics = true;
+    GetBool(pRope, KEY_SIT_ON_GROUND, sitOnGround);
+    GetBool(pRope, KEY_PHYSICS, physics);
+
+    // A non-syncer may still render and simulate a rope, but it must not give GTA
+    // a physical holder pointer because CRope::Update applies reaction forces to it.
+    CEntitySAInterface* pNativeHolder = nullptr;
+    if (physics && pHolder && ShouldOwnPhysics(pHolder))
+    {
+        CEntity* pGameEntity = pHolder->GetGameEntity();
+        pNativeHolder = pGameEntity ? pGameEntity->GetInterface() : nullptr;
+    }
+
+    if (!g_pGame->GetRopes()->RegisterRope(entry.uiNativeId, ropeType, vecAnchor, false, fixedNode, sitOnGround, pNativeHolder, 20000))
+        return false;
+
+    double vx = 0.0, vy = 0.0, vz = 0.0;
+    GetNumber(pRope, KEY_VELOCITY_X, vx);
+    GetNumber(pRope, KEY_VELOCITY_Y, vy);
+    GetNumber(pRope, KEY_VELOCITY_Z, vz);
+    g_pGame->GetRopes()->SetSpeedOfTopNode(entry.uiNativeId, CVector(static_cast<float>(vx), static_cast<float>(vy), static_cast<float>(vz)));
+
+    if (winchHeight >= 0.01)
+        g_pGame->GetRopes()->SetWinchHeight(entry.uiNativeId, static_cast<float>(winchHeight));
+    if (length > 0.0)
+        g_pGame->GetRopes()->SetRopeLength(entry.uiNativeId, static_cast<float>(length));
+
+    CClientEntity* pCarried = GetElement(pRope, KEY_CARRIED);
+    const bool carriedTypeAllowed = pCarried && (pCarried->GetType() == CCLIENTOBJECT || pCarried->GetType() == CCLIENTVEHICLE);
+    const bool canOwnCarried = physics && carriedTypeAllowed && ShouldOwnPhysics(pCarried) && (!pHolder || ShouldOwnPhysics(pHolder));
+
+    CEntitySAInterface* pNativeCarried = nullptr;
+    if (canOwnCarried)
+    {
+        CEntity* pGameEntity = pCarried->GetGameEntity();
+        pNativeCarried = pGameEntity ? pGameEntity->GetInterface() : nullptr;
+    }
+
+    CEntitySAInterface* pCurrentCarried = g_pGame->GetRopes()->GetPickedUpEntity(entry.uiNativeId);
+    if (pNativeCarried && pNativeCarried != pCurrentCarried)
+    {
+        if (pCurrentCarried)
+            g_pGame->GetRopes()->ReleasePickedUpEntity(entry.uiNativeId);
+        entry.bPhysicsAttached = g_pGame->GetRopes()->PickUpEntity(entry.uiNativeId, pNativeCarried);
+    }
+    else if (!pNativeCarried && pCurrentCarried)
+    {
+        g_pGame->GetRopes()->ReleasePickedUpEntity(entry.uiNativeId);
+        entry.bPhysicsAttached = false;
+    }
+    else
+    {
+        entry.bPhysicsAttached = pNativeCarried && pCurrentCarried == pNativeCarried;
+    }
+
+    return true;
+}
+
+bool CClientRopeManager::AcquireLease(SRopeEntry& entry, const CVector& vecAnchor, CClientEntity* pHolder)
+{
+    if (entry.bLeased)
+        return UpdateNative(entry, vecAnchor, pHolder);
+    if (!g_pGame || !g_pGame->GetRopes() || g_pGame->GetRopes()->GetFreeRopeCount() == 0)
+        return false;
+
+    entry.uiNativeId = AllocateNativeId();
+    if (!entry.uiNativeId)
+        return false;
+
+    if (!UpdateNative(entry, vecAnchor, pHolder) || g_pGame->GetRopes()->FindRope(entry.uiNativeId) < 0)
+    {
+        entry.uiNativeId = 0;
+        return false;
+    }
+
+    entry.bLeased = true;
+    return true;
+}
+
+void CClientRopeManager::ReleaseLease(SRopeEntry& entry)
+{
+    if (!entry.uiNativeId || !g_pGame || !g_pGame->GetRopes())
+    {
+        entry.bLeased = false;
+        entry.bPhysicsAttached = false;
+        entry.uiNativeId = 0;
+        return;
+    }
+
+    g_pGame->GetRopes()->ReleasePickedUpEntity(entry.uiNativeId);
+    g_pGame->GetRopes()->RemoveRope(entry.uiNativeId);
+    entry.bLeased = false;
+    entry.bPhysicsAttached = false;
+    entry.uiNativeId = 0;
+}
+
+void CClientRopeManager::DoPulse()
+{
+    if (!m_pManager || !g_pGame || !g_pGame->GetRopes())
+        return;
+
+    CClientPlayer* pLocalPlayer = m_pManager->GetPlayerManager()->GetLocalPlayer();
+    if (!pLocalPlayer)
+        return;
+
+    CVector cameraPosition;
+    m_pManager->GetCamera()->GetPosition(cameraPosition);
+    const unsigned short dimension = pLocalPlayer->GetDimension();
+    const unsigned char interior = pLocalPlayer->GetInterior();
+    const unsigned long long now = GetTickCount64_();
+
+    struct SCandidate
+    {
+        SRopeEntry* pEntry{};
+        CVector     anchor;
+        CClientEntity* pHolder{};
+        float       distanceSq{};
+        bool        physicsCritical{};
+    };
+
+    std::vector<SCandidate> candidates;
+    std::vector<CClientDummy*> expiredLocalRopes;
+
+    for (auto& entry : m_Ropes)
+    {
+        CClientDummy* pRope = entry.pElement;
+        if (!pRope || pRope->IsBeingDeleted())
+            continue;
+
+        const unsigned long long elapsed = entry.ullLastPulse ? now - entry.ullLastPulse : 0;
+        entry.ullLastPulse = now;
+        double duration = 0.0;
+        double remaining = 0.0;
+        GetNumber(pRope, KEY_DURATION, duration);
+        GetNumber(pRope, KEY_REMAINING, remaining);
+        if (duration > 0.0 && remaining > 0.0 && elapsed > 0)
+        {
+            remaining = std::max(0.0, remaining - static_cast<double>(elapsed));
+            SetLocalNumber(pRope, KEY_REMAINING, remaining);
+        }
+        if (duration > 0.0 && remaining <= 0.0)
+        {
+            ReleaseLease(entry);
+            if (pRope->IsLocalEntity())
+                expiredLocalRopes.push_back(pRope);
+            continue;
+        }
+
+        CVector anchor;
+        CClientEntity* pHolder = nullptr;
+        if (!ResolveAnchor(pRope, anchor, pHolder))
+        {
+            ReleaseLease(entry);
+            continue;
+        }
+
+        const bool contextMatches = pRope->GetDimension() == dimension && pRope->GetInterior() == interior;
+        const float distanceSq = DistanceSquared(cameraPosition, anchor);
+        bool physics = true;
+        GetBool(pRope, KEY_PHYSICS, physics);
+        CClientEntity* pCarried = GetElement(pRope, KEY_CARRIED);
+        const bool physicsCritical = physics && pCarried && ShouldOwnPhysics(pCarried) && (!pHolder || ShouldOwnPhysics(pHolder));
+
+        if (!contextMatches || (!physicsCritical && distanceSq > RELEASE_DISTANCE * RELEASE_DISTANCE))
+        {
+            ReleaseLease(entry);
+            continue;
+        }
+
+        if (entry.bLeased)
+        {
+            if (!UpdateNative(entry, anchor, pHolder))
+                ReleaseLease(entry);
+            continue;
+        }
+
+        if (physicsCritical || distanceSq <= ACQUIRE_DISTANCE * ACQUIRE_DISTANCE)
+            candidates.push_back({&entry, anchor, pHolder, distanceSq, physicsCritical});
+    }
+
+    std::sort(candidates.begin(), candidates.end(), [](const SCandidate& a, const SCandidate& b) {
+        if (a.physicsCritical != b.physicsCritical)
+            return a.physicsCritical > b.physicsCritical;
+        return a.distanceSq < b.distanceSq;
+    });
+
+    for (SCandidate& candidate : candidates)
+    {
+        if (g_pGame->GetRopes()->GetFreeRopeCount() == 0)
+            break;
+        AcquireLease(*candidate.pEntry, candidate.anchor, candidate.pHolder);
+    }
+
+    for (CClientDummy* pRope : expiredLocalRopes)
+    {
+        if (pRope && !pRope->IsBeingDeleted())
+            CStaticFunctionDefinitions::DestroyElement(*pRope);
+    }
+}

--- a/Client/mods/deathmatch/logic/CClientRopeManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientRopeManager.cpp
@@ -406,8 +406,46 @@ void CClientRopeManager::DoPulse()
 
     for (SCandidate& candidate : candidates)
     {
+        if (g_pGame->GetRopes()->GetFreeRopeCount() == 0 && candidate.physicsCritical)
+        {
+            // A gameplay rope carrying the sync-owner object must not be starved
+            // by eight nearby visual ropes. Evict the farthest non-authoritative
+            // lease; stock GTA ropes are never candidates because they are not in
+            // m_Ropes and therefore remain untouched.
+            SRopeEntry* victim = nullptr;
+            float victimDistanceSq = -1.0f;
+            for (auto& leased : m_Ropes)
+            {
+                if (!leased.bLeased || &leased == candidate.pEntry || !leased.pElement || leased.pElement->IsBeingDeleted())
+                    continue;
+
+                CVector leasedAnchor;
+                CClientEntity* leasedHolder = nullptr;
+                if (!ResolveAnchor(leased.pElement, leasedAnchor, leasedHolder))
+                    continue;
+
+                bool leasedPhysics = true;
+                GetBool(leased.pElement, KEY_PHYSICS, leasedPhysics);
+                CClientEntity* leasedCarried = GetElement(leased.pElement, KEY_CARRIED);
+                const bool leasedCritical = leasedPhysics && leasedCarried && ShouldOwnPhysics(leasedCarried) &&
+                                            (!leasedHolder || ShouldOwnPhysics(leasedHolder));
+                if (leasedCritical)
+                    continue;
+
+                const float leasedDistanceSq = DistanceSquared(cameraPosition, leasedAnchor);
+                if (!victim || leasedDistanceSq > victimDistanceSq)
+                {
+                    victim = &leased;
+                    victimDistanceSq = leasedDistanceSq;
+                }
+            }
+
+            if (victim)
+                ReleaseLease(*victim);
+        }
+
         if (g_pGame->GetRopes()->GetFreeRopeCount() == 0)
-            break;
+            continue;
         AcquireLease(*candidate.pEntry, candidate.anchor, candidate.pHolder);
     }
 

--- a/Client/mods/deathmatch/logic/CClientRopeManager.h
+++ b/Client/mods/deathmatch/logic/CClientRopeManager.h
@@ -1,0 +1,74 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  PURPOSE:     Managed rope presentation and native-slot leasing
+ *
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+class CClientDummy;
+class CClientEntity;
+class CClientManager;
+class CVector;
+
+class CClientRopeManager
+{
+public:
+    explicit CClientRopeManager(CClientManager* pManager);
+    ~CClientRopeManager();
+
+    void Register(CClientDummy* pRope);
+    void Unregister(CClientDummy* pRope);
+    void DoPulse();
+
+    static bool IsRopeElement(const CClientEntity* pElement);
+
+    bool IsActive(const CClientEntity* pElement) const;
+    bool GetPositionAt(const CClientEntity* pElement, float fProgress, CVector& vecPosition, CVector* pVelocity = nullptr) const;
+
+    static constexpr const char* KEY_DURATION = "__neon_rope_duration";
+    static constexpr const char* KEY_REMAINING = "__neon_rope_remaining";
+    static constexpr const char* KEY_TYPE = "__neon_rope_type";
+    static constexpr const char* KEY_HOLDER = "__neon_rope_holder";
+    static constexpr const char* KEY_OFFSET_X = "__neon_rope_offset_x";
+    static constexpr const char* KEY_OFFSET_Y = "__neon_rope_offset_y";
+    static constexpr const char* KEY_OFFSET_Z = "__neon_rope_offset_z";
+    static constexpr const char* KEY_VELOCITY_X = "__neon_rope_velocity_x";
+    static constexpr const char* KEY_VELOCITY_Y = "__neon_rope_velocity_y";
+    static constexpr const char* KEY_VELOCITY_Z = "__neon_rope_velocity_z";
+    static constexpr const char* KEY_FIXED_NODE = "__neon_rope_fixed_node";
+    static constexpr const char* KEY_SIT_ON_GROUND = "__neon_rope_sit_on_ground";
+    static constexpr const char* KEY_WINCH_HEIGHT = "__neon_rope_winch_height";
+    static constexpr const char* KEY_LENGTH = "__neon_rope_length";
+    static constexpr const char* KEY_CARRIED = "__neon_rope_carried";
+    static constexpr const char* KEY_PHYSICS = "__neon_rope_physics";
+
+private:
+    struct SRopeEntry
+    {
+        CClientDummy*     pElement{};
+        std::uint32_t     uiNativeId{};
+        unsigned long long ullLastPulse{};
+        bool              bLeased{};
+        bool              bPhysicsAttached{};
+    };
+
+    SRopeEntry* FindEntry(const CClientEntity* pElement);
+    const SRopeEntry* FindEntry(const CClientEntity* pElement) const;
+
+    bool ResolveAnchor(CClientDummy* pRope, CVector& vecAnchor, CClientEntity*& pHolder) const;
+    bool ShouldOwnPhysics(CClientEntity* pEntity) const;
+    bool UpdateNative(SRopeEntry& entry, const CVector& vecAnchor, CClientEntity* pHolder);
+    bool AcquireLease(SRopeEntry& entry, const CVector& vecAnchor, CClientEntity* pHolder);
+    void ReleaseLease(SRopeEntry& entry);
+    std::uint32_t AllocateNativeId();
+
+    CClientManager*         m_pManager{};
+    std::vector<SRopeEntry> m_Ropes;
+    std::uint32_t           m_uiNextNativeId{0x4E520000u};
+};

--- a/Client/mods/deathmatch/logic/CClientRopeManager.h
+++ b/Client/mods/deathmatch/logic/CClientRopeManager.h
@@ -19,12 +19,22 @@ class CVector;
 class CClientRopeManager
 {
 public:
-    static CClientRopeManager& GetSingleton();
+    static CClientRopeManager& GetSingleton()
+    {
+        static CClientRopeManager manager(nullptr);
+        return manager;
+    }
+
     ~CClientRopeManager();
 
     void Register(CClientDummy* pRope);
     void Unregister(CClientDummy* pRope);
-    void DoPulse(CClientManager* pManager);
+    void DoPulse();
+    void DoPulse(CClientManager* pManager)
+    {
+        m_pManager = pManager;
+        DoPulse();
+    }
 
     static bool IsRopeElement(const CClientEntity* pElement);
 
@@ -49,7 +59,7 @@ public:
     static constexpr const char* KEY_PHYSICS = "__neon_rope_physics";
 
 private:
-    CClientRopeManager() = default;
+    explicit CClientRopeManager(CClientManager* pManager);
 
     struct SRopeEntry
     {

--- a/Client/mods/deathmatch/logic/CClientRopeManager.h
+++ b/Client/mods/deathmatch/logic/CClientRopeManager.h
@@ -19,12 +19,12 @@ class CVector;
 class CClientRopeManager
 {
 public:
-    explicit CClientRopeManager(CClientManager* pManager);
+    static CClientRopeManager& GetSingleton();
     ~CClientRopeManager();
 
     void Register(CClientDummy* pRope);
     void Unregister(CClientDummy* pRope);
-    void DoPulse();
+    void DoPulse(CClientManager* pManager);
 
     static bool IsRopeElement(const CClientEntity* pElement);
 
@@ -49,13 +49,15 @@ public:
     static constexpr const char* KEY_PHYSICS = "__neon_rope_physics";
 
 private:
+    CClientRopeManager() = default;
+
     struct SRopeEntry
     {
-        CClientDummy*     pElement{};
-        std::uint32_t     uiNativeId{};
+        CClientDummy*      pElement{};
+        std::uint32_t      uiNativeId{};
         unsigned long long ullLastPulse{};
-        bool              bLeased{};
-        bool              bPhysicsAttached{};
+        bool               bLeased{};
+        bool               bPhysicsAttached{};
     };
 
     SRopeEntry* FindEntry(const CClientEntity* pElement);

--- a/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -12,6 +12,7 @@
 #include "StdInc.h"
 #include "../luadefs/CLua2DFXDefs.h"
 #include "../luadefs/CLuaFireDefs.h"
+#include "../luadefs/CLuaRopeDefs.h"
 #include "../luadefs/CLuaClientDefs.h"
 #include "../luadefs/CLuaVectorGraphicDefs.h"
 #include "../luadefs/CLuaPostfxDefs.h"
@@ -261,6 +262,7 @@ void CLuaManager::LoadCFunctions()
     CLuaEngineDefs::LoadFunctions();
     CLua2DFXDefs::LoadFunctions();
     CLuaFireDefs::LoadFunctions();
+    CLuaRopeDefs::LoadFunctions();
     CLuaGUIDefs::LoadFunctions();
     CLuaMarkerDefs::LoadFunctions();
     CLuaNetworkDefs::LoadFunctions();

--- a/Client/mods/deathmatch/logic/luadefs/CLuaRopeDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaRopeDefs.cpp
@@ -1,0 +1,486 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  PURPOSE:     Managed rope Lua definitions
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+#include "CLuaRopeDefs.h"
+#include "../CClientRopeManager.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+namespace
+{
+using RopeManager = CClientRopeManager;
+
+bool IsRope(CClientEntity* pElement)
+{
+    return RopeManager::IsRopeElement(pElement);
+}
+
+bool CanMutate(CClientEntity* pRope)
+{
+    return pRope && pRope->IsLocalEntity();
+}
+
+void SetNumber(CClientEntity* pRope, const char* szKey, double dValue)
+{
+    CLuaArgument argument;
+    argument.ReadNumber(dValue);
+    pRope->SetCustomData(szKey, argument, false);
+}
+
+void SetBool(CClientEntity* pRope, const char* szKey, bool bValue)
+{
+    CLuaArgument argument;
+    argument.ReadBool(bValue);
+    pRope->SetCustomData(szKey, argument, false);
+}
+
+void SetElement(CClientEntity* pRope, const char* szKey, CClientEntity* pValue)
+{
+    if (!pValue)
+    {
+        pRope->DeleteCustomData(szKey);
+        return;
+    }
+
+    CLuaArgument argument;
+    argument.ReadElement(pValue);
+    pRope->SetCustomData(szKey, argument, false);
+}
+
+bool GetNumber(CClientEntity* pRope, const char* szKey, double& dValue)
+{
+    CLuaArgument* pArgument = pRope ? pRope->GetCustomData(szKey, false) : nullptr;
+    if (!pArgument || pArgument->GetType() != LUA_TNUMBER)
+        return false;
+    dValue = pArgument->GetNumber();
+    return true;
+}
+
+bool GetBool(CClientEntity* pRope, const char* szKey, bool& bValue)
+{
+    CLuaArgument* pArgument = pRope ? pRope->GetCustomData(szKey, false) : nullptr;
+    if (!pArgument || pArgument->GetType() != LUA_TBOOLEAN)
+        return false;
+    bValue = pArgument->GetBoolean();
+    return true;
+}
+
+CClientEntity* GetElement(CClientEntity* pRope, const char* szKey)
+{
+    CLuaArgument* pArgument = pRope ? pRope->GetCustomData(szKey, false) : nullptr;
+    return pArgument ? pArgument->GetElement() : nullptr;
+}
+
+bool ReadNumberField(lua_State* luaVM, int iTable, const char* szField, double& dValue)
+{
+    lua_getfield(luaVM, iTable, szField);
+    if (!lua_isnumber(luaVM, -1))
+    {
+        lua_pop(luaVM, 1);
+        return false;
+    }
+    dValue = lua_tonumber(luaVM, -1);
+    lua_pop(luaVM, 1);
+    return std::isfinite(dValue);
+}
+
+bool ReadBoolField(lua_State* luaVM, int iTable, const char* szField, bool& bValue)
+{
+    lua_getfield(luaVM, iTable, szField);
+    if (!lua_isboolean(luaVM, -1))
+    {
+        lua_pop(luaVM, 1);
+        return false;
+    }
+    bValue = lua_toboolean(luaVM, -1) != 0;
+    lua_pop(luaVM, 1);
+    return true;
+}
+
+CClientEntity* ReadElementField(lua_State* luaVM, int iTable, const char* szField)
+{
+    lua_getfield(luaVM, iTable, szField);
+    CClientEntity* pValue = lua_toelement(luaVM, -1);
+    lua_pop(luaVM, 1);
+    return pValue;
+}
+
+bool ReadVectorTable(lua_State* luaVM, int iTable, const char* szField, CVector& vecValue)
+{
+    lua_getfield(luaVM, iTable, szField);
+    if (!lua_istable(luaVM, -1))
+    {
+        lua_pop(luaVM, 1);
+        return false;
+    }
+
+    auto readComponent = [luaVM](const char* szName, int iArrayIndex, float& fOut) {
+        lua_getfield(luaVM, -1, szName);
+        if (!lua_isnumber(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            lua_rawgeti(luaVM, -1, iArrayIndex);
+        }
+        if (!lua_isnumber(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            return false;
+        }
+        fOut = static_cast<float>(lua_tonumber(luaVM, -1));
+        lua_pop(luaVM, 1);
+        return std::isfinite(fOut);
+    };
+
+    const bool ok = readComponent("x", 1, vecValue.fX) && readComponent("y", 2, vecValue.fY) && readComponent("z", 3, vecValue.fZ);
+    lua_pop(luaVM, 1);
+    return ok;
+}
+
+void PushVector3(lua_State* luaVM, const CVector& vecValue)
+{
+    lua_getglobal(luaVM, "Vector3");
+    lua_pushnumber(luaVM, vecValue.fX);
+    lua_pushnumber(luaVM, vecValue.fY);
+    lua_pushnumber(luaVM, vecValue.fZ);
+    lua_call(luaVM, 3, 1);
+}
+
+int RopeTypeFromName(const char* szName)
+{
+    if (!szName)
+        return 0;
+    if (strcmp(szName, "winchMagnet") == 0) return 1;
+    if (strcmp(szName, "harness") == 0) return 2;
+    if (strcmp(szName, "miniMagnet") == 0) return 3;
+    if (strcmp(szName, "dockCrane") == 0) return 4;
+    if (strcmp(szName, "wreckingBall") == 0) return 5;
+    if (strcmp(szName, "quarryCrane") == 0) return 6;
+    if (strcmp(szName, "vegasCrane") == 0) return 7;
+    if (strcmp(szName, "swat") == 0) return 8;
+    return 0;
+}
+
+const char* RopeTypeName(int iType)
+{
+    switch (iType)
+    {
+        case 1: return "winchMagnet";
+        case 2: return "harness";
+        case 3: return "miniMagnet";
+        case 4: return "dockCrane";
+        case 5: return "wreckingBall";
+        case 6: return "quarryCrane";
+        case 7: return "vegasCrane";
+        case 8: return "swat";
+        default: return nullptr;
+    }
+}
+
+bool IsPhysicalRopeElement(CClientEntity* pElement)
+{
+    return pElement && (pElement->GetType() == CCLIENTOBJECT || pElement->GetType() == CCLIENTVEHICLE);
+}
+
+CClientEntity* ReadRope(lua_State* luaVM)
+{
+    CClientEntity* pRope = lua_toelement(luaVM, 1);
+    return IsRope(pRope) ? pRope : nullptr;
+}
+
+void SetVector(CClientEntity* pRope, const char* xKey, const char* yKey, const char* zKey, const CVector& vecValue)
+{
+    SetNumber(pRope, xKey, vecValue.fX);
+    SetNumber(pRope, yKey, vecValue.fY);
+    SetNumber(pRope, zKey, vecValue.fZ);
+}
+
+CVector GetVector(CClientEntity* pRope, const char* xKey, const char* yKey, const char* zKey)
+{
+    double x = 0.0, y = 0.0, z = 0.0;
+    GetNumber(pRope, xKey, x);
+    GetNumber(pRope, yKey, y);
+    GetNumber(pRope, zKey, z);
+    return CVector(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z));
+}
+}  // namespace
+
+void CLuaRopeDefs::LoadFunctions()
+{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
+        {"createRope", CreateRope},
+        {"getRopeType", GetRopeType}, {"setRopeType", SetRopeType},
+        {"getRopeDuration", GetRopeDuration}, {"setRopeDuration", SetRopeDuration},
+        {"getRopeRemainingTime", GetRopeRemainingTime}, {"setRopeRemainingTime", SetRopeRemainingTime},
+        {"getRopeHolder", GetRopeHolder}, {"setRopeHolder", SetRopeHolder},
+        {"getRopeHolderOffset", GetRopeHolderOffset}, {"setRopeHolderOffset", SetRopeHolderOffset},
+        {"getRopeTopVelocity", GetRopeTopVelocity}, {"setRopeTopVelocity", SetRopeTopVelocity},
+        {"getRopeWinchHeight", GetRopeWinchHeight}, {"setRopeWinchHeight", SetRopeWinchHeight},
+        {"getRopeLength", GetRopeLength}, {"setRopeLength", SetRopeLength},
+        {"getRopeFixedNode", GetRopeFixedNode}, {"setRopeFixedNode", SetRopeFixedNode},
+        {"isRopeOnGround", IsRopeOnGround}, {"setRopeOnGround", SetRopeOnGround},
+        {"isRopePhysicsEnabled", IsRopePhysicsEnabled}, {"setRopePhysicsEnabled", SetRopePhysicsEnabled},
+        {"getRopeCarriedElement", GetRopeCarriedElement}, {"attachElementToRope", AttachElementToRope}, {"detachElementFromRope", DetachElementFromRope},
+        {"getRopePositionAt", GetRopePositionAt}, {"isRopeActive", IsRopeActive},
+    };
+    for (const auto& [name, function] : functions)
+        CLuaCFunctions::AddFunction(name, function);
+}
+
+int CLuaRopeDefs::CreateRope(lua_State* luaVM)
+{
+    CVector position;
+    CScriptArgReader args(luaVM);
+    args.ReadVector3D(position);
+    if (args.HasErrors())
+    {
+        lua_pushboolean(luaVM, false);
+        return 1;
+    }
+
+    int type = 8;
+    double duration = 0.0;
+    double winchHeight = 0.5;
+    double length = 0.0;
+    double fixedNode = 0.0;
+    bool sitOnGround = false;
+    bool physics = true;
+    CVector offset;
+    CVector velocity;
+    CClientEntity* pHolder = nullptr;
+    CClientEntity* pCarried = nullptr;
+
+    if (lua_istable(luaVM, 4))
+    {
+        lua_getfield(luaVM, 4, "type");
+        if (lua_isstring(luaVM, -1))
+            type = RopeTypeFromName(lua_tostring(luaVM, -1));
+        lua_pop(luaVM, 1);
+        if (type < 1 || type > 8)
+        {
+            lua_pushboolean(luaVM, false);
+            return 1;
+        }
+
+        ReadNumberField(luaVM, 4, "duration", duration);
+        ReadNumberField(luaVM, 4, "winchHeight", winchHeight);
+        ReadNumberField(luaVM, 4, "length", length);
+        ReadNumberField(luaVM, 4, "fixedNode", fixedNode);
+        ReadBoolField(luaVM, 4, "sitOnGround", sitOnGround);
+        ReadBoolField(luaVM, 4, "physics", physics);
+        ReadVectorTable(luaVM, 4, "holderOffset", offset);
+        ReadVectorTable(luaVM, 4, "topVelocity", velocity);
+        pHolder = ReadElementField(luaVM, 4, "holder");
+        pCarried = ReadElementField(luaVM, 4, "carriedElement");
+    }
+
+    if (duration < 0.0 || winchHeight < 0.01 || fixedNode < 0.0 || fixedNode > 30.0 || (pHolder && !IsPhysicalRopeElement(pHolder)) ||
+        (pCarried && !IsPhysicalRopeElement(pCarried)))
+    {
+        lua_pushboolean(luaVM, false);
+        return 1;
+    }
+
+    CResource& resource = lua_getownerresource(luaVM);
+    CClientDummy* pRope = CStaticFunctionDefinitions::CreateElement(resource, "rope", "");
+    if (!pRope)
+    {
+        lua_pushboolean(luaVM, false);
+        return 1;
+    }
+
+    pRope->SetPosition(position);
+    SetNumber(pRope, RopeManager::KEY_TYPE, type);
+    SetNumber(pRope, RopeManager::KEY_DURATION, duration);
+    SetNumber(pRope, RopeManager::KEY_REMAINING, duration);
+    SetNumber(pRope, RopeManager::KEY_FIXED_NODE, fixedNode);
+    SetBool(pRope, RopeManager::KEY_SIT_ON_GROUND, sitOnGround);
+    SetNumber(pRope, RopeManager::KEY_WINCH_HEIGHT, winchHeight);
+    SetNumber(pRope, RopeManager::KEY_LENGTH, std::max(0.0, length));
+    SetBool(pRope, RopeManager::KEY_PHYSICS, physics);
+    SetVector(pRope, RopeManager::KEY_OFFSET_X, RopeManager::KEY_OFFSET_Y, RopeManager::KEY_OFFSET_Z, offset);
+    SetVector(pRope, RopeManager::KEY_VELOCITY_X, RopeManager::KEY_VELOCITY_Y, RopeManager::KEY_VELOCITY_Z, velocity);
+    SetElement(pRope, RopeManager::KEY_HOLDER, pHolder);
+    SetElement(pRope, RopeManager::KEY_CARRIED, pCarried);
+
+    pRope->SetParent(resource.GetResourceDynamicEntity());
+    if (CElementGroup* pGroup = resource.GetElementGroup())
+        pGroup->Add(pRope);
+
+    lua_pushelement(luaVM, pRope);
+    return 1;
+}
+
+int CLuaRopeDefs::GetRopeType(lua_State* luaVM)
+{
+    CClientEntity* pRope = ReadRope(luaVM);
+    double value = 0.0;
+    const char* name = pRope && GetNumber(pRope, RopeManager::KEY_TYPE, value) ? RopeTypeName(static_cast<int>(value)) : nullptr;
+    if (name) lua_pushstring(luaVM, name); else lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaRopeDefs::SetRopeType(lua_State* luaVM)
+{
+    CClientEntity* pRope = ReadRope(luaVM);
+    const char* name = lua_isstring(luaVM, 2) ? lua_tostring(luaVM, 2) : nullptr;
+    const int type = RopeTypeFromName(name);
+    const bool ok = pRope && CanMutate(pRope) && type > 0;
+    if (ok) SetNumber(pRope, RopeManager::KEY_TYPE, type);
+    lua_pushboolean(luaVM, ok);
+    return 1;
+}
+
+#define ROPE_NUMBER_GETTER(Method, Key) \
+    int CLuaRopeDefs::Method(lua_State* luaVM) { CClientEntity* pRope = ReadRope(luaVM); double v = 0.0; if (pRope && GetNumber(pRope, Key, v)) lua_pushnumber(luaVM, v); else lua_pushboolean(luaVM, false); return 1; }
+
+ROPE_NUMBER_GETTER(GetRopeDuration, RopeManager::KEY_DURATION)
+ROPE_NUMBER_GETTER(GetRopeRemainingTime, RopeManager::KEY_REMAINING)
+ROPE_NUMBER_GETTER(GetRopeWinchHeight, RopeManager::KEY_WINCH_HEIGHT)
+ROPE_NUMBER_GETTER(GetRopeLength, RopeManager::KEY_LENGTH)
+ROPE_NUMBER_GETTER(GetRopeFixedNode, RopeManager::KEY_FIXED_NODE)
+
+int CLuaRopeDefs::SetRopeDuration(lua_State* luaVM)
+{
+    CClientEntity* pRope = ReadRope(luaVM); double value = luaL_optnumber(luaVM, 2, -1.0);
+    const bool ok = pRope && CanMutate(pRope) && value >= 0.0;
+    if (ok) { SetNumber(pRope, RopeManager::KEY_DURATION, value); SetNumber(pRope, RopeManager::KEY_REMAINING, value); }
+    lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::SetRopeRemainingTime(lua_State* luaVM)
+{
+    CClientEntity* pRope = ReadRope(luaVM); double value = luaL_optnumber(luaVM, 2, -1.0);
+    const bool ok = pRope && CanMutate(pRope) && value >= 0.0;
+    if (ok) SetNumber(pRope, RopeManager::KEY_REMAINING, value);
+    lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::SetRopeWinchHeight(lua_State* luaVM)
+{
+    CClientEntity* pRope = ReadRope(luaVM); double value = luaL_optnumber(luaVM, 2, 0.0);
+    const bool ok = pRope && CanMutate(pRope) && value >= 0.01;
+    if (ok) SetNumber(pRope, RopeManager::KEY_WINCH_HEIGHT, value);
+    lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::SetRopeLength(lua_State* luaVM)
+{
+    CClientEntity* pRope = ReadRope(luaVM); double value = luaL_optnumber(luaVM, 2, 0.0);
+    const bool ok = pRope && CanMutate(pRope) && value >= 0.0;
+    if (ok) SetNumber(pRope, RopeManager::KEY_LENGTH, value);
+    lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::SetRopeFixedNode(lua_State* luaVM)
+{
+    CClientEntity* pRope = ReadRope(luaVM); int value = static_cast<int>(luaL_optinteger(luaVM, 2, -1));
+    const bool ok = pRope && CanMutate(pRope) && value >= 0 && value <= 30;
+    if (ok) SetNumber(pRope, RopeManager::KEY_FIXED_NODE, value);
+    lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::GetRopeHolder(lua_State* luaVM)
+{
+    CClientEntity* pRope = ReadRope(luaVM); CClientEntity* pValue = pRope ? GetElement(pRope, RopeManager::KEY_HOLDER) : nullptr;
+    if (pValue) lua_pushelement(luaVM, pValue); else lua_pushboolean(luaVM, false); return 1;
+}
+
+int CLuaRopeDefs::SetRopeHolder(lua_State* luaVM)
+{
+    CClientEntity* pRope = ReadRope(luaVM);
+    CClientEntity* pHolder = lua_isnoneornil(luaVM, 2) ? nullptr : lua_toelement(luaVM, 2);
+    const bool ok = pRope && CanMutate(pRope) && (lua_isnoneornil(luaVM, 2) || IsPhysicalRopeElement(pHolder));
+    if (ok) SetElement(pRope, RopeManager::KEY_HOLDER, pHolder);
+    lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::GetRopeHolderOffset(lua_State* luaVM)
+{
+    CClientEntity* pRope = ReadRope(luaVM); if (!pRope) { lua_pushboolean(luaVM, false); return 1; }
+    PushVector3(luaVM, GetVector(pRope, RopeManager::KEY_OFFSET_X, RopeManager::KEY_OFFSET_Y, RopeManager::KEY_OFFSET_Z)); return 1;
+}
+
+int CLuaRopeDefs::SetRopeHolderOffset(lua_State* luaVM)
+{
+    CClientEntity* pRope = nullptr; CVector value; CScriptArgReader args(luaVM); args.ReadUserData(pRope); args.ReadVector3D(value);
+    const bool ok = !args.HasErrors() && IsRope(pRope) && CanMutate(pRope);
+    if (ok) SetVector(pRope, RopeManager::KEY_OFFSET_X, RopeManager::KEY_OFFSET_Y, RopeManager::KEY_OFFSET_Z, value);
+    lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::GetRopeTopVelocity(lua_State* luaVM)
+{
+    CClientEntity* pRope = ReadRope(luaVM); if (!pRope) { lua_pushboolean(luaVM, false); return 1; }
+    PushVector3(luaVM, GetVector(pRope, RopeManager::KEY_VELOCITY_X, RopeManager::KEY_VELOCITY_Y, RopeManager::KEY_VELOCITY_Z)); return 1;
+}
+
+int CLuaRopeDefs::SetRopeTopVelocity(lua_State* luaVM)
+{
+    CClientEntity* pRope = nullptr; CVector value; CScriptArgReader args(luaVM); args.ReadUserData(pRope); args.ReadVector3D(value);
+    const bool ok = !args.HasErrors() && IsRope(pRope) && CanMutate(pRope);
+    if (ok) SetVector(pRope, RopeManager::KEY_VELOCITY_X, RopeManager::KEY_VELOCITY_Y, RopeManager::KEY_VELOCITY_Z, value);
+    lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::IsRopeOnGround(lua_State* luaVM)
+{
+    CClientEntity* pRope = ReadRope(luaVM); bool value = false; if (pRope && GetBool(pRope, RopeManager::KEY_SIT_ON_GROUND, value)) lua_pushboolean(luaVM, value); else lua_pushboolean(luaVM, false); return 1;
+}
+
+int CLuaRopeDefs::SetRopeOnGround(lua_State* luaVM)
+{
+    CClientEntity* pRope = nullptr; bool value = false; CScriptArgReader args(luaVM); args.ReadUserData(pRope); args.ReadBool(value);
+    const bool ok = !args.HasErrors() && IsRope(pRope) && CanMutate(pRope); if (ok) SetBool(pRope, RopeManager::KEY_SIT_ON_GROUND, value); lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::IsRopePhysicsEnabled(lua_State* luaVM)
+{
+    CClientEntity* pRope = ReadRope(luaVM); bool value = false; if (pRope && GetBool(pRope, RopeManager::KEY_PHYSICS, value)) lua_pushboolean(luaVM, value); else lua_pushboolean(luaVM, false); return 1;
+}
+
+int CLuaRopeDefs::SetRopePhysicsEnabled(lua_State* luaVM)
+{
+    CClientEntity* pRope = nullptr; bool value = false; CScriptArgReader args(luaVM); args.ReadUserData(pRope); args.ReadBool(value);
+    const bool ok = !args.HasErrors() && IsRope(pRope) && CanMutate(pRope); if (ok) SetBool(pRope, RopeManager::KEY_PHYSICS, value); lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::GetRopeCarriedElement(lua_State* luaVM)
+{
+    CClientEntity* pRope = ReadRope(luaVM); CClientEntity* pValue = pRope ? GetElement(pRope, RopeManager::KEY_CARRIED) : nullptr;
+    if (pValue) lua_pushelement(luaVM, pValue); else lua_pushboolean(luaVM, false); return 1;
+}
+
+int CLuaRopeDefs::AttachElementToRope(lua_State* luaVM)
+{
+    CClientEntity* pRope = ReadRope(luaVM); CClientEntity* pValue = lua_toelement(luaVM, 2);
+    const bool ok = pRope && CanMutate(pRope) && IsPhysicalRopeElement(pValue); if (ok) SetElement(pRope, RopeManager::KEY_CARRIED, pValue); lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::DetachElementFromRope(lua_State* luaVM)
+{
+    CClientEntity* pRope = ReadRope(luaVM); const bool ok = pRope && CanMutate(pRope); if (ok) SetElement(pRope, RopeManager::KEY_CARRIED, nullptr); lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::GetRopePositionAt(lua_State* luaVM)
+{
+    CClientEntity* pRope = ReadRope(luaVM); const float progress = static_cast<float>(luaL_optnumber(luaVM, 2, -1.0));
+    CVector position, velocity;
+    if (!pRope || progress < 0.0f || progress > 1.0f || !RopeManager::GetSingleton().GetPositionAt(pRope, progress, position, &velocity))
+    {
+        lua_pushboolean(luaVM, false); return 1;
+    }
+    PushVector3(luaVM, position); PushVector3(luaVM, velocity); return 2;
+}
+
+int CLuaRopeDefs::IsRopeActive(lua_State* luaVM)
+{
+    CClientEntity* pRope = ReadRope(luaVM); lua_pushboolean(luaVM, pRope && RopeManager::GetSingleton().IsActive(pRope)); return 1;
+}

--- a/Client/mods/deathmatch/logic/luadefs/CLuaRopeDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaRopeDefs.h
@@ -1,0 +1,45 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  PURPOSE:     Managed rope Lua definitions
+ *
+ *****************************************************************************/
+#pragma once
+
+#include "CLuaDefs.h"
+
+class CLuaRopeDefs : public CLuaDefs
+{
+public:
+    static void LoadFunctions();
+
+    LUA_DECLARE(CreateRope);
+    LUA_DECLARE(GetRopeType);
+    LUA_DECLARE(SetRopeType);
+    LUA_DECLARE(GetRopeDuration);
+    LUA_DECLARE(SetRopeDuration);
+    LUA_DECLARE(GetRopeRemainingTime);
+    LUA_DECLARE(SetRopeRemainingTime);
+    LUA_DECLARE(GetRopeHolder);
+    LUA_DECLARE(SetRopeHolder);
+    LUA_DECLARE(GetRopeHolderOffset);
+    LUA_DECLARE(SetRopeHolderOffset);
+    LUA_DECLARE(GetRopeTopVelocity);
+    LUA_DECLARE(SetRopeTopVelocity);
+    LUA_DECLARE(GetRopeWinchHeight);
+    LUA_DECLARE(SetRopeWinchHeight);
+    LUA_DECLARE(GetRopeLength);
+    LUA_DECLARE(SetRopeLength);
+    LUA_DECLARE(GetRopeFixedNode);
+    LUA_DECLARE(SetRopeFixedNode);
+    LUA_DECLARE(IsRopeOnGround);
+    LUA_DECLARE(SetRopeOnGround);
+    LUA_DECLARE(IsRopePhysicsEnabled);
+    LUA_DECLARE(SetRopePhysicsEnabled);
+    LUA_DECLARE(GetRopeCarriedElement);
+    LUA_DECLARE(AttachElementToRope);
+    LUA_DECLARE(DetachElementFromRope);
+    LUA_DECLARE(GetRopePositionAt);
+    LUA_DECLARE(IsRopeActive);
+};

--- a/Client/sdk/game/CRopes.h
+++ b/Client/sdk/game/CRopes.h
@@ -11,12 +11,50 @@
 
 #pragma once
 
+#include <cstdint>
+
 class CVector;
 class CEntitySAInterface;
+
+enum class eRopeType : std::uint8_t
+{
+    NONE = 0,
+    WINCH_MAGNET = 1,
+    HARNESS = 2,
+    MINI_MAGNET = 3,
+    DOCK_CRANE = 4,
+    WRECKING_BALL = 5,
+    QUARRY_CRANE = 6,
+    VEGAS_CRANE = 7,
+    SWAT = 8,
+};
 
 class CRopes
 {
 public:
-    virtual int  CreateRopeForSwatPed(const CVector& vecPosition, DWORD dwDuration = 4000) = 0;
+    virtual int CreateRopeForSwatPed(const CVector& vecPosition, DWORD dwDuration = 4000) = 0;
+
+    // Managed ropes deliberately use the game's existing eight-slot CRopes pool.
+    // Callers must treat the ID as an opaque client-local lease key and never expose
+    // it to Lua or assume that a particular native slot remains stable.
+    virtual bool RegisterRope(std::uint32_t uiId, eRopeType type, const CVector& vecPosition, bool bExpires, std::uint8_t ucFixedNode,
+                              bool bSitOnGround, CEntitySAInterface* pHolder, std::uint32_t uiLifetime) = 0;
+    virtual bool RemoveRope(std::uint32_t uiId) = 0;
     virtual void RemoveEntityRope(CEntitySAInterface* pObjectSA) = 0;
+
+    virtual int  FindRope(std::uint32_t uiId) const = 0;
+    virtual bool FindCoorsAlongRope(std::uint32_t uiId, float fProgress, CVector& vecPosition, CVector* pVelocity = nullptr) const = 0;
+    virtual bool SetSpeedOfTopNode(std::uint32_t uiId, const CVector& vecVelocity) = 0;
+
+    virtual bool GetWinchHeight(std::uint32_t uiId, float& fHeight) const = 0;
+    virtual bool SetWinchHeight(std::uint32_t uiId, float fHeight) = 0;
+    virtual bool GetRopeLength(std::uint32_t uiId, float& fLength) const = 0;
+    virtual bool SetRopeLength(std::uint32_t uiId, float fLength) = 0;
+
+    virtual bool PickUpEntity(std::uint32_t uiId, CEntitySAInterface* pEntity) = 0;
+    virtual bool ReleasePickedUpEntity(std::uint32_t uiId) = 0;
+    virtual CEntitySAInterface* GetPickedUpEntity(std::uint32_t uiId) const = 0;
+
+    virtual bool GetNode(std::uint32_t uiId, std::uint8_t ucNode, CVector& vecPosition, CVector& vecVelocity) const = 0;
+    virtual unsigned int GetFreeRopeCount() const = 0;
 };

--- a/Server/mods/deathmatch/logic/CDummy.cpp
+++ b/Server/mods/deathmatch/logic/CDummy.cpp
@@ -14,6 +14,7 @@
 #include "CGroups.h"
 #include "CGame.h"
 #include "luadefs/CLuaFireDefs.h"
+#include "luadefs/CLuaRopeDefs.h"
 
 CDummy::CDummy(CGroups* pGroups, CElement* pParent) : CElement(pParent)
 {
@@ -33,6 +34,8 @@ CDummy::~CDummy()
 {
     if (GetTypeName() == "fire")
         CLuaFireDefs::OnFireDestroyed(this);
+    else if (GetTypeName() == "rope")
+        CLuaRopeDefs::OnRopeDestroyed(this);
 
     // Unlink from manager
     Unlink();

--- a/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -19,6 +19,7 @@
 #include "luadefs/CLuaUtilDefs.h"
 #include "luadefs/CLuaElementDefs.h"
 #include "luadefs/CLuaFireDefs.h"
+#include "luadefs/CLuaRopeDefs.h"
 #include "luadefs/CLuaAccountDefs.h"
 #include "luadefs/CLuaACLDefs.h"
 #include "luadefs/CLuaBanDefs.h"
@@ -136,6 +137,7 @@ void CLuaManager::DoPulse()
     }
     m_pLuaModuleManager->DoPulse();
     CLuaFireDefs::DoPulse();
+    CLuaRopeDefs::DoPulse();
 }
 
 CLuaMain* CLuaManager::GetVirtualMachine(lua_State* luaVM)
@@ -205,7 +207,7 @@ CLuaTimer* CLuaManager::FindTimerGlobally(unsigned long scriptID) const
     }
 
     // Timer exists in global ID array but not in any resource manager
-    // This indicates the timer has been cleaned up
+    // This indicates that it has been cleaned up
     return nullptr;
 }
 
@@ -223,6 +225,7 @@ void CLuaManager::LoadCFunctions()
     CLuaDatabaseDefs::LoadFunctions();
     CLuaElementDefs::LoadFunctions();
     CLuaFireDefs::LoadFunctions();
+    CLuaRopeDefs::LoadFunctions();
     CLuaHandlingDefs::LoadFunctions();
     CLuaMarkerDefs::LoadFunctions();
     CLuaModelDefs::LoadFunctions();

--- a/Server/mods/deathmatch/logic/luadefs/CLuaRopeDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaRopeDefs.cpp
@@ -1,0 +1,557 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  PURPOSE:     Managed rope Lua definitions
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+#include "CLuaRopeDefs.h"
+#include "../CDummy.h"
+#include "../CElementGroup.h"
+#include "../CResource.h"
+#include "../packets/CEntityAddPacket.h"
+#include "../CStaticFunctionDefinitions.h"
+#include <CScriptArgReader.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstring>
+#include <unordered_map>
+#include <vector>
+
+namespace
+{
+constexpr const char* KEY_DURATION = "__neon_rope_duration";
+constexpr const char* KEY_REMAINING = "__neon_rope_remaining";
+constexpr const char* KEY_EXPIRY = "__neon_rope_expiry";  // Server-local absolute clock; clients receive only remaining time.
+constexpr const char* KEY_TYPE = "__neon_rope_type";
+constexpr const char* KEY_HOLDER = "__neon_rope_holder";
+constexpr const char* KEY_OFFSET_X = "__neon_rope_offset_x";
+constexpr const char* KEY_OFFSET_Y = "__neon_rope_offset_y";
+constexpr const char* KEY_OFFSET_Z = "__neon_rope_offset_z";
+constexpr const char* KEY_VELOCITY_X = "__neon_rope_velocity_x";
+constexpr const char* KEY_VELOCITY_Y = "__neon_rope_velocity_y";
+constexpr const char* KEY_VELOCITY_Z = "__neon_rope_velocity_z";
+constexpr const char* KEY_FIXED_NODE = "__neon_rope_fixed_node";
+constexpr const char* KEY_SIT_ON_GROUND = "__neon_rope_sit_on_ground";
+constexpr const char* KEY_WINCH_HEIGHT = "__neon_rope_winch_height";
+constexpr const char* KEY_LENGTH = "__neon_rope_length";
+constexpr const char* KEY_CARRIED = "__neon_rope_carried";
+constexpr const char* KEY_PHYSICS = "__neon_rope_physics";
+
+struct SRopeRecord
+{
+    CDummy*    pRope{};
+    CResource* pResource{};
+};
+
+std::unordered_map<CDummy*, SRopeRecord> g_Ropes;
+
+double NowMs()
+{
+    return static_cast<double>(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+}
+
+bool IsRope(CElement* pElement)
+{
+    return pElement && pElement->GetType() == CElement::DUMMY && pElement->GetTypeName() == "rope";
+}
+
+bool IsPhysicalRopeElement(CElement* pElement)
+{
+    return pElement && (IS_OBJECT(pElement) || IS_VEHICLE(pElement));
+}
+
+void StoreNumber(CElement* pRope, const char* key, double value, ESyncType syncType)
+{
+    CLuaArgument argument;
+    argument.ReadNumber(value);
+    pRope->GetCustomDataManager().Set(key, argument, syncType);
+}
+
+void SetInitialNumber(CElement* pRope, const char* key, double value)
+{
+    StoreNumber(pRope, key, value, ESyncType::BROADCAST);
+}
+
+void SetInitialBool(CElement* pRope, const char* key, bool value)
+{
+    CLuaArgument argument;
+    argument.ReadBool(value);
+    pRope->GetCustomDataManager().Set(key, argument, ESyncType::BROADCAST);
+}
+
+void SetInitialElement(CElement* pRope, const char* key, CElement* value)
+{
+    if (!value)
+        return;
+    CLuaArgument argument;
+    argument.ReadElement(value);
+    pRope->GetCustomDataManager().Set(key, argument, ESyncType::BROADCAST);
+}
+
+void SetNumber(CElement* pRope, const char* key, double value)
+{
+    CLuaArgument argument;
+    argument.ReadNumber(value);
+    CStaticFunctionDefinitions::SetElementData(pRope, key, argument, ESyncType::BROADCAST, std::nullopt);
+}
+
+void SetBool(CElement* pRope, const char* key, bool value)
+{
+    CLuaArgument argument;
+    argument.ReadBool(value);
+    CStaticFunctionDefinitions::SetElementData(pRope, key, argument, ESyncType::BROADCAST, std::nullopt);
+}
+
+void SetElement(CElement* pRope, const char* key, CElement* value)
+{
+    if (!value)
+    {
+        CStaticFunctionDefinitions::RemoveElementData(pRope, key);
+        return;
+    }
+    CLuaArgument argument;
+    argument.ReadElement(value);
+    CStaticFunctionDefinitions::SetElementData(pRope, key, argument, ESyncType::BROADCAST, std::nullopt);
+}
+
+bool GetNumber(CElement* pRope, const char* key, double& value)
+{
+    CLuaArgument* argument = pRope ? pRope->GetCustomData(key, false) : nullptr;
+    if (!argument || argument->GetType() != LUA_TNUMBER)
+        return false;
+    value = argument->GetNumber();
+    return true;
+}
+
+bool GetBool(CElement* pRope, const char* key, bool& value)
+{
+    CLuaArgument* argument = pRope ? pRope->GetCustomData(key, false) : nullptr;
+    if (!argument || argument->GetType() != LUA_TBOOLEAN)
+        return false;
+    value = argument->GetBoolean();
+    return true;
+}
+
+CElement* GetElement(CElement* pRope, const char* key)
+{
+    CLuaArgument* argument = pRope ? pRope->GetCustomData(key, false) : nullptr;
+    return argument ? argument->GetElement() : nullptr;
+}
+
+double ReadTableNumber(lua_State* luaVM, int tableIndex, const char* key, double defaultValue)
+{
+    lua_getfield(luaVM, tableIndex, key);
+    const double value = lua_isnumber(luaVM, -1) ? lua_tonumber(luaVM, -1) : defaultValue;
+    lua_pop(luaVM, 1);
+    return std::isfinite(value) ? value : defaultValue;
+}
+
+bool ReadTableBool(lua_State* luaVM, int tableIndex, const char* key, bool defaultValue)
+{
+    lua_getfield(luaVM, tableIndex, key);
+    const bool value = lua_isboolean(luaVM, -1) ? lua_toboolean(luaVM, -1) != 0 : defaultValue;
+    lua_pop(luaVM, 1);
+    return value;
+}
+
+CElement* ReadTableElement(lua_State* luaVM, int tableIndex, const char* key)
+{
+    lua_getfield(luaVM, tableIndex, key);
+    CElement* value = lua_toelement(luaVM, -1);
+    lua_pop(luaVM, 1);
+    return value;
+}
+
+bool ReadVectorTable(lua_State* luaVM, int tableIndex, const char* key, CVector& value)
+{
+    lua_getfield(luaVM, tableIndex, key);
+    if (!lua_istable(luaVM, -1))
+    {
+        lua_pop(luaVM, 1);
+        return false;
+    }
+
+    auto readComponent = [luaVM](const char* name, int arrayIndex, float& out) {
+        lua_getfield(luaVM, -1, name);
+        if (!lua_isnumber(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            lua_rawgeti(luaVM, -1, arrayIndex);
+        }
+        if (!lua_isnumber(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            return false;
+        }
+        out = static_cast<float>(lua_tonumber(luaVM, -1));
+        lua_pop(luaVM, 1);
+        return std::isfinite(out);
+    };
+
+    const bool ok = readComponent("x", 1, value.fX) && readComponent("y", 2, value.fY) && readComponent("z", 3, value.fZ);
+    lua_pop(luaVM, 1);
+    return ok;
+}
+
+void PushVector3(lua_State* luaVM, const CVector& value)
+{
+    lua_getglobal(luaVM, "Vector3");
+    lua_pushnumber(luaVM, value.fX);
+    lua_pushnumber(luaVM, value.fY);
+    lua_pushnumber(luaVM, value.fZ);
+    lua_call(luaVM, 3, 1);
+}
+
+int RopeTypeFromName(const char* name)
+{
+    if (!name) return 0;
+    if (strcmp(name, "winchMagnet") == 0) return 1;
+    if (strcmp(name, "harness") == 0) return 2;
+    if (strcmp(name, "miniMagnet") == 0) return 3;
+    if (strcmp(name, "dockCrane") == 0) return 4;
+    if (strcmp(name, "wreckingBall") == 0) return 5;
+    if (strcmp(name, "quarryCrane") == 0) return 6;
+    if (strcmp(name, "vegasCrane") == 0) return 7;
+    if (strcmp(name, "swat") == 0) return 8;
+    return 0;
+}
+
+const char* RopeTypeName(int type)
+{
+    switch (type)
+    {
+        case 1: return "winchMagnet";
+        case 2: return "harness";
+        case 3: return "miniMagnet";
+        case 4: return "dockCrane";
+        case 5: return "wreckingBall";
+        case 6: return "quarryCrane";
+        case 7: return "vegasCrane";
+        case 8: return "swat";
+        default: return nullptr;
+    }
+}
+
+CElement* ReadRope(lua_State* luaVM)
+{
+    CElement* rope = lua_toelement(luaVM, 1);
+    return IsRope(rope) ? rope : nullptr;
+}
+
+void SetInitialVector(CElement* rope, const char* xKey, const char* yKey, const char* zKey, const CVector& value)
+{
+    SetInitialNumber(rope, xKey, value.fX);
+    SetInitialNumber(rope, yKey, value.fY);
+    SetInitialNumber(rope, zKey, value.fZ);
+}
+
+void SetVector(CElement* rope, const char* xKey, const char* yKey, const char* zKey, const CVector& value)
+{
+    SetNumber(rope, xKey, value.fX);
+    SetNumber(rope, yKey, value.fY);
+    SetNumber(rope, zKey, value.fZ);
+}
+
+CVector GetVector(CElement* rope, const char* xKey, const char* yKey, const char* zKey)
+{
+    double x = 0.0, y = 0.0, z = 0.0;
+    GetNumber(rope, xKey, x);
+    GetNumber(rope, yKey, y);
+    GetNumber(rope, zKey, z);
+    return CVector(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z));
+}
+
+CDummy* CreateRopeElement(CResource* resource, const CVector& position, int type, double duration, CElement* holder, const CVector& offset,
+                          const CVector& velocity, unsigned int fixedNode, bool sitOnGround, double winchHeight, double length, CElement* carried,
+                          bool physics, unsigned short dimension = 0, unsigned char interior = 0)
+{
+    if (!resource)
+        return nullptr;
+
+    CDummy* rope = new CDummy(g_pGame->GetGroups(), resource->GetDynamicElementRoot());
+    rope->SetTypeName("rope");
+    rope->SetPosition(position);
+    rope->SetDimension(dimension);
+    rope->SetInterior(interior);
+
+    // All client-visible state is present in the EntityAdd snapshot. This is what
+    // makes late join and resource restart deterministic without a rope-specific RPC.
+    SetInitialNumber(rope, KEY_TYPE, type);
+    SetInitialNumber(rope, KEY_DURATION, duration);
+    SetInitialNumber(rope, KEY_REMAINING, duration);
+    StoreNumber(rope, KEY_EXPIRY, duration > 0.0 ? NowMs() + duration : 0.0, ESyncType::LOCAL);
+    SetInitialElement(rope, KEY_HOLDER, holder);
+    SetInitialVector(rope, KEY_OFFSET_X, KEY_OFFSET_Y, KEY_OFFSET_Z, offset);
+    SetInitialVector(rope, KEY_VELOCITY_X, KEY_VELOCITY_Y, KEY_VELOCITY_Z, velocity);
+    SetInitialNumber(rope, KEY_FIXED_NODE, fixedNode);
+    SetInitialBool(rope, KEY_SIT_ON_GROUND, sitOnGround);
+    SetInitialNumber(rope, KEY_WINCH_HEIGHT, winchHeight);
+    SetInitialNumber(rope, KEY_LENGTH, length);
+    SetInitialElement(rope, KEY_CARRIED, carried);
+    SetInitialBool(rope, KEY_PHYSICS, physics);
+
+    if (CElementGroup* group = resource->GetElementGroup())
+        group->Add(rope);
+
+    g_Ropes.emplace(rope, SRopeRecord{rope, resource});
+
+    if (resource->IsClientSynced())
+    {
+        CEntityAddPacket packet;
+        packet.Add(rope);
+        g_pGame->GetPlayerManager()->BroadcastOnlyJoined(packet);
+    }
+    return rope;
+}
+
+bool DestroyManagedRope(CDummy* rope)
+{
+    if (!rope || !IsRope(rope))
+        return false;
+    g_Ropes.erase(rope);
+    return CStaticFunctionDefinitions::DestroyElement(rope);
+}
+}  // namespace
+
+void CLuaRopeDefs::LoadFunctions()
+{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
+        {"createRope", CreateRope},
+        {"getRopeType", GetRopeType}, {"setRopeType", SetRopeType},
+        {"getRopeDuration", GetRopeDuration}, {"setRopeDuration", SetRopeDuration},
+        {"getRopeRemainingTime", GetRopeRemainingTime}, {"setRopeRemainingTime", SetRopeRemainingTime},
+        {"getRopeHolder", GetRopeHolder}, {"setRopeHolder", SetRopeHolder},
+        {"getRopeHolderOffset", GetRopeHolderOffset}, {"setRopeHolderOffset", SetRopeHolderOffset},
+        {"getRopeTopVelocity", GetRopeTopVelocity}, {"setRopeTopVelocity", SetRopeTopVelocity},
+        {"getRopeWinchHeight", GetRopeWinchHeight}, {"setRopeWinchHeight", SetRopeWinchHeight},
+        {"getRopeLength", GetRopeLength}, {"setRopeLength", SetRopeLength},
+        {"getRopeFixedNode", GetRopeFixedNode}, {"setRopeFixedNode", SetRopeFixedNode},
+        {"isRopeOnGround", IsRopeOnGround}, {"setRopeOnGround", SetRopeOnGround},
+        {"isRopePhysicsEnabled", IsRopePhysicsEnabled}, {"setRopePhysicsEnabled", SetRopePhysicsEnabled},
+        {"getRopeCarriedElement", GetRopeCarriedElement}, {"attachElementToRope", AttachElementToRope}, {"detachElementFromRope", DetachElementFromRope},
+    };
+    for (const auto& [name, function] : functions)
+        CLuaCFunctions::AddFunction(name, function);
+}
+
+void CLuaRopeDefs::OnRopeDestroyed(CDummy* pRope)
+{
+    g_Ropes.erase(pRope);
+}
+
+void CLuaRopeDefs::DoPulse()
+{
+    const double now = NowMs();
+    std::vector<CDummy*> expired;
+    for (auto& [rope, record] : g_Ropes)
+    {
+        if (!rope || rope->IsBeingDeleted())
+            continue;
+
+        double duration = 0.0;
+        double expiry = 0.0;
+        GetNumber(rope, KEY_DURATION, duration);
+        GetNumber(rope, KEY_EXPIRY, expiry);
+        if (duration <= 0.0)
+            continue;
+
+        const double remaining = expiry > 0.0 ? std::max(0.0, expiry - now) : 0.0;
+        // Store without broadcasting every pulse. Existing clients count down
+        // locally while this fresh value is available to a late join snapshot.
+        StoreNumber(rope, KEY_REMAINING, remaining, ESyncType::BROADCAST);
+        if (remaining <= 0.0)
+            expired.push_back(rope);
+    }
+
+    for (CDummy* rope : expired)
+        DestroyManagedRope(rope);
+}
+
+int CLuaRopeDefs::CreateRope(lua_State* luaVM)
+{
+    CVector position;
+    CScriptArgReader args(luaVM);
+    args.ReadVector3D(position);
+    if (args.HasErrors())
+    {
+        m_pScriptDebugging->LogCustom(luaVM, args.GetFullErrorMessage());
+        lua_pushboolean(luaVM, false);
+        return 1;
+    }
+
+    int type = 8;
+    double duration = 0.0;
+    double winchHeight = 0.5;
+    double length = 0.0;
+    unsigned int fixedNode = 0;
+    bool sitOnGround = false;
+    bool physics = true;
+    CVector offset;
+    CVector velocity;
+    CElement* holder = nullptr;
+    CElement* carried = nullptr;
+
+    if (lua_istable(luaVM, 4))
+    {
+        lua_getfield(luaVM, 4, "type");
+        if (lua_isstring(luaVM, -1))
+            type = RopeTypeFromName(lua_tostring(luaVM, -1));
+        lua_pop(luaVM, 1);
+
+        duration = std::max(0.0, ReadTableNumber(luaVM, 4, "duration", duration));
+        winchHeight = ReadTableNumber(luaVM, 4, "winchHeight", winchHeight);
+        length = std::max(0.0, ReadTableNumber(luaVM, 4, "length", length));
+        fixedNode = static_cast<unsigned int>(std::clamp(ReadTableNumber(luaVM, 4, "fixedNode", fixedNode), 0.0, 30.0));
+        sitOnGround = ReadTableBool(luaVM, 4, "sitOnGround", sitOnGround);
+        physics = ReadTableBool(luaVM, 4, "physics", physics);
+        ReadVectorTable(luaVM, 4, "holderOffset", offset);
+        ReadVectorTable(luaVM, 4, "topVelocity", velocity);
+        holder = ReadTableElement(luaVM, 4, "holder");
+        carried = ReadTableElement(luaVM, 4, "carriedElement");
+    }
+
+    if (type < 1 || type > 8 || winchHeight < 0.01 || (holder && !IsPhysicalRopeElement(holder)) || (carried && !IsPhysicalRopeElement(carried)))
+    {
+        lua_pushboolean(luaVM, false);
+        return 1;
+    }
+
+    CLuaMain* luaMain = m_pLuaManager->GetVirtualMachine(luaVM);
+    CResource* resource = luaMain ? luaMain->GetResource() : nullptr;
+    CDummy* rope = CreateRopeElement(resource, position, type, duration, holder, offset, velocity, fixedNode, sitOnGround, winchHeight, length, carried, physics);
+    if (rope)
+        lua_pushelement(luaVM, rope);
+    else
+        lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaRopeDefs::GetRopeType(lua_State* luaVM)
+{
+    CElement* rope = ReadRope(luaVM);
+    double value = 0.0;
+    const char* name = rope && GetNumber(rope, KEY_TYPE, value) ? RopeTypeName(static_cast<int>(value)) : nullptr;
+    if (name) lua_pushstring(luaVM, name); else lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaRopeDefs::SetRopeType(lua_State* luaVM)
+{
+    CElement* rope = ReadRope(luaVM);
+    const int type = lua_isstring(luaVM, 2) ? RopeTypeFromName(lua_tostring(luaVM, 2)) : 0;
+    const bool ok = rope && type > 0;
+    if (ok) SetNumber(rope, KEY_TYPE, type);
+    lua_pushboolean(luaVM, ok);
+    return 1;
+}
+
+#define ROPE_NUMBER_GETTER(Method, Key) \
+    int CLuaRopeDefs::Method(lua_State* luaVM) { CElement* rope = ReadRope(luaVM); double value = 0.0; if (rope && GetNumber(rope, Key, value)) lua_pushnumber(luaVM, value); else lua_pushboolean(luaVM, false); return 1; }
+
+ROPE_NUMBER_GETTER(GetRopeDuration, KEY_DURATION)
+ROPE_NUMBER_GETTER(GetRopeRemainingTime, KEY_REMAINING)
+ROPE_NUMBER_GETTER(GetRopeWinchHeight, KEY_WINCH_HEIGHT)
+ROPE_NUMBER_GETTER(GetRopeLength, KEY_LENGTH)
+ROPE_NUMBER_GETTER(GetRopeFixedNode, KEY_FIXED_NODE)
+
+int CLuaRopeDefs::SetRopeDuration(lua_State* luaVM)
+{
+    CElement* rope = ReadRope(luaVM); double value = luaL_optnumber(luaVM, 2, -1.0); const bool ok = rope && value >= 0.0;
+    if (ok) { SetNumber(rope, KEY_DURATION, value); SetNumber(rope, KEY_REMAINING, value); StoreNumber(rope, KEY_EXPIRY, value > 0.0 ? NowMs() + value : 0.0, ESyncType::LOCAL); }
+    lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::SetRopeRemainingTime(lua_State* luaVM)
+{
+    CElement* rope = ReadRope(luaVM); double value = luaL_optnumber(luaVM, 2, -1.0); const bool ok = rope && value >= 0.0;
+    if (ok) { SetNumber(rope, KEY_REMAINING, value); double duration = 0.0; GetNumber(rope, KEY_DURATION, duration); if (duration <= 0.0 && value > 0.0) SetNumber(rope, KEY_DURATION, value); StoreNumber(rope, KEY_EXPIRY, value > 0.0 ? NowMs() + value : 0.0, ESyncType::LOCAL); }
+    lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::GetRopeHolder(lua_State* luaVM)
+{
+    CElement* rope = ReadRope(luaVM); CElement* value = rope ? GetElement(rope, KEY_HOLDER) : nullptr; if (value) lua_pushelement(luaVM, value); else lua_pushboolean(luaVM, false); return 1;
+}
+
+int CLuaRopeDefs::SetRopeHolder(lua_State* luaVM)
+{
+    CElement* rope = ReadRope(luaVM); CElement* value = lua_isnoneornil(luaVM, 2) ? nullptr : lua_toelement(luaVM, 2);
+    const bool ok = rope && (lua_isnoneornil(luaVM, 2) || IsPhysicalRopeElement(value)); if (ok) SetElement(rope, KEY_HOLDER, value); lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::GetRopeHolderOffset(lua_State* luaVM)
+{
+    CElement* rope = ReadRope(luaVM); if (!rope) { lua_pushboolean(luaVM, false); return 1; } PushVector3(luaVM, GetVector(rope, KEY_OFFSET_X, KEY_OFFSET_Y, KEY_OFFSET_Z)); return 1;
+}
+
+int CLuaRopeDefs::SetRopeHolderOffset(lua_State* luaVM)
+{
+    CElement* rope = nullptr; CVector value; CScriptArgReader args(luaVM); args.ReadUserData(rope); args.ReadVector3D(value);
+    const bool ok = !args.HasErrors() && IsRope(rope); if (ok) SetVector(rope, KEY_OFFSET_X, KEY_OFFSET_Y, KEY_OFFSET_Z, value); lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::GetRopeTopVelocity(lua_State* luaVM)
+{
+    CElement* rope = ReadRope(luaVM); if (!rope) { lua_pushboolean(luaVM, false); return 1; } PushVector3(luaVM, GetVector(rope, KEY_VELOCITY_X, KEY_VELOCITY_Y, KEY_VELOCITY_Z)); return 1;
+}
+
+int CLuaRopeDefs::SetRopeTopVelocity(lua_State* luaVM)
+{
+    CElement* rope = nullptr; CVector value; CScriptArgReader args(luaVM); args.ReadUserData(rope); args.ReadVector3D(value);
+    const bool ok = !args.HasErrors() && IsRope(rope); if (ok) SetVector(rope, KEY_VELOCITY_X, KEY_VELOCITY_Y, KEY_VELOCITY_Z, value); lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::SetRopeWinchHeight(lua_State* luaVM)
+{
+    CElement* rope = ReadRope(luaVM); double value = luaL_optnumber(luaVM, 2, 0.0); const bool ok = rope && value >= 0.01; if (ok) SetNumber(rope, KEY_WINCH_HEIGHT, value); lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::SetRopeLength(lua_State* luaVM)
+{
+    CElement* rope = ReadRope(luaVM); double value = luaL_optnumber(luaVM, 2, -1.0); const bool ok = rope && value >= 0.0; if (ok) SetNumber(rope, KEY_LENGTH, value); lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::SetRopeFixedNode(lua_State* luaVM)
+{
+    CElement* rope = ReadRope(luaVM); int value = static_cast<int>(luaL_optinteger(luaVM, 2, -1)); const bool ok = rope && value >= 0 && value <= 30; if (ok) SetNumber(rope, KEY_FIXED_NODE, value); lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::IsRopeOnGround(lua_State* luaVM)
+{
+    CElement* rope = ReadRope(luaVM); bool value = false; if (rope && GetBool(rope, KEY_SIT_ON_GROUND, value)) lua_pushboolean(luaVM, value); else lua_pushboolean(luaVM, false); return 1;
+}
+
+int CLuaRopeDefs::SetRopeOnGround(lua_State* luaVM)
+{
+    CElement* rope = nullptr; bool value = false; CScriptArgReader args(luaVM); args.ReadUserData(rope); args.ReadBool(value); const bool ok = !args.HasErrors() && IsRope(rope); if (ok) SetBool(rope, KEY_SIT_ON_GROUND, value); lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::IsRopePhysicsEnabled(lua_State* luaVM)
+{
+    CElement* rope = ReadRope(luaVM); bool value = false; if (rope && GetBool(rope, KEY_PHYSICS, value)) lua_pushboolean(luaVM, value); else lua_pushboolean(luaVM, false); return 1;
+}
+
+int CLuaRopeDefs::SetRopePhysicsEnabled(lua_State* luaVM)
+{
+    CElement* rope = nullptr; bool value = false; CScriptArgReader args(luaVM); args.ReadUserData(rope); args.ReadBool(value); const bool ok = !args.HasErrors() && IsRope(rope); if (ok) SetBool(rope, KEY_PHYSICS, value); lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::GetRopeCarriedElement(lua_State* luaVM)
+{
+    CElement* rope = ReadRope(luaVM); CElement* value = rope ? GetElement(rope, KEY_CARRIED) : nullptr; if (value) lua_pushelement(luaVM, value); else lua_pushboolean(luaVM, false); return 1;
+}
+
+int CLuaRopeDefs::AttachElementToRope(lua_State* luaVM)
+{
+    CElement* rope = ReadRope(luaVM); CElement* value = lua_toelement(luaVM, 2); const bool ok = rope && IsPhysicalRopeElement(value); if (ok) SetElement(rope, KEY_CARRIED, value); lua_pushboolean(luaVM, ok); return 1;
+}
+
+int CLuaRopeDefs::DetachElementFromRope(lua_State* luaVM)
+{
+    CElement* rope = ReadRope(luaVM); const bool ok = rope != nullptr; if (ok) SetElement(rope, KEY_CARRIED, nullptr); lua_pushboolean(luaVM, ok); return 1;
+}

--- a/Server/mods/deathmatch/logic/luadefs/CLuaRopeDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaRopeDefs.h
@@ -1,0 +1,47 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  PURPOSE:     Managed rope Lua definitions
+ *
+ *****************************************************************************/
+#pragma once
+
+#include "CLuaDefs.h"
+
+class CDummy;
+
+class CLuaRopeDefs : public CLuaDefs
+{
+public:
+    static void LoadFunctions();
+    static void DoPulse();
+    static void OnRopeDestroyed(CDummy* pRope);
+
+    LUA_DECLARE(CreateRope);
+    LUA_DECLARE(GetRopeType);
+    LUA_DECLARE(SetRopeType);
+    LUA_DECLARE(GetRopeDuration);
+    LUA_DECLARE(SetRopeDuration);
+    LUA_DECLARE(GetRopeRemainingTime);
+    LUA_DECLARE(SetRopeRemainingTime);
+    LUA_DECLARE(GetRopeHolder);
+    LUA_DECLARE(SetRopeHolder);
+    LUA_DECLARE(GetRopeHolderOffset);
+    LUA_DECLARE(SetRopeHolderOffset);
+    LUA_DECLARE(GetRopeTopVelocity);
+    LUA_DECLARE(SetRopeTopVelocity);
+    LUA_DECLARE(GetRopeWinchHeight);
+    LUA_DECLARE(SetRopeWinchHeight);
+    LUA_DECLARE(GetRopeLength);
+    LUA_DECLARE(SetRopeLength);
+    LUA_DECLARE(GetRopeFixedNode);
+    LUA_DECLARE(SetRopeFixedNode);
+    LUA_DECLARE(IsRopeOnGround);
+    LUA_DECLARE(SetRopeOnGround);
+    LUA_DECLARE(IsRopePhysicsEnabled);
+    LUA_DECLARE(SetRopePhysicsEnabled);
+    LUA_DECLARE(GetRopeCarriedElement);
+    LUA_DECLARE(AttachElementToRope);
+    LUA_DECLARE(DetachElementFromRope);
+};

--- a/test-resources/rope-showcase/README.md
+++ b/test-resources/rope-showcase/README.md
@@ -23,14 +23,14 @@ The resource moves the player into an isolated dimension, hides the HUD/chat, ru
 The shot is intentionally built around visible API behavior rather than debug text:
 
 1. three managed ropes are created close together using native GTA rope types (`miniMagnet`, `wreckingBall`, `harness`);
-2. a synchronized dynamic crate is assigned to the showcase player as its physics syncer;
-3. the hero magnet rope explicitly picks the crate up with `attachElementToRope`;
+2. a synchronized dynamic crate is explicitly assigned to the showcase player as its physics syncer;
+3. the hero magnet rope picks the crate up with `attachElementToRope`;
 4. `setRopeWinchHeight` lowers and raises the suspended load while the scripted top anchor moves sideways, producing native rope/cargo motion;
 5. the two secondary rope types animate independently in the same shot;
 6. `detachElementFromRope` releases the crate and native dynamic-object physics takes over for the drop;
 7. the camera follows the release and pulls back for the final frame.
 
-The cargo is server-owned and has `setObjectDynamicPhysics` enabled server-side. The sequence waits until the showcase player is the object's syncer before starting, so the Rope manager exercises the same sync-owner-safe physical path used in multiplayer rather than relying on a purely local fake.
+The cargo is server-owned and has `setObjectDynamicPhysics` enabled server-side. Because this is a deterministic one-player showcase, the server explicitly calls `setElementSyncer(cargo, player)` and then waits a short grace period for the client-side object-sync ownership transition before starting. The Rope manager therefore exercises the same sync-owner-safe physical path used in multiplayer rather than relying on a purely local fake.
 
 ## Recording intent
 
@@ -42,4 +42,4 @@ Before recording, run:
 /ropetest all
 ```
 
-and confirm the Rope harness has no `FAIL` lines. If the showcase reports that cargo sync ownership was not assigned, stop/restart the resource and retry after the player is fully spawned.
+and confirm the Rope harness has no `FAIL` lines.

--- a/test-resources/rope-showcase/README.md
+++ b/test-resources/rope-showcase/README.md
@@ -1,0 +1,45 @@
+# Managed rope showcase
+
+A short cinematic resource for recording the managed Rope API in action.
+
+## Run
+
+Start `rope-showcase`, join the server, then run:
+
+```text
+/ropeshow
+```
+
+Stop/reset early with:
+
+```text
+/ropeshow stop
+```
+
+The resource moves the player into an isolated dimension, hides the HUD/chat, runs the sequence, then restores the original player state automatically.
+
+## Sequence
+
+The shot is intentionally built around visible API behavior rather than debug text:
+
+1. three managed ropes are created close together using native GTA rope types (`miniMagnet`, `wreckingBall`, `harness`);
+2. a synchronized dynamic crate is assigned to the showcase player as its physics syncer;
+3. the hero magnet rope explicitly picks the crate up with `attachElementToRope`;
+4. `setRopeWinchHeight` lowers and raises the suspended load while the scripted top anchor moves sideways, producing native rope/cargo motion;
+5. the two secondary rope types animate independently in the same shot;
+6. `detachElementFromRope` releases the crate and native dynamic-object physics takes over for the drop;
+7. the camera follows the release and pulls back for the final frame.
+
+The cargo is server-owned and has `setObjectDynamicPhysics` enabled server-side. The sequence waits until the showcase player is the object's syncer before starting, so the Rope manager exercises the same sync-owner-safe physical path used in multiplayer rather than relying on a purely local fake.
+
+## Recording intent
+
+The full sequence is about 33 seconds. For a short README clip, the strongest section starts around the winch movement and runs through the crate release.
+
+Before recording, run:
+
+```text
+/ropetest all
+```
+
+and confirm the Rope harness has no `FAIL` lines. If the showcase reports that cargo sync ownership was not assigned, stop/restart the resource and retry after the player is fully spawned.

--- a/test-resources/rope-showcase/README.md
+++ b/test-resources/rope-showcase/README.md
@@ -33,10 +33,12 @@ It remains in its own showcase dimension, so the Rope and 2DFX resources do not 
 The three native rope types are separated into clear left/center/right demonstrations with world-space labels:
 
 1. **Left — Wrecking Ball**: a `wreckingBall` rope uses GTA's native weighted ball hook. The invisible physical holder moves laterally so the ball visibly swings. Its rope length is explicitly shortened so the native ball remains well above the runway instead of initializing below terrain.
-2. **Center — Mini Magnet**: a `miniMagnet` rope explicitly picks up a local crate. The rope shortens to hoist it, the holder translates while the crate follows through native rope physics, and the crate is released near the final wide shot.
-3. **Right — Harness**: a `harness` rope explicitly carries a local Bobcat vehicle. During the right-side close-up the rope shortens and the vehicle is visibly lifted off the runway.
+2. **Center — Mini Magnet**: the crate begins resting on the runway. During the center close-up it is unfrozen immediately before `attachElementToRope`, picked up by the `miniMagnet`, hoisted by shortening the rope, translated smoothly, and released in the final wide shot.
+3. **Right — Harness**: the Bobcat also begins resting on the runway. It is not attached during setup. As the right-side close-up begins, the vehicle is unfrozen, attached to the `harness`, then visibly lifted by shortening the rope.
 
-The camera first establishes all three setups, then gives each one its own close-up before returning to a final wide shot. Labels remain attached to the relevant payload so the differences are obvious while recording.
+The camera first establishes all three setups, then gives each one its own close-up before returning to a final wide shot. Camera endpoints and holder motion are continuous across shot boundaries to avoid showcase-only snap/stutter artifacts.
+
+Payloads are kept frozen only while they are static runway props. Once a native rope takes ownership, they are unfrozen so the Rope solver is not fighting MTA's frozen-element state.
 
 ## Native-holder safety
 

--- a/test-resources/rope-showcase/README.md
+++ b/test-resources/rope-showcase/README.md
@@ -1,6 +1,6 @@
 # Managed rope showcase
 
-A short cinematic resource for recording the managed Rope API in action.
+A cinematic visual demo for the managed Rope API.
 
 ## Run
 
@@ -16,35 +16,40 @@ Stop/reset early with:
 /ropeshow stop
 ```
 
-The resource moves the player into an isolated dimension, hides the HUD/chat, runs the sequence, then restores the original player state automatically.
+The resource moves the player into an isolated dimension, hides the normal HUD/chat, runs the sequence, then restores the original player state automatically.
 
-## Sequence
+## Location
 
-The shot is intentionally built around visible API behavior rather than debug text:
+The scene uses the same clear Las Venturas runway coordinates as `2dfx-showcase`:
 
-1. three managed ropes are created close together using native GTA rope types (`miniMagnet`, `wreckingBall`, `harness`);
-2. three invisible client-local objects act as the required physical holders for those native winch/crane rope types;
-3. a client-local crate is created for deterministic native rope physics;
-4. the hero magnet rope picks the crate up with `attachElementToRope`;
-5. `setRopeWinchHeight` lowers and raises the suspended load while the hero holder moves sideways, producing native rope/cargo motion;
-6. the two secondary holder/rope pairs animate independently in the same shot;
-7. `detachElementFromRope` releases the crate and the native GTA object continues moving with the release velocity;
-8. the camera follows the release and pulls back for the final frame.
+```text
+center ~= 262.375, 2502.074, 16.484
+```
 
-The showcase intentionally uses client-local holder and cargo objects. Local elements are authoritative by construction in the managed Rope runtime, and GTA's native `CRope::PickUpObject` promotes a picked-up object into the moving physical-object path. This keeps the recording resource deterministic and removes any dependency on server object-sync election.
+It remains in its own showcase dimension, so the Rope and 2DFX resources do not share runtime entities.
 
-Native GTA rope types 1 through 7 require a valid physical holder: `CRope::Update` dereferences that holder during its weight/force pass. Managed ropes of those types remain logical but are not native-leased until an authoritative holder is available. `swat` is the free world-anchored type.
+## What the shot shows
 
-Synchronized object/vehicle authority, leasing and multiplayer state are covered separately by `rope-test`; the showcase is only the visual demonstration resource.
+The three native rope types are separated into clear left/center/right demonstrations with world-space labels:
 
-## Recording intent
+1. **Left — Wrecking Ball**: a `wreckingBall` rope uses GTA's native weighted ball hook. The invisible physical holder moves laterally so the ball visibly swings. Its rope length is explicitly shortened so the native ball remains well above the runway instead of initializing below terrain.
+2. **Center — Mini Magnet**: a `miniMagnet` rope explicitly picks up a local crate. The rope shortens to hoist it, the holder translates while the crate follows through native rope physics, and the crate is released near the final wide shot.
+3. **Right — Harness**: a `harness` rope explicitly carries a local Bobcat vehicle. During the right-side close-up the rope shortens and the vehicle is visibly lifted off the runway.
 
-The full sequence is about 33 seconds. For a short README clip, the strongest section starts around the winch movement and runs through the crate release.
+The camera first establishes all three setups, then gives each one its own close-up before returning to a final wide shot. Labels remain attached to the relevant payload so the differences are obvious while recording.
 
-Before recording, run:
+## Native-holder safety
+
+Native GTA rope types 1 through 7 require a valid physical holder: `CRope::Update` dereferences `m_pRopeHolder` during its force pass. The showcase therefore uses three invisible client-local physical holder objects. `swat` remains the only free world-anchored native type.
+
+Synchronized object/vehicle authority, leasing and multiplayer behavior are covered separately by `rope-test`; this resource is deliberately a deterministic visual demo.
+
+## Before recording
+
+After rebuilding the Rope safety fix, run:
 
 ```text
 /ropetest all
 ```
 
-and confirm the Rope harness has no `FAIL` lines.
+and confirm there are no `FAIL` lines, especially the missing-holder regression and local physical-pickup checks.

--- a/test-resources/rope-showcase/README.md
+++ b/test-resources/rope-showcase/README.md
@@ -23,14 +23,17 @@ The resource moves the player into an isolated dimension, hides the HUD/chat, ru
 The shot is intentionally built around visible API behavior rather than debug text:
 
 1. three managed ropes are created close together using native GTA rope types (`miniMagnet`, `wreckingBall`, `harness`);
-2. a client-local crate is created for deterministic native rope physics;
-3. the hero magnet rope picks the crate up with `attachElementToRope`;
-4. `setRopeWinchHeight` lowers and raises the suspended load while the scripted top anchor moves sideways, producing native rope/cargo motion;
-5. the two secondary rope types animate independently in the same shot;
-6. `detachElementFromRope` releases the crate and the native GTA object continues moving with the release velocity;
-7. the camera follows the release and pulls back for the final frame.
+2. three invisible client-local objects act as the required physical holders for those native winch/crane rope types;
+3. a client-local crate is created for deterministic native rope physics;
+4. the hero magnet rope picks the crate up with `attachElementToRope`;
+5. `setRopeWinchHeight` lowers and raises the suspended load while the hero holder moves sideways, producing native rope/cargo motion;
+6. the two secondary holder/rope pairs animate independently in the same shot;
+7. `detachElementFromRope` releases the crate and the native GTA object continues moving with the release velocity;
+8. the camera follows the release and pulls back for the final frame.
 
-The showcase intentionally uses a client-local cargo object. Local elements are authoritative by construction in the managed Rope runtime, and GTA's native `CRope::PickUpObject` promotes a picked-up object into the moving physical-object path. This keeps the recording resource deterministic and removes any dependency on server object-sync election.
+The showcase intentionally uses client-local holder and cargo objects. Local elements are authoritative by construction in the managed Rope runtime, and GTA's native `CRope::PickUpObject` promotes a picked-up object into the moving physical-object path. This keeps the recording resource deterministic and removes any dependency on server object-sync election.
+
+Native GTA rope types 1 through 7 require a valid physical holder: `CRope::Update` dereferences that holder during its weight/force pass. Managed ropes of those types remain logical but are not native-leased until an authoritative holder is available. `swat` is the free world-anchored type.
 
 Synchronized object/vehicle authority, leasing and multiplayer state are covered separately by `rope-test`; the showcase is only the visual demonstration resource.
 

--- a/test-resources/rope-showcase/README.md
+++ b/test-resources/rope-showcase/README.md
@@ -23,14 +23,16 @@ The resource moves the player into an isolated dimension, hides the HUD/chat, ru
 The shot is intentionally built around visible API behavior rather than debug text:
 
 1. three managed ropes are created close together using native GTA rope types (`miniMagnet`, `wreckingBall`, `harness`);
-2. a synchronized dynamic crate is explicitly assigned to the showcase player as its physics syncer;
+2. a client-local crate is created for deterministic native rope physics;
 3. the hero magnet rope picks the crate up with `attachElementToRope`;
 4. `setRopeWinchHeight` lowers and raises the suspended load while the scripted top anchor moves sideways, producing native rope/cargo motion;
 5. the two secondary rope types animate independently in the same shot;
-6. `detachElementFromRope` releases the crate and native dynamic-object physics takes over for the drop;
+6. `detachElementFromRope` releases the crate and the native GTA object continues moving with the release velocity;
 7. the camera follows the release and pulls back for the final frame.
 
-The cargo is server-owned and has `setObjectDynamicPhysics` enabled server-side. Because this is a deterministic one-player showcase, the server explicitly calls `setElementSyncer(cargo, player)` and then waits a short grace period for the client-side object-sync ownership transition before starting. The Rope manager therefore exercises the same sync-owner-safe physical path used in multiplayer rather than relying on a purely local fake.
+The showcase intentionally uses a client-local cargo object. Local elements are authoritative by construction in the managed Rope runtime, and GTA's native `CRope::PickUpObject` promotes a picked-up object into the moving physical-object path. This keeps the recording resource deterministic and removes any dependency on server object-sync election.
+
+Synchronized object/vehicle authority, leasing and multiplayer state are covered separately by `rope-test`; the showcase is only the visual demonstration resource.
 
 ## Recording intent
 

--- a/test-resources/rope-showcase/client.lua
+++ b/test-resources/rope-showcase/client.lua
@@ -1,4 +1,3 @@
-local CARGO_MODEL = 2912
 local SHOW_DURATION = 33000
 
 local show = {
@@ -102,25 +101,21 @@ local function createRopeAt(x, y, z, ropeType, winchHeight)
     return rope
 end
 
-local function createScene()
+local function createScene(cargo)
     destroyScene()
 
-    local cx, cy, cz = show.centerX, show.centerY, show.centerZ
-
-    show.cargo = track(createObject(CARGO_MODEL, cx, cy, cz + 0.9, 0, 0, 18))
-    if not isElement(show.cargo) then
-        outputDebugString("[ROPE SHOWCASE] Failed to create cargo object", 1)
+    if not isElement(cargo) or getElementType(cargo) ~= "object" then
+        outputDebugString("[ROPE SHOWCASE] Missing synchronized cargo object", 1)
         return false
     end
 
-    configureElement(show.cargo)
-    setElementCollisionsEnabled(show.cargo, true)
-    setElementFrozen(show.cargo, false)
+    local cx, cy, cz = show.centerX, show.centerY, show.centerZ
+    show.cargo = cargo
+
     setObjectProperty(show.cargo, "mass", 45.0)
     setObjectProperty(show.cargo, "turn_mass", 55.0)
     setObjectProperty(show.cargo, "air_resistance", 0.995)
     setObjectProperty(show.cargo, "elasticity", 0.18)
-    setObjectDynamicPhysics(show.cargo, true)
     setElementVelocity(show.cargo, 0, 0, 0)
     setElementAngularVelocity(show.cargo, 0, 0, 0)
 
@@ -189,7 +184,6 @@ local function animateRopes(elapsed)
     if elapsed >= 24750 and not show.cargoReleased and isElement(show.cargo) then
         show.cargoReleased = true
         detachElementFromRope(show.heroRope)
-        setObjectDynamicPhysics(show.cargo, true)
         setElementFrozen(show.cargo, false)
         setElementVelocity(show.cargo, 0.045, 0.015, 0.035)
         setElementAngularVelocity(show.cargo, 0.04, -0.07, 0.12)
@@ -288,7 +282,7 @@ local function stopShow()
 end
 
 addEvent("ropeShowcase:start", true)
-addEventHandler("ropeShowcase:start", resourceRoot, function(centerX, centerY, centerZ, dimension)
+addEventHandler("ropeShowcase:start", resourceRoot, function(centerX, centerY, centerZ, dimension, cargo)
     stopShow()
 
     show.centerX = centerX
@@ -298,7 +292,7 @@ addEventHandler("ropeShowcase:start", resourceRoot, function(centerX, centerY, c
     show.startedAt = getTickCount()
     show.finished = false
 
-    if not createScene() then
+    if not createScene(cargo) then
         outputChatBox("[ROPE SHOWCASE] Scene creation failed; run /ropetest all first.", 255, 90, 90)
         triggerServerEvent("ropeShowcase:finished", resourceRoot)
         return

--- a/test-resources/rope-showcase/client.lua
+++ b/test-resources/rope-showcase/client.lua
@@ -1,0 +1,315 @@
+local CARGO_MODEL = 2912
+local SHOW_DURATION = 33000
+
+local show = {
+    active = false,
+    finished = false,
+    startedAt = 0,
+    centerX = 0,
+    centerY = 0,
+    centerZ = 0,
+    dimension = 0,
+    cargo = nil,
+    heroRope = nil,
+    leftRope = nil,
+    rightRope = nil,
+    elements = {},
+    cargoReleased = false,
+}
+
+local function clamp(value, minimum, maximum)
+    return math.max(minimum, math.min(maximum, value))
+end
+
+local function smoothstep(value)
+    value = clamp(value, 0, 1)
+    return value * value * (3 - 2 * value)
+end
+
+local function lerp(a, b, t)
+    return a + (b - a) * t
+end
+
+local function track(element)
+    if isElement(element) then
+        show.elements[#show.elements + 1] = element
+    end
+    return element
+end
+
+local function configureElement(element)
+    if not isElement(element) then
+        return
+    end
+    setElementInterior(element, 0)
+    setElementDimension(element, show.dimension)
+end
+
+local function destroyScene()
+    if isElement(show.heroRope) and isElement(show.cargo) then
+        detachElementFromRope(show.heroRope)
+    end
+
+    for i = #show.elements, 1, -1 do
+        local element = show.elements[i]
+        if isElement(element) then
+            destroyElement(element)
+        end
+    end
+
+    show.elements = {}
+    show.cargo = nil
+    show.heroRope = nil
+    show.leftRope = nil
+    show.rightRope = nil
+    show.cargoReleased = false
+end
+
+local function setPresentationUI(visible)
+    showPlayerHudComponent("all", visible)
+    showChat(visible)
+end
+
+local function cameraLerp(ax, ay, az, alx, aly, alz, bx, by, bz, blx, bly, blz, t, fovA, fovB)
+    t = smoothstep(t)
+    setCameraMatrix(
+        lerp(ax, bx, t),
+        lerp(ay, by, t),
+        lerp(az, bz, t),
+        lerp(alx, blx, t),
+        lerp(aly, bly, t),
+        lerp(alz, blz, t),
+        0,
+        lerp(fovA or 65, fovB or 65, t)
+    )
+end
+
+local function createRopeAt(x, y, z, ropeType, winchHeight)
+    local rope = createRope(x, y, z, {
+        type = ropeType,
+        duration = 0,
+        fixedNode = 0,
+        sitOnGround = false,
+        winchHeight = winchHeight or 0.35,
+        physics = true,
+    })
+    if not isElement(rope) then
+        return false
+    end
+
+    track(rope)
+    configureElement(rope)
+    return rope
+end
+
+local function createScene()
+    destroyScene()
+
+    local cx, cy, cz = show.centerX, show.centerY, show.centerZ
+
+    show.cargo = track(createObject(CARGO_MODEL, cx, cy, cz + 0.9, 0, 0, 18))
+    if not isElement(show.cargo) then
+        outputDebugString("[ROPE SHOWCASE] Failed to create cargo object", 1)
+        return false
+    end
+
+    configureElement(show.cargo)
+    setElementCollisionsEnabled(show.cargo, true)
+    setElementFrozen(show.cargo, false)
+    setObjectProperty(show.cargo, "mass", 45.0)
+    setObjectProperty(show.cargo, "turn_mass", 55.0)
+    setObjectProperty(show.cargo, "air_resistance", 0.995)
+    setObjectProperty(show.cargo, "elasticity", 0.18)
+    setObjectDynamicPhysics(show.cargo, true)
+    setElementVelocity(show.cargo, 0, 0, 0)
+    setElementAngularVelocity(show.cargo, 0, 0, 0)
+
+    show.heroRope = createRopeAt(cx, cy, cz + 12.5, "miniMagnet", 0.22)
+    show.leftRope = createRopeAt(cx - 7.0, cy + 1.5, cz + 12.0, "wreckingBall", 0.45)
+    show.rightRope = createRopeAt(cx + 7.0, cy + 1.5, cz + 12.0, "harness", 0.60)
+
+    if not isElement(show.heroRope) or not isElement(show.leftRope) or not isElement(show.rightRope) then
+        outputDebugString("[ROPE SHOWCASE] Failed to create one or more ropes", 1)
+        return false
+    end
+
+    if not attachElementToRope(show.heroRope, show.cargo) then
+        outputDebugString("[ROPE SHOWCASE] attachElementToRope failed", 1)
+        return false
+    end
+
+    return true
+end
+
+local function animateRopes(elapsed)
+    local cx, cy, cz = show.centerX, show.centerY, show.centerZ
+    local time = elapsed / 1000.0
+
+    if isElement(show.leftRope) then
+        setElementPosition(show.leftRope, cx - 7.0 + math.sin(time * 0.55) * 0.45, cy + 1.5, cz + 12.0)
+        setRopeWinchHeight(show.leftRope, 0.30 + (math.sin(time * 0.85) * 0.5 + 0.5) * 0.42)
+    end
+
+    if isElement(show.rightRope) then
+        setElementPosition(show.rightRope, cx + 7.0 + math.sin(time * 0.48 + 1.7) * 0.35, cy + 1.5, cz + 12.0)
+        setRopeWinchHeight(show.rightRope, 0.25 + (math.sin(time * 0.72 + 2.2) * 0.5 + 0.5) * 0.48)
+    end
+
+    if not isElement(show.heroRope) then
+        return
+    end
+
+    local anchorX, anchorY, anchorZ = cx, cy, cz + 12.5
+    local winch = 0.22
+
+    if elapsed < 6000 then
+        winch = 0.22
+    elseif elapsed < 12000 then
+        local t = smoothstep((elapsed - 6000) / 6000)
+        winch = lerp(0.22, 0.82, t)
+    elseif elapsed < 20000 then
+        local t = (elapsed - 12000) / 8000
+        anchorX = cx + math.sin(t * math.pi * 1.25) * 6.5
+        anchorY = cy + math.sin(t * math.pi * 2.0) * 1.4
+        anchorZ = cz + 12.5 + math.sin(t * math.pi) * 1.2
+        winch = 0.82
+    elseif elapsed < 24500 then
+        local t = smoothstep((elapsed - 20000) / 4500)
+        anchorX = lerp(cx, cx + 2.0, t)
+        anchorZ = cz + 12.5
+        winch = lerp(0.82, 0.18, t)
+    else
+        anchorX = cx + 2.0 + math.sin(time * 1.1) * 0.55
+        winch = 0.18
+    end
+
+    setElementPosition(show.heroRope, anchorX, anchorY, anchorZ)
+    setRopeWinchHeight(show.heroRope, winch)
+
+    if elapsed >= 24750 and not show.cargoReleased and isElement(show.cargo) then
+        show.cargoReleased = true
+        detachElementFromRope(show.heroRope)
+        setObjectDynamicPhysics(show.cargo, true)
+        setElementFrozen(show.cargo, false)
+        setElementVelocity(show.cargo, 0.045, 0.015, 0.035)
+        setElementAngularVelocity(show.cargo, 0.04, -0.07, 0.12)
+    end
+end
+
+local function updateCamera(elapsed)
+    local cx, cy, cz = show.centerX, show.centerY, show.centerZ
+
+    if elapsed < 7000 then
+        local t = elapsed / 7000
+        cameraLerp(
+            cx, cy - 24.0, cz + 7.0,
+            cx, cy, cz + 5.5,
+            cx + 3.0, cy - 21.0, cz + 6.0,
+            cx, cy, cz + 5.0,
+            t,
+            78, 70
+        )
+    elseif elapsed < 15000 then
+        local t = (elapsed - 7000) / 8000
+        cameraLerp(
+            cx + 3.0, cy - 21.0, cz + 6.0,
+            cx, cy, cz + 5.0,
+            cx + 15.0, cy - 14.0, cz + 8.5,
+            cx, cy, cz + 4.0,
+            t,
+            70, 64
+        )
+    elseif elapsed < 24500 then
+        local cargoX, cargoY, cargoZ = cx, cy, cz + 2.0
+        if isElement(show.cargo) then
+            local x, y, z = getElementPosition(show.cargo)
+            if type(x) == "number" then
+                cargoX, cargoY, cargoZ = x, y, z
+            end
+        end
+
+        local t = smoothstep((elapsed - 15000) / 9500)
+        cameraLerp(
+            cx + 15.0, cy - 14.0, cz + 8.5,
+            cx, cy, cz + 4.0,
+            cargoX + 8.5, cargoY - 10.0, cargoZ + 5.0,
+            cargoX, cargoY, cargoZ + 1.0,
+            t,
+            64, 58
+        )
+    elseif elapsed < 29500 then
+        local cargoX, cargoY, cargoZ = cx + 2.0, cy, cz
+        if isElement(show.cargo) then
+            local x, y, z = getElementPosition(show.cargo)
+            if type(x) == "number" then
+                cargoX, cargoY, cargoZ = x, y, z
+            end
+        end
+
+        setCameraMatrix(cargoX + 8.0, cargoY - 10.5, cargoZ + 5.0, cargoX, cargoY, cargoZ + 0.8, 0, 58)
+    else
+        local t = smoothstep((elapsed - 29500) / 3500)
+        cameraLerp(
+            cx + 10.0, cy - 13.0, cz + 5.5,
+            cx, cy, cz + 3.0,
+            cx, cy - 25.0, cz + 8.0,
+            cx, cy, cz + 5.0,
+            t,
+            62, 76
+        )
+    end
+end
+
+local function renderShow()
+    if not show.active then
+        return
+    end
+
+    local elapsed = getTickCount() - show.startedAt
+    animateRopes(elapsed)
+    updateCamera(elapsed)
+
+    if elapsed >= SHOW_DURATION and not show.finished then
+        show.finished = true
+        triggerServerEvent("ropeShowcase:finished", resourceRoot)
+    end
+end
+
+local function stopShow()
+    if show.active then
+        removeEventHandler("onClientRender", root, renderShow)
+    end
+
+    show.active = false
+    show.finished = false
+    destroyScene()
+    setCameraTarget(localPlayer)
+    setPresentationUI(true)
+end
+
+addEvent("ropeShowcase:start", true)
+addEventHandler("ropeShowcase:start", resourceRoot, function(centerX, centerY, centerZ, dimension)
+    stopShow()
+
+    show.centerX = centerX
+    show.centerY = centerY
+    show.centerZ = centerZ
+    show.dimension = dimension
+    show.startedAt = getTickCount()
+    show.finished = false
+
+    if not createScene() then
+        outputChatBox("[ROPE SHOWCASE] Scene creation failed; run /ropetest all first.", 255, 90, 90)
+        triggerServerEvent("ropeShowcase:finished", resourceRoot)
+        return
+    end
+
+    show.active = true
+    setPresentationUI(false)
+    addEventHandler("onClientRender", root, renderShow)
+end)
+
+addEvent("ropeShowcase:stop", true)
+addEventHandler("ropeShowcase:stop", resourceRoot, stopShow)
+
+addEventHandler("onClientResourceStop", resourceRoot, stopShow)

--- a/test-resources/rope-showcase/client.lua
+++ b/test-resources/rope-showcase/client.lua
@@ -1,7 +1,7 @@
 local ANCHOR_MODEL = 1337
 local CARGO_MODEL = 2912
 local HARNESS_VEHICLE_MODEL = 422
-local SHOW_DURATION = 36000
+local SHOW_DURATION = 38000
 local STAGE_SPACING = 18.0
 local ANCHOR_Z_OFFSET = 18.0
 
@@ -23,6 +23,8 @@ local show = {
     leftRope = nil,
     rightRope = nil,
     elements = {},
+    heroAttached = false,
+    harnessAttached = false,
     cargoReleased = false,
     prepareTimer = nil,
     beginTimer = nil,
@@ -68,10 +70,10 @@ local function clearTimers()
 end
 
 local function destroyScene()
-    if isElement(show.heroRope) and isElement(show.cargo) then
+    if show.heroAttached and isElement(show.heroRope) and isElement(show.cargo) then
         detachElementFromRope(show.heroRope)
     end
-    if isElement(show.rightRope) and isElement(show.harnessVehicle) then
+    if show.harnessAttached and isElement(show.rightRope) and isElement(show.harnessVehicle) then
         detachElementFromRope(show.rightRope)
     end
 
@@ -91,6 +93,8 @@ local function destroyScene()
     show.heroRope = nil
     show.leftRope = nil
     show.rightRope = nil
+    show.heroAttached = false
+    show.harnessAttached = false
     show.cargoReleased = false
 end
 
@@ -155,7 +159,7 @@ end
 local function createScene()
     destroyScene()
 
-    local cx, cy, cz = show.centerX, show.centerY, show.centerZ
+    local cx, cz = show.centerX, show.centerZ
     local stageY = show.stageY
     local leftX = cx - STAGE_SPACING
     local rightX = cx + STAGE_SPACING
@@ -170,18 +174,22 @@ local function createScene()
         return false
     end
 
-    -- Explicit short lengths keep the native hook objects well above runway Z.
-    -- WRECKING_BALL otherwise initializes with roughly 68 units of rope.
+    -- The wrecking ball is intentionally short so its native hook stays visible.
+    -- Magnet/harness start long enough for their hooks to sit close to the payloads
+    -- on the runway before the scripted pickup happens in their camera shot.
     show.leftRope = createRopeForAnchor(show.leftAnchor, "wreckingBall", 12.5, 0.48)
-    show.heroRope = createRopeForAnchor(show.heroAnchor, "miniMagnet", 11.0, 0.52)
-    show.rightRope = createRopeForAnchor(show.rightAnchor, "harness", 12.0, 0.56)
+    show.heroRope = createRopeForAnchor(show.heroAnchor, "miniMagnet", 16.5, 0.52)
+    show.rightRope = createRopeForAnchor(show.rightAnchor, "harness", 15.5, 0.56)
 
     if not isElement(show.heroRope) or not isElement(show.leftRope) or not isElement(show.rightRope) then
         outputDebugString("[ROPE SHOWCASE] Failed to create one or more ropes", 1)
         return false
     end
 
-    show.cargo = track(createObject(CARGO_MODEL, cx, stageY, cz + 6.0, 0, 0, 18))
+    -- Both carried elements begin visibly on the runway and stay frozen only
+    -- while they are props. They are unfrozen immediately before native pickup,
+    -- avoiding a fight between MTA frozen state and CRope's physical solver.
+    show.cargo = track(createObject(CARGO_MODEL, cx, stageY, cz + 0.65, 0, 0, 18))
     if not isElement(show.cargo) then
         outputDebugString("[ROPE SHOWCASE] Failed to create center cargo", 1)
         return false
@@ -194,7 +202,7 @@ local function createScene()
     setObjectProperty(show.cargo, "air_resistance", 0.995)
     setObjectProperty(show.cargo, "elasticity", 0.18)
 
-    show.harnessVehicle = track(createVehicle(HARNESS_VEHICLE_MODEL, rightX, stageY, cz + 5.0, 0, 0, 180))
+    show.harnessVehicle = track(createVehicle(HARNESS_VEHICLE_MODEL, rightX, stageY, cz + 1.0, 0, 0, 180))
     if not isElement(show.harnessVehicle) then
         outputDebugString("[ROPE SHOWCASE] Failed to create harness vehicle", 1)
         return false
@@ -203,16 +211,35 @@ local function createScene()
     setElementCollisionsEnabled(show.harnessVehicle, true)
     setElementFrozen(show.harnessVehicle, true)
 
-    if not attachElementToRope(show.heroRope, show.cargo) then
-        outputDebugString("[ROPE SHOWCASE] Center miniMagnet attach failed", 1)
-        return false
-    end
-    if not attachElementToRope(show.rightRope, show.harnessVehicle) then
-        outputDebugString("[ROPE SHOWCASE] Harness vehicle attach failed", 1)
-        return false
+    return true
+end
+
+local function attachCenterCargo()
+    if show.heroAttached or not isElement(show.heroRope) or not isElement(show.cargo) then
+        return
     end
 
-    return true
+    setElementVelocity(show.cargo, 0, 0, 0)
+    setElementAngularVelocity(show.cargo, 0, 0, 0)
+    setElementFrozen(show.cargo, false)
+    show.heroAttached = attachElementToRope(show.heroRope, show.cargo) == true
+    if not show.heroAttached then
+        outputDebugString("[ROPE SHOWCASE] Center miniMagnet attach failed", 1)
+    end
+end
+
+local function attachHarnessVehicle()
+    if show.harnessAttached or not isElement(show.rightRope) or not isElement(show.harnessVehicle) then
+        return
+    end
+
+    setElementVelocity(show.harnessVehicle, 0, 0, 0)
+    setElementAngularVelocity(show.harnessVehicle, 0, 0, 0)
+    setElementFrozen(show.harnessVehicle, false)
+    show.harnessAttached = attachElementToRope(show.rightRope, show.harnessVehicle) == true
+    if not show.harnessAttached then
+        outputDebugString("[ROPE SHOWCASE] Harness vehicle attach failed", 1)
+    end
 end
 
 local function animateRopes(elapsed)
@@ -223,8 +250,7 @@ local function animateRopes(elapsed)
     local anchorZ = cz + ANCHOR_Z_OFFSET
     local time = elapsed / 1000.0
 
-    -- LEFT: the native wrecking-ball hook is the payload. Moving the holder
-    -- laterally makes its weight/swing immediately distinguishable from a bare rope.
+    -- LEFT: native wrecking-ball hook as the payload.
     if isElement(show.leftAnchor) and isElement(show.leftRope) then
         local swing = math.sin(time * 1.05)
         setElementPosition(show.leftAnchor, leftX + swing * 3.7, stageY + math.sin(time * 0.52) * 0.7, anchorZ)
@@ -232,25 +258,32 @@ local function animateRopes(elapsed)
         setRopeWinchHeight(show.leftRope, 0.48)
     end
 
-    -- CENTER: visibly hoist the crate, translate it, then release it in the final shot.
+    -- CENTER: the crate stays on the runway until the center close-up, then gets
+    -- picked up, hoisted and translated. Every phase joins continuously.
+    if elapsed >= 13300 then
+        attachCenterCargo()
+    end
+
     if isElement(show.heroAnchor) and isElement(show.heroRope) then
         local heroX, heroY, heroZ = cx, stageY, anchorZ
-        local heroLength = 11.0
+        local heroLength = 16.5
 
-        if elapsed >= 9000 and elapsed < 16000 then
-            heroLength = lerp(11.0, 6.6, smoothstep((elapsed - 9000) / 7000))
-        elseif elapsed >= 16000 and elapsed < 24500 then
-            local t = (elapsed - 16000) / 8500
-            heroX = cx + math.sin(t * math.pi * 1.35) * 5.2
-            heroY = stageY + math.sin(t * math.pi * 2.0) * 1.5
-            heroZ = anchorZ + math.sin(t * math.pi) * 1.0
-            heroLength = 6.6
-        elseif elapsed >= 24500 and elapsed < 30200 then
-            heroLength = lerp(6.6, 9.2, smoothstep((elapsed - 24500) / 5700))
-            heroX = cx + 1.5
-        elseif elapsed >= 30200 then
-            heroLength = 9.2
-            heroX = cx + 1.5
+        if elapsed >= 14000 and elapsed < 19000 then
+            heroLength = lerp(16.5, 8.5, smoothstep((elapsed - 14000) / 5000))
+        elseif elapsed >= 19000 and elapsed < 23000 then
+            local t = smoothstep((elapsed - 19000) / 4000)
+            heroX = lerp(cx, cx + 4.0, t)
+            heroY = stageY + math.sin(t * math.pi) * 1.0
+            heroLength = 8.5
+        elseif elapsed >= 23000 and elapsed < 26000 then
+            heroX = cx + 4.0
+            heroLength = 8.5
+        elseif elapsed >= 26000 and elapsed < 30000 then
+            heroX = cx + 4.0
+            heroLength = lerp(8.5, 10.0, smoothstep((elapsed - 26000) / 4000))
+        elseif elapsed >= 30000 then
+            heroX = cx + 4.0
+            heroLength = 10.0
         end
 
         setElementPosition(show.heroAnchor, heroX, heroY, heroZ)
@@ -258,27 +291,37 @@ local function animateRopes(elapsed)
         setRopeWinchHeight(show.heroRope, 0.52)
     end
 
-    -- RIGHT: the harness carries a real local Bobcat. It starts lower, then the
-    -- rope shortens during the right-side close-up so the whole vehicle lifts.
+    -- RIGHT: Bobcat is visibly on the runway through the establishing/center
+    -- shots. The harness picks it up only as the camera starts the right shot.
+    if elapsed >= 23200 then
+        attachHarnessVehicle()
+    end
+
     if isElement(show.rightAnchor) and isElement(show.rightRope) then
-        local rightLength = 12.0
+        local rightLength = 15.5
+        local rightXOffset = 0.0
         local rightZ = anchorZ
-        if elapsed >= 19000 and elapsed < 28500 then
-            rightLength = lerp(12.0, 8.0, smoothstep((elapsed - 19000) / 9500))
-            rightZ = anchorZ + smoothstep((elapsed - 19000) / 9500) * 1.2
-        elseif elapsed >= 28500 then
-            rightLength = 8.0
-            rightZ = anchorZ + 1.2
+
+        if elapsed >= 24000 and elapsed < 29500 then
+            local t = smoothstep((elapsed - 24000) / 5500)
+            rightLength = lerp(15.5, 8.5, t)
+            rightZ = anchorZ + t * 0.8
+            rightXOffset = math.sin(t * math.pi) * 0.7
+        elseif elapsed >= 29500 then
+            rightLength = 8.5
+            rightZ = anchorZ + 0.8
+            rightXOffset = math.sin((elapsed - 29500) / 1800.0) * 0.35
         end
-        setElementPosition(show.rightAnchor, rightX + math.sin(time * 0.55) * 1.4, stageY, rightZ)
+
+        setElementPosition(show.rightAnchor, rightX + rightXOffset, stageY, rightZ)
         setRopeLength(show.rightRope, rightLength)
         setRopeWinchHeight(show.rightRope, 0.56)
     end
 
-    if elapsed >= 30600 and not show.cargoReleased and isElement(show.cargo) and isElement(show.heroRope) then
+    if elapsed >= 31200 and not show.cargoReleased and show.heroAttached and isElement(show.cargo) and isElement(show.heroRope) then
         show.cargoReleased = true
         detachElementFromRope(show.heroRope)
-        setElementFrozen(show.cargo, false)
+        show.heroAttached = false
         setElementVelocity(show.cargo, 0.035, 0.010, 0.020)
         setElementAngularVelocity(show.cargo, 0.03, -0.05, 0.10)
     end
@@ -290,12 +333,17 @@ local function updateCamera(elapsed)
     local leftX = cx - STAGE_SPACING
     local rightX = cx + STAGE_SPACING
 
-    -- 0-7s: establish all three demonstrations at once.
+    local wideX, wideY, wideZ = cx + 2.0, stageY - 43.0, cz + 11.5
+    local leftCamX, leftCamY, leftCamZ = leftX + 8.0, stageY - 19.0, cz + 9.0
+    local centerCamX, centerCamY, centerCamZ = cx + 10.0, stageY - 19.0, cz + 10.0
+    local rightCamX, rightCamY, rightCamZ = rightX - 9.0, stageY - 19.0, cz + 9.5
+
+    -- 0-7s: establish all three demonstrations.
     if elapsed < 7000 then
         cameraLerp(
             cx, stageY - 50.0, cz + 10.5,
             cx, stageY, cz + 8.0,
-            cx + 2.0, stageY - 43.0, cz + 11.5,
+            wideX, wideY, wideZ,
             cx, stageY, cz + 8.0,
             elapsed / 7000,
             76, 70
@@ -305,61 +353,52 @@ local function updateCamera(elapsed)
 
     -- 7-13s: wrecking ball close-up.
     if elapsed < 13000 then
-        local t = (elapsed - 7000) / 6000
         cameraLerp(
-            cx + 2.0, stageY - 43.0, cz + 11.5,
+            wideX, wideY, wideZ,
             cx, stageY, cz + 8.0,
-            leftX + 8.0, stageY - 19.0, cz + 9.0,
+            leftCamX, leftCamY, leftCamZ,
             leftX, stageY, cz + 7.5,
-            t,
+            (elapsed - 7000) / 6000,
             70, 58
         )
         return
     end
 
-    -- 13-23s: mini magnet + crate hoist.
+    -- 13-23s: mini magnet pickup + crate hoist. Fixed shot endpoints keep the
+    -- 23s handoff continuous even while the crate itself is moving.
     if elapsed < 23000 then
-        local t = (elapsed - 13000) / 10000
-        local cargoX, cargoY, cargoZ = cx, stageY, cz + 5.0
-        if isElement(show.cargo) then
-            cargoX, cargoY, cargoZ = getElementPosition(show.cargo)
-        end
         cameraLerp(
-            leftX + 8.0, stageY - 19.0, cz + 9.0,
+            leftCamX, leftCamY, leftCamZ,
             leftX, stageY, cz + 7.5,
-            cargoX + 9.5, cargoY - 18.0, cargoZ + 6.5,
-            cargoX, cargoY, cargoZ + 1.0,
-            t,
+            centerCamX, centerCamY, centerCamZ,
+            cx + 1.5, stageY, cz + 6.0,
+            (elapsed - 13000) / 10000,
             58, 56
         )
         return
     end
 
-    -- 23-30s: harness + vehicle lift.
+    -- 23-30s: harness pickup + Bobcat lift. This starts exactly where the center
+    -- shot ended, avoiding the old camera snap at the transition.
     if elapsed < 30000 then
-        local t = (elapsed - 23000) / 7000
-        local vx, vy, vz = rightX, stageY, cz + 4.0
-        if isElement(show.harnessVehicle) then
-            vx, vy, vz = getElementPosition(show.harnessVehicle)
-        end
         cameraLerp(
-            cx + 9.5, stageY - 18.0, cz + 11.0,
-            cx, stageY, cz + 6.0,
-            vx - 8.5, vy - 19.0, vz + 6.5,
-            vx, vy, vz + 1.2,
-            t,
-            58, 58
+            centerCamX, centerCamY, centerCamZ,
+            cx + 1.5, stageY, cz + 6.0,
+            rightCamX, rightCamY, rightCamZ,
+            rightX, stageY, cz + 4.5,
+            (elapsed - 23000) / 7000,
+            56, 58
         )
         return
     end
 
-    -- 30-36s: final wide shot, including the center crate release.
+    -- 30-38s: final wide shot, including the center crate release.
     cameraLerp(
-        rightX - 8.5, stageY - 19.0, cz + 10.0,
-        rightX, stageY, cz + 6.0,
+        rightCamX, rightCamY, rightCamZ,
+        rightX, stageY, cz + 4.5,
         cx, stageY - 48.0, cz + 12.0,
         cx, stageY, cz + 7.0,
-        (elapsed - 30000) / 6000,
+        (elapsed - 30000) / 8000,
         58, 74
     )
 end
@@ -395,12 +434,14 @@ local function drawLabels(elapsed)
 
     if isElement(show.cargo) then
         local x, y, z = getElementPosition(show.cargo)
-        worldLabel("MINI MAGNET\nscripted object pickup", x, y, z + 3.0)
+        local action = show.heroAttached and "native object pickup" or "pickup from runway"
+        worldLabel("MINI MAGNET\n" .. action, x, y, z + 3.0)
     end
 
     if isElement(show.harnessVehicle) then
         local x, y, z = getElementPosition(show.harnessVehicle)
-        worldLabel("HARNESS\nvehicle lift", x, y, z + 3.4)
+        local action = show.harnessAttached and "vehicle lift" or "vehicle on runway"
+        worldLabel("HARNESS\n" .. action, x, y, z + 3.4)
     else
         worldLabel("HARNESS", rightX, stageY, cz + 8.0)
     end
@@ -448,13 +489,9 @@ local function beginWhenNativeReady()
             end
             show.prepareTimer = nil
 
-            -- Reassert display lengths after native creation and let the hooks settle
-            -- for a few frames before the fade-in starts.
             setRopeLength(show.leftRope, 12.5)
-            setRopeLength(show.heroRope, 11.0)
-            setRopeLength(show.rightRope, 12.0)
-            setElementFrozen(show.cargo, false)
-            setElementFrozen(show.harnessVehicle, false)
+            setRopeLength(show.heroRope, 16.5)
+            setRopeLength(show.rightRope, 15.5)
 
             setCameraMatrix(show.centerX, show.stageY - 50.0, show.centerZ + 10.5,
                 show.centerX, show.stageY, show.centerZ + 8.0, 0, 76)

--- a/test-resources/rope-showcase/client.lua
+++ b/test-resources/rope-showcase/client.lua
@@ -1,3 +1,4 @@
+local CARGO_MODEL = 2912
 local SHOW_DURATION = 33000
 
 local show = {
@@ -101,17 +102,23 @@ local function createRopeAt(x, y, z, ropeType, winchHeight)
     return rope
 end
 
-local function createScene(cargo)
+local function createScene()
     destroyScene()
 
-    if not isElement(cargo) or getElementType(cargo) ~= "object" then
-        outputDebugString("[ROPE SHOWCASE] Missing synchronized cargo object", 1)
+    local cx, cy, cz = show.centerX, show.centerY, show.centerZ
+
+    -- Keep the showcase cargo local. Local elements are authoritative by
+    -- construction in CClientRopeManager, and native CRope::PickUpObject turns a
+    -- static GTA object into a moving physical object when it is attached.
+    show.cargo = track(createObject(CARGO_MODEL, cx, cy, cz + 0.9, 0, 0, 18))
+    if not isElement(show.cargo) then
+        outputDebugString("[ROPE SHOWCASE] Failed to create local cargo object", 1)
         return false
     end
 
-    local cx, cy, cz = show.centerX, show.centerY, show.centerZ
-    show.cargo = cargo
-
+    configureElement(show.cargo)
+    setElementCollisionsEnabled(show.cargo, true)
+    setElementFrozen(show.cargo, false)
     setObjectProperty(show.cargo, "mass", 45.0)
     setObjectProperty(show.cargo, "turn_mass", 55.0)
     setObjectProperty(show.cargo, "air_resistance", 0.995)
@@ -282,7 +289,7 @@ local function stopShow()
 end
 
 addEvent("ropeShowcase:start", true)
-addEventHandler("ropeShowcase:start", resourceRoot, function(centerX, centerY, centerZ, dimension, cargo)
+addEventHandler("ropeShowcase:start", resourceRoot, function(centerX, centerY, centerZ, dimension)
     stopShow()
 
     show.centerX = centerX
@@ -292,7 +299,7 @@ addEventHandler("ropeShowcase:start", resourceRoot, function(centerX, centerY, c
     show.startedAt = getTickCount()
     show.finished = false
 
-    if not createScene(cargo) then
+    if not createScene() then
         outputChatBox("[ROPE SHOWCASE] Scene creation failed; run /ropetest all first.", 255, 90, 90)
         triggerServerEvent("ropeShowcase:finished", resourceRoot)
         return

--- a/test-resources/rope-showcase/client.lua
+++ b/test-resources/rope-showcase/client.lua
@@ -10,6 +10,9 @@ local show = {
     centerZ = 0,
     dimension = 0,
     cargo = nil,
+    heroAnchor = nil,
+    leftAnchor = nil,
+    rightAnchor = nil,
     heroRope = nil,
     leftRope = nil,
     rightRope = nil,
@@ -59,6 +62,9 @@ local function destroyScene()
 
     show.elements = {}
     show.cargo = nil
+    show.heroAnchor = nil
+    show.leftAnchor = nil
+    show.rightAnchor = nil
     show.heroRope = nil
     show.leftRope = nil
     show.rightRope = nil
@@ -84,9 +90,29 @@ local function cameraLerp(ax, ay, az, alx, aly, alz, bx, by, bz, blx, bly, blz, 
     )
 end
 
-local function createRopeAt(x, y, z, ropeType, winchHeight)
+local function createAnchor(x, y, z)
+    local anchor = track(createObject(CARGO_MODEL, x, y, z, 0, 0, 0))
+    if not isElement(anchor) then
+        return false
+    end
+
+    configureElement(anchor)
+    setElementAlpha(anchor, 0)
+    setElementCollisionsEnabled(anchor, false)
+    setElementFrozen(anchor, true)
+    return anchor
+end
+
+local function createRopeForAnchor(anchor, ropeType, winchHeight)
+    if not isElement(anchor) then
+        return false
+    end
+
+    local x, y, z = getElementPosition(anchor)
     local rope = createRope(x, y, z, {
         type = ropeType,
+        holder = anchor,
+        holderOffset = {0, 0, 0},
         duration = 0,
         fixedNode = 0,
         sitOnGround = false,
@@ -126,9 +152,21 @@ local function createScene()
     setElementVelocity(show.cargo, 0, 0, 0)
     setElementAngularVelocity(show.cargo, 0, 0, 0)
 
-    show.heroRope = createRopeAt(cx, cy, cz + 12.5, "miniMagnet", 0.22)
-    show.leftRope = createRopeAt(cx - 7.0, cy + 1.5, cz + 12.0, "wreckingBall", 0.45)
-    show.rightRope = createRopeAt(cx + 7.0, cy + 1.5, cz + 12.0, "harness", 0.60)
+    -- GTA's winch/crane rope types dereference m_pRopeHolder during CRope::Update.
+    -- Use explicit invisible local objects as stable physical holders instead of
+    -- creating free world-anchored magnet/harness ropes.
+    show.heroAnchor = createAnchor(cx, cy, cz + 12.5)
+    show.leftAnchor = createAnchor(cx - 7.0, cy + 1.5, cz + 12.0)
+    show.rightAnchor = createAnchor(cx + 7.0, cy + 1.5, cz + 12.0)
+
+    if not isElement(show.heroAnchor) or not isElement(show.leftAnchor) or not isElement(show.rightAnchor) then
+        outputDebugString("[ROPE SHOWCASE] Failed to create one or more rope anchors", 1)
+        return false
+    end
+
+    show.heroRope = createRopeForAnchor(show.heroAnchor, "miniMagnet", 0.22)
+    show.leftRope = createRopeForAnchor(show.leftAnchor, "wreckingBall", 0.45)
+    show.rightRope = createRopeForAnchor(show.rightAnchor, "harness", 0.60)
 
     if not isElement(show.heroRope) or not isElement(show.leftRope) or not isElement(show.rightRope) then
         outputDebugString("[ROPE SHOWCASE] Failed to create one or more ropes", 1)
@@ -147,17 +185,17 @@ local function animateRopes(elapsed)
     local cx, cy, cz = show.centerX, show.centerY, show.centerZ
     local time = elapsed / 1000.0
 
-    if isElement(show.leftRope) then
-        setElementPosition(show.leftRope, cx - 7.0 + math.sin(time * 0.55) * 0.45, cy + 1.5, cz + 12.0)
+    if isElement(show.leftAnchor) and isElement(show.leftRope) then
+        setElementPosition(show.leftAnchor, cx - 7.0 + math.sin(time * 0.55) * 0.45, cy + 1.5, cz + 12.0)
         setRopeWinchHeight(show.leftRope, 0.30 + (math.sin(time * 0.85) * 0.5 + 0.5) * 0.42)
     end
 
-    if isElement(show.rightRope) then
-        setElementPosition(show.rightRope, cx + 7.0 + math.sin(time * 0.48 + 1.7) * 0.35, cy + 1.5, cz + 12.0)
+    if isElement(show.rightAnchor) and isElement(show.rightRope) then
+        setElementPosition(show.rightAnchor, cx + 7.0 + math.sin(time * 0.48 + 1.7) * 0.35, cy + 1.5, cz + 12.0)
         setRopeWinchHeight(show.rightRope, 0.25 + (math.sin(time * 0.72 + 2.2) * 0.5 + 0.5) * 0.48)
     end
 
-    if not isElement(show.heroRope) then
+    if not isElement(show.heroRope) or not isElement(show.heroAnchor) then
         return
     end
 
@@ -185,7 +223,7 @@ local function animateRopes(elapsed)
         winch = 0.18
     end
 
-    setElementPosition(show.heroRope, anchorX, anchorY, anchorZ)
+    setElementPosition(show.heroAnchor, anchorX, anchorY, anchorZ)
     setRopeWinchHeight(show.heroRope, winch)
 
     if elapsed >= 24750 and not show.cargoReleased and isElement(show.cargo) then

--- a/test-resources/rope-showcase/client.lua
+++ b/test-resources/rope-showcase/client.lua
@@ -1,5 +1,9 @@
+local ANCHOR_MODEL = 1337
 local CARGO_MODEL = 2912
-local SHOW_DURATION = 33000
+local HARNESS_VEHICLE_MODEL = 422
+local SHOW_DURATION = 36000
+local STAGE_SPACING = 18.0
+local ANCHOR_Z_OFFSET = 18.0
 
 local show = {
     active = false,
@@ -9,7 +13,9 @@ local show = {
     centerY = 0,
     centerZ = 0,
     dimension = 0,
+    stageY = 0,
     cargo = nil,
+    harnessVehicle = nil,
     heroAnchor = nil,
     leftAnchor = nil,
     rightAnchor = nil,
@@ -18,6 +24,8 @@ local show = {
     rightRope = nil,
     elements = {},
     cargoReleased = false,
+    prepareTimer = nil,
+    beginTimer = nil,
 }
 
 local function clamp(value, minimum, maximum)
@@ -48,9 +56,23 @@ local function configureElement(element)
     setElementDimension(element, show.dimension)
 end
 
+local function clearTimers()
+    if isTimer(show.prepareTimer) then
+        killTimer(show.prepareTimer)
+    end
+    if isTimer(show.beginTimer) then
+        killTimer(show.beginTimer)
+    end
+    show.prepareTimer = nil
+    show.beginTimer = nil
+end
+
 local function destroyScene()
     if isElement(show.heroRope) and isElement(show.cargo) then
         detachElementFromRope(show.heroRope)
+    end
+    if isElement(show.rightRope) and isElement(show.harnessVehicle) then
+        detachElementFromRope(show.rightRope)
     end
 
     for i = #show.elements, 1, -1 do
@@ -62,6 +84,7 @@ local function destroyScene()
 
     show.elements = {}
     show.cargo = nil
+    show.harnessVehicle = nil
     show.heroAnchor = nil
     show.leftAnchor = nil
     show.rightAnchor = nil
@@ -91,7 +114,7 @@ local function cameraLerp(ax, ay, az, alx, aly, alz, bx, by, bz, blx, bly, blz, 
 end
 
 local function createAnchor(x, y, z)
-    local anchor = track(createObject(CARGO_MODEL, x, y, z, 0, 0, 0))
+    local anchor = track(createObject(ANCHOR_MODEL, x, y, z, 0, 0, 0))
     if not isElement(anchor) then
         return false
     end
@@ -103,7 +126,7 @@ local function createAnchor(x, y, z)
     return anchor
 end
 
-local function createRopeForAnchor(anchor, ropeType, winchHeight)
+local function createRopeForAnchor(anchor, ropeType, length, winchHeight)
     if not isElement(anchor) then
         return false
     end
@@ -116,7 +139,8 @@ local function createRopeForAnchor(anchor, ropeType, winchHeight)
         duration = 0,
         fixedNode = 0,
         sitOnGround = false,
-        winchHeight = winchHeight or 0.35,
+        winchHeight = winchHeight or 0.5,
+        length = length,
         physics = true,
     })
     if not isElement(rope) then
@@ -132,49 +156,59 @@ local function createScene()
     destroyScene()
 
     local cx, cy, cz = show.centerX, show.centerY, show.centerZ
+    local stageY = show.stageY
+    local leftX = cx - STAGE_SPACING
+    local rightX = cx + STAGE_SPACING
+    local anchorZ = cz + ANCHOR_Z_OFFSET
 
-    -- Keep the showcase cargo local. Local elements are authoritative by
-    -- construction in CClientRopeManager, and native CRope::PickUpObject turns a
-    -- static GTA object into a moving physical object when it is attached.
-    show.cargo = track(createObject(CARGO_MODEL, cx, cy, cz + 0.9, 0, 0, 18))
-    if not isElement(show.cargo) then
-        outputDebugString("[ROPE SHOWCASE] Failed to create local cargo object", 1)
-        return false
-    end
-
-    configureElement(show.cargo)
-    setElementCollisionsEnabled(show.cargo, true)
-    setElementFrozen(show.cargo, false)
-    setObjectProperty(show.cargo, "mass", 45.0)
-    setObjectProperty(show.cargo, "turn_mass", 55.0)
-    setObjectProperty(show.cargo, "air_resistance", 0.995)
-    setObjectProperty(show.cargo, "elasticity", 0.18)
-    setElementVelocity(show.cargo, 0, 0, 0)
-    setElementAngularVelocity(show.cargo, 0, 0, 0)
-
-    -- GTA's winch/crane rope types dereference m_pRopeHolder during CRope::Update.
-    -- Use explicit invisible local objects as stable physical holders instead of
-    -- creating free world-anchored magnet/harness ropes.
-    show.heroAnchor = createAnchor(cx, cy, cz + 12.5)
-    show.leftAnchor = createAnchor(cx - 7.0, cy + 1.5, cz + 12.0)
-    show.rightAnchor = createAnchor(cx + 7.0, cy + 1.5, cz + 12.0)
+    show.heroAnchor = createAnchor(cx, stageY, anchorZ)
+    show.leftAnchor = createAnchor(leftX, stageY, anchorZ)
+    show.rightAnchor = createAnchor(rightX, stageY, anchorZ)
 
     if not isElement(show.heroAnchor) or not isElement(show.leftAnchor) or not isElement(show.rightAnchor) then
-        outputDebugString("[ROPE SHOWCASE] Failed to create one or more rope anchors", 1)
+        outputDebugString("[ROPE SHOWCASE] Failed to create rope holders", 1)
         return false
     end
 
-    show.heroRope = createRopeForAnchor(show.heroAnchor, "miniMagnet", 0.22)
-    show.leftRope = createRopeForAnchor(show.leftAnchor, "wreckingBall", 0.45)
-    show.rightRope = createRopeForAnchor(show.rightAnchor, "harness", 0.60)
+    -- Explicit short lengths keep the native hook objects well above runway Z.
+    -- WRECKING_BALL otherwise initializes with roughly 68 units of rope.
+    show.leftRope = createRopeForAnchor(show.leftAnchor, "wreckingBall", 12.5, 0.48)
+    show.heroRope = createRopeForAnchor(show.heroAnchor, "miniMagnet", 11.0, 0.52)
+    show.rightRope = createRopeForAnchor(show.rightAnchor, "harness", 12.0, 0.56)
 
     if not isElement(show.heroRope) or not isElement(show.leftRope) or not isElement(show.rightRope) then
         outputDebugString("[ROPE SHOWCASE] Failed to create one or more ropes", 1)
         return false
     end
 
+    show.cargo = track(createObject(CARGO_MODEL, cx, stageY, cz + 6.0, 0, 0, 18))
+    if not isElement(show.cargo) then
+        outputDebugString("[ROPE SHOWCASE] Failed to create center cargo", 1)
+        return false
+    end
+    configureElement(show.cargo)
+    setElementCollisionsEnabled(show.cargo, true)
+    setElementFrozen(show.cargo, true)
+    setObjectProperty(show.cargo, "mass", 45.0)
+    setObjectProperty(show.cargo, "turn_mass", 55.0)
+    setObjectProperty(show.cargo, "air_resistance", 0.995)
+    setObjectProperty(show.cargo, "elasticity", 0.18)
+
+    show.harnessVehicle = track(createVehicle(HARNESS_VEHICLE_MODEL, rightX, stageY, cz + 5.0, 0, 0, 180))
+    if not isElement(show.harnessVehicle) then
+        outputDebugString("[ROPE SHOWCASE] Failed to create harness vehicle", 1)
+        return false
+    end
+    configureElement(show.harnessVehicle)
+    setElementCollisionsEnabled(show.harnessVehicle, true)
+    setElementFrozen(show.harnessVehicle, true)
+
     if not attachElementToRope(show.heroRope, show.cargo) then
-        outputDebugString("[ROPE SHOWCASE] attachElementToRope failed", 1)
+        outputDebugString("[ROPE SHOWCASE] Center miniMagnet attach failed", 1)
+        return false
+    end
+    if not attachElementToRope(show.rightRope, show.harnessVehicle) then
+        outputDebugString("[ROPE SHOWCASE] Harness vehicle attach failed", 1)
         return false
     end
 
@@ -182,120 +216,193 @@ local function createScene()
 end
 
 local function animateRopes(elapsed)
-    local cx, cy, cz = show.centerX, show.centerY, show.centerZ
+    local cx, cz = show.centerX, show.centerZ
+    local stageY = show.stageY
+    local leftX = cx - STAGE_SPACING
+    local rightX = cx + STAGE_SPACING
+    local anchorZ = cz + ANCHOR_Z_OFFSET
     local time = elapsed / 1000.0
 
+    -- LEFT: the native wrecking-ball hook is the payload. Moving the holder
+    -- laterally makes its weight/swing immediately distinguishable from a bare rope.
     if isElement(show.leftAnchor) and isElement(show.leftRope) then
-        setElementPosition(show.leftAnchor, cx - 7.0 + math.sin(time * 0.55) * 0.45, cy + 1.5, cz + 12.0)
-        setRopeWinchHeight(show.leftRope, 0.30 + (math.sin(time * 0.85) * 0.5 + 0.5) * 0.42)
+        local swing = math.sin(time * 1.05)
+        setElementPosition(show.leftAnchor, leftX + swing * 3.7, stageY + math.sin(time * 0.52) * 0.7, anchorZ)
+        setRopeLength(show.leftRope, 12.5 + math.sin(time * 0.7) * 0.35)
+        setRopeWinchHeight(show.leftRope, 0.48)
     end
 
+    -- CENTER: visibly hoist the crate, translate it, then release it in the final shot.
+    if isElement(show.heroAnchor) and isElement(show.heroRope) then
+        local heroX, heroY, heroZ = cx, stageY, anchorZ
+        local heroLength = 11.0
+
+        if elapsed >= 9000 and elapsed < 16000 then
+            heroLength = lerp(11.0, 6.6, smoothstep((elapsed - 9000) / 7000))
+        elseif elapsed >= 16000 and elapsed < 24500 then
+            local t = (elapsed - 16000) / 8500
+            heroX = cx + math.sin(t * math.pi * 1.35) * 5.2
+            heroY = stageY + math.sin(t * math.pi * 2.0) * 1.5
+            heroZ = anchorZ + math.sin(t * math.pi) * 1.0
+            heroLength = 6.6
+        elseif elapsed >= 24500 and elapsed < 30200 then
+            heroLength = lerp(6.6, 9.2, smoothstep((elapsed - 24500) / 5700))
+            heroX = cx + 1.5
+        elseif elapsed >= 30200 then
+            heroLength = 9.2
+            heroX = cx + 1.5
+        end
+
+        setElementPosition(show.heroAnchor, heroX, heroY, heroZ)
+        setRopeLength(show.heroRope, heroLength)
+        setRopeWinchHeight(show.heroRope, 0.52)
+    end
+
+    -- RIGHT: the harness carries a real local Bobcat. It starts lower, then the
+    -- rope shortens during the right-side close-up so the whole vehicle lifts.
     if isElement(show.rightAnchor) and isElement(show.rightRope) then
-        setElementPosition(show.rightAnchor, cx + 7.0 + math.sin(time * 0.48 + 1.7) * 0.35, cy + 1.5, cz + 12.0)
-        setRopeWinchHeight(show.rightRope, 0.25 + (math.sin(time * 0.72 + 2.2) * 0.5 + 0.5) * 0.48)
+        local rightLength = 12.0
+        local rightZ = anchorZ
+        if elapsed >= 19000 and elapsed < 28500 then
+            rightLength = lerp(12.0, 8.0, smoothstep((elapsed - 19000) / 9500))
+            rightZ = anchorZ + smoothstep((elapsed - 19000) / 9500) * 1.2
+        elseif elapsed >= 28500 then
+            rightLength = 8.0
+            rightZ = anchorZ + 1.2
+        end
+        setElementPosition(show.rightAnchor, rightX + math.sin(time * 0.55) * 1.4, stageY, rightZ)
+        setRopeLength(show.rightRope, rightLength)
+        setRopeWinchHeight(show.rightRope, 0.56)
     end
 
-    if not isElement(show.heroRope) or not isElement(show.heroAnchor) then
-        return
-    end
-
-    local anchorX, anchorY, anchorZ = cx, cy, cz + 12.5
-    local winch = 0.22
-
-    if elapsed < 6000 then
-        winch = 0.22
-    elseif elapsed < 12000 then
-        local t = smoothstep((elapsed - 6000) / 6000)
-        winch = lerp(0.22, 0.82, t)
-    elseif elapsed < 20000 then
-        local t = (elapsed - 12000) / 8000
-        anchorX = cx + math.sin(t * math.pi * 1.25) * 6.5
-        anchorY = cy + math.sin(t * math.pi * 2.0) * 1.4
-        anchorZ = cz + 12.5 + math.sin(t * math.pi) * 1.2
-        winch = 0.82
-    elseif elapsed < 24500 then
-        local t = smoothstep((elapsed - 20000) / 4500)
-        anchorX = lerp(cx, cx + 2.0, t)
-        anchorZ = cz + 12.5
-        winch = lerp(0.82, 0.18, t)
-    else
-        anchorX = cx + 2.0 + math.sin(time * 1.1) * 0.55
-        winch = 0.18
-    end
-
-    setElementPosition(show.heroAnchor, anchorX, anchorY, anchorZ)
-    setRopeWinchHeight(show.heroRope, winch)
-
-    if elapsed >= 24750 and not show.cargoReleased and isElement(show.cargo) then
+    if elapsed >= 30600 and not show.cargoReleased and isElement(show.cargo) and isElement(show.heroRope) then
         show.cargoReleased = true
         detachElementFromRope(show.heroRope)
         setElementFrozen(show.cargo, false)
-        setElementVelocity(show.cargo, 0.045, 0.015, 0.035)
-        setElementAngularVelocity(show.cargo, 0.04, -0.07, 0.12)
+        setElementVelocity(show.cargo, 0.035, 0.010, 0.020)
+        setElementAngularVelocity(show.cargo, 0.03, -0.05, 0.10)
     end
 end
 
 local function updateCamera(elapsed)
-    local cx, cy, cz = show.centerX, show.centerY, show.centerZ
+    local cx, cz = show.centerX, show.centerZ
+    local stageY = show.stageY
+    local leftX = cx - STAGE_SPACING
+    local rightX = cx + STAGE_SPACING
 
+    -- 0-7s: establish all three demonstrations at once.
     if elapsed < 7000 then
-        local t = elapsed / 7000
         cameraLerp(
-            cx, cy - 24.0, cz + 7.0,
-            cx, cy, cz + 5.5,
-            cx + 3.0, cy - 21.0, cz + 6.0,
-            cx, cy, cz + 5.0,
-            t,
-            78, 70
+            cx, stageY - 50.0, cz + 10.5,
+            cx, stageY, cz + 8.0,
+            cx + 2.0, stageY - 43.0, cz + 11.5,
+            cx, stageY, cz + 8.0,
+            elapsed / 7000,
+            76, 70
         )
-    elseif elapsed < 15000 then
-        local t = (elapsed - 7000) / 8000
-        cameraLerp(
-            cx + 3.0, cy - 21.0, cz + 6.0,
-            cx, cy, cz + 5.0,
-            cx + 15.0, cy - 14.0, cz + 8.5,
-            cx, cy, cz + 4.0,
-            t,
-            70, 64
-        )
-    elseif elapsed < 24500 then
-        local cargoX, cargoY, cargoZ = cx, cy, cz + 2.0
-        if isElement(show.cargo) then
-            local x, y, z = getElementPosition(show.cargo)
-            if type(x) == "number" then
-                cargoX, cargoY, cargoZ = x, y, z
-            end
-        end
+        return
+    end
 
-        local t = smoothstep((elapsed - 15000) / 9500)
+    -- 7-13s: wrecking ball close-up.
+    if elapsed < 13000 then
+        local t = (elapsed - 7000) / 6000
         cameraLerp(
-            cx + 15.0, cy - 14.0, cz + 8.5,
-            cx, cy, cz + 4.0,
-            cargoX + 8.5, cargoY - 10.0, cargoZ + 5.0,
+            cx + 2.0, stageY - 43.0, cz + 11.5,
+            cx, stageY, cz + 8.0,
+            leftX + 8.0, stageY - 19.0, cz + 9.0,
+            leftX, stageY, cz + 7.5,
+            t,
+            70, 58
+        )
+        return
+    end
+
+    -- 13-23s: mini magnet + crate hoist.
+    if elapsed < 23000 then
+        local t = (elapsed - 13000) / 10000
+        local cargoX, cargoY, cargoZ = cx, stageY, cz + 5.0
+        if isElement(show.cargo) then
+            cargoX, cargoY, cargoZ = getElementPosition(show.cargo)
+        end
+        cameraLerp(
+            leftX + 8.0, stageY - 19.0, cz + 9.0,
+            leftX, stageY, cz + 7.5,
+            cargoX + 9.5, cargoY - 18.0, cargoZ + 6.5,
             cargoX, cargoY, cargoZ + 1.0,
             t,
-            64, 58
+            58, 56
         )
-    elseif elapsed < 29500 then
-        local cargoX, cargoY, cargoZ = cx + 2.0, cy, cz
-        if isElement(show.cargo) then
-            local x, y, z = getElementPosition(show.cargo)
-            if type(x) == "number" then
-                cargoX, cargoY, cargoZ = x, y, z
-            end
-        end
+        return
+    end
 
-        setCameraMatrix(cargoX + 8.0, cargoY - 10.5, cargoZ + 5.0, cargoX, cargoY, cargoZ + 0.8, 0, 58)
-    else
-        local t = smoothstep((elapsed - 29500) / 3500)
+    -- 23-30s: harness + vehicle lift.
+    if elapsed < 30000 then
+        local t = (elapsed - 23000) / 7000
+        local vx, vy, vz = rightX, stageY, cz + 4.0
+        if isElement(show.harnessVehicle) then
+            vx, vy, vz = getElementPosition(show.harnessVehicle)
+        end
         cameraLerp(
-            cx + 10.0, cy - 13.0, cz + 5.5,
-            cx, cy, cz + 3.0,
-            cx, cy - 25.0, cz + 8.0,
-            cx, cy, cz + 5.0,
+            cx + 9.5, stageY - 18.0, cz + 11.0,
+            cx, stageY, cz + 6.0,
+            vx - 8.5, vy - 19.0, vz + 6.5,
+            vx, vy, vz + 1.2,
             t,
-            62, 76
+            58, 58
         )
+        return
+    end
+
+    -- 30-36s: final wide shot, including the center crate release.
+    cameraLerp(
+        rightX - 8.5, stageY - 19.0, cz + 10.0,
+        rightX, stageY, cz + 6.0,
+        cx, stageY - 48.0, cz + 12.0,
+        cx, stageY, cz + 7.0,
+        (elapsed - 30000) / 6000,
+        58, 74
+    )
+end
+
+local function worldLabel(text, x, y, z)
+    local sx, sy = getScreenFromWorldPosition(x, y, z, 0.05)
+    if not sx then
+        return
+    end
+
+    dxDrawText(text, sx - 150, sy - 30, sx + 150, sy + 30, tocolor(255, 255, 255, 235), 1.0,
+        "default-bold", "center", "center", false, false, true, true)
+end
+
+local function drawLabels(elapsed)
+    local cx, cz = show.centerX, show.centerZ
+    local stageY = show.stageY
+    local leftX = cx - STAGE_SPACING
+    local rightX = cx + STAGE_SPACING
+
+    if elapsed < 7000 then
+        local sw = guiGetScreenSize()
+        dxDrawText("MANAGED ROPE API  -  3 NATIVE ROPE TYPES", 0, 45, sw, 85, tocolor(255, 255, 255, 235), 1.25,
+            "default-bold", "center", "center", false, false, true, true)
+    end
+
+    local leftPos = isElement(show.leftRope) and getRopePositionAt(show.leftRope, 0.96) or nil
+    if leftPos then
+        worldLabel("WRECKING BALL\nnative weighted hook", leftPos.x, leftPos.y, leftPos.z + 3.0)
+    else
+        worldLabel("WRECKING BALL", leftX, stageY, cz + 8.0)
+    end
+
+    if isElement(show.cargo) then
+        local x, y, z = getElementPosition(show.cargo)
+        worldLabel("MINI MAGNET\nscripted object pickup", x, y, z + 3.0)
+    end
+
+    if isElement(show.harnessVehicle) then
+        local x, y, z = getElementPosition(show.harnessVehicle)
+        worldLabel("HARNESS\nvehicle lift", x, y, z + 3.4)
+    else
+        worldLabel("HARNESS", rightX, stageY, cz + 8.0)
     end
 end
 
@@ -307,6 +414,7 @@ local function renderShow()
     local elapsed = getTickCount() - show.startedAt
     animateRopes(elapsed)
     updateCamera(elapsed)
+    drawLabels(elapsed)
 
     if elapsed >= SHOW_DURATION and not show.finished then
         show.finished = true
@@ -315,6 +423,7 @@ local function renderShow()
 end
 
 local function stopShow()
+    clearTimers()
     if show.active then
         removeEventHandler("onClientRender", root, renderShow)
     end
@@ -326,6 +435,52 @@ local function stopShow()
     setPresentationUI(true)
 end
 
+local function beginWhenNativeReady()
+    local attempts = 0
+    show.prepareTimer = setTimer(function()
+        attempts = attempts + 1
+        local ready = isElement(show.leftRope) and isElement(show.heroRope) and isElement(show.rightRope) and
+            isRopeActive(show.leftRope) and isRopeActive(show.heroRope) and isRopeActive(show.rightRope)
+
+        if ready then
+            if isTimer(show.prepareTimer) then
+                killTimer(show.prepareTimer)
+            end
+            show.prepareTimer = nil
+
+            -- Reassert display lengths after native creation and let the hooks settle
+            -- for a few frames before the fade-in starts.
+            setRopeLength(show.leftRope, 12.5)
+            setRopeLength(show.heroRope, 11.0)
+            setRopeLength(show.rightRope, 12.0)
+            setElementFrozen(show.cargo, false)
+            setElementFrozen(show.harnessVehicle, false)
+
+            setCameraMatrix(show.centerX, show.stageY - 50.0, show.centerZ + 10.5,
+                show.centerX, show.stageY, show.centerZ + 8.0, 0, 76)
+            setPresentationUI(false)
+
+            show.beginTimer = setTimer(function()
+                show.beginTimer = nil
+                show.startedAt = getTickCount()
+                show.active = true
+                addEventHandler("onClientRender", root, renderShow)
+                triggerServerEvent("ropeShowcase:ready", resourceRoot)
+            end, 450, 1)
+            return
+        end
+
+        if attempts >= 30 then
+            if isTimer(show.prepareTimer) then
+                killTimer(show.prepareTimer)
+            end
+            show.prepareTimer = nil
+            outputChatBox("[ROPE SHOWCASE] Native rope slots did not become ready.", 255, 90, 90)
+            triggerServerEvent("ropeShowcase:finished", resourceRoot)
+        end
+    end, 100, 30)
+end
+
 addEvent("ropeShowcase:start", true)
 addEventHandler("ropeShowcase:start", resourceRoot, function(centerX, centerY, centerZ, dimension)
     stopShow()
@@ -333,8 +488,8 @@ addEventHandler("ropeShowcase:start", resourceRoot, function(centerX, centerY, c
     show.centerX = centerX
     show.centerY = centerY
     show.centerZ = centerZ
+    show.stageY = centerY + 4.0
     show.dimension = dimension
-    show.startedAt = getTickCount()
     show.finished = false
 
     if not createScene() then
@@ -343,9 +498,7 @@ addEventHandler("ropeShowcase:start", resourceRoot, function(centerX, centerY, c
         return
     end
 
-    show.active = true
-    setPresentationUI(false)
-    addEventHandler("onClientRender", root, renderShow)
+    beginWhenNativeReady()
 end)
 
 addEvent("ropeShowcase:stop", true)

--- a/test-resources/rope-showcase/meta.xml
+++ b/test-resources/rope-showcase/meta.xml
@@ -1,0 +1,5 @@
+<meta>
+    <info author="MTA Neon" name="Managed rope showcase" type="script" version="1.0" />
+    <script src="server.lua" type="server" />
+    <script src="client.lua" type="client" cache="false" />
+</meta>

--- a/test-resources/rope-showcase/server.lua
+++ b/test-resources/rope-showcase/server.lua
@@ -1,19 +1,30 @@
 local SHOW_DIMENSION = 64988
 local CENTER_X, CENTER_Y, CENTER_Z = 405.0, 2535.0, 22.0
+local CARGO_MODEL = 2912
 
 local state = {
     player = nil,
     saved = nil,
+    cargo = nil,
+    startTimer = nil,
     running = false,
 }
+
+local function clearStartTimer()
+    if isTimer(state.startTimer) then
+        killTimer(state.startTimer)
+    end
+    state.startTimer = nil
+end
 
 local function restore()
     if not state.running then
         return
     end
 
-    local player, saved = state.player, state.saved
+    local player, saved, cargo = state.player, state.saved, state.cargo
     state.running = false
+    clearStartTimer()
 
     if isElement(player) then
         triggerClientEvent(player, "ropeShowcase:stop", resourceRoot)
@@ -27,8 +38,13 @@ local function restore()
         end
     end
 
+    if isElement(cargo) then
+        destroyElement(cargo)
+    end
+
     state.player = nil
     state.saved = nil
+    state.cargo = nil
 end
 
 local function start(player)
@@ -61,11 +77,44 @@ local function start(player)
     setElementAlpha(player, 0)
     setElementFrozen(player, true)
 
-    setTimer(function()
-        if state.running and state.player == player and isElement(player) then
-            triggerClientEvent(player, "ropeShowcase:start", resourceRoot, CENTER_X, CENTER_Y, CENTER_Z, SHOW_DIMENSION)
+    local cargo = createObject(CARGO_MODEL, CENTER_X, CENTER_Y, CENTER_Z + 0.9, 0, 0, 18)
+    if not isElement(cargo) then
+        outputChatBox("[ROPE SHOWCASE] Failed to create cargo object.", player, 255, 90, 90)
+        restore()
+        return
+    end
+
+    state.cargo = cargo
+    setElementInterior(cargo, 0)
+    setElementDimension(cargo, SHOW_DIMENSION)
+    setElementCollisionsEnabled(cargo, true)
+    setElementFrozen(cargo, true)
+    setObjectDynamicPhysics(cargo, true)
+
+    local attempts = 0
+    local function beginWhenAuthoritative()
+        if not state.running or state.player ~= player or state.cargo ~= cargo or not isElement(player) or not isElement(cargo) then
+            return
         end
-    end, 600, 1)
+
+        attempts = attempts + 1
+        if getElementSyncer(cargo) == player then
+            state.startTimer = nil
+            setElementFrozen(cargo, false)
+            triggerClientEvent(player, "ropeShowcase:start", resourceRoot, CENTER_X, CENTER_Y, CENTER_Z, SHOW_DIMENSION, cargo)
+            return
+        end
+
+        if attempts >= 24 then
+            outputChatBox("[ROPE SHOWCASE] Cargo sync ownership was not assigned; showcase aborted.", player, 255, 90, 90)
+            restore()
+            return
+        end
+
+        state.startTimer = setTimer(beginWhenAuthoritative, 250, 1)
+    end
+
+    state.startTimer = setTimer(beginWhenAuthoritative, 750, 1)
 end
 
 addCommandHandler("ropeshow", function(player, _, action)
@@ -98,9 +147,14 @@ end)
 
 addEventHandler("onPlayerQuit", root, function()
     if source == state.player then
+        clearStartTimer()
+        if isElement(state.cargo) then
+            destroyElement(state.cargo)
+        end
         state.running = false
         state.player = nil
         state.saved = nil
+        state.cargo = nil
     end
 end)
 

--- a/test-resources/rope-showcase/server.lua
+++ b/test-resources/rope-showcase/server.lua
@@ -1,11 +1,9 @@
 local SHOW_DIMENSION = 64988
 local CENTER_X, CENTER_Y, CENTER_Z = 405.0, 2535.0, 22.0
-local CARGO_MODEL = 2912
 
 local state = {
     player = nil,
     saved = nil,
-    cargo = nil,
     startTimer = nil,
     running = false,
 }
@@ -22,7 +20,7 @@ local function restore()
         return
     end
 
-    local player, saved, cargo = state.player, state.saved, state.cargo
+    local player, saved = state.player, state.saved
     state.running = false
     clearStartTimer()
 
@@ -38,13 +36,8 @@ local function restore()
         end
     end
 
-    if isElement(cargo) then
-        destroyElement(cargo)
-    end
-
     state.player = nil
     state.saved = nil
-    state.cargo = nil
 end
 
 local function start(player)
@@ -77,64 +70,15 @@ local function start(player)
     setElementAlpha(player, 0)
     setElementFrozen(player, true)
 
-    local cargo = createObject(CARGO_MODEL, CENTER_X, CENTER_Y, CENTER_Z + 0.9, 0, 0, 18)
-    if not isElement(cargo) then
-        outputChatBox("[ROPE SHOWCASE] Failed to create cargo object.", player, 255, 90, 90)
-        restore()
-        return
-    end
-
-    state.cargo = cargo
-    setElementInterior(cargo, 0)
-    setElementDimension(cargo, SHOW_DIMENSION)
-    setElementCollisionsEnabled(cargo, true)
-    setElementFrozen(cargo, true)
-    setObjectDynamicPhysics(cargo, true)
-
-    -- This is a deterministic one-player showcase. Do not wait for the normal
-    -- object-sync election: explicitly nominate the showcase player, then give
-    -- OBJECT_STARTSYNC a short grace period before the rope touches the object.
-    setElementSyncer(cargo, player)
-
-    local attempts = 0
-    local ownershipConfirmedAt = false
-    local function beginWhenAuthoritative()
-        if not state.running or state.player ~= player or state.cargo ~= cargo or not isElement(player) or not isElement(cargo) then
-            return
+    -- The visual cargo is client-local. The synchronized/object-authority path is
+    -- already covered by rope-test; the showcase must be deterministic and must
+    -- not depend on the server object-sync election.
+    state.startTimer = setTimer(function()
+        if state.running and state.player == player and isElement(player) then
+            state.startTimer = nil
+            triggerClientEvent(player, "ropeShowcase:start", resourceRoot, CENTER_X, CENTER_Y, CENTER_Z, SHOW_DIMENSION)
         end
-
-        if getElementSyncer(cargo) ~= player then
-            attempts = attempts + 1
-            setElementSyncer(cargo, player)
-            ownershipConfirmedAt = false
-
-            if attempts >= 24 then
-                outputChatBox("[ROPE SHOWCASE] Could not force cargo sync ownership; showcase aborted.", player, 255, 90, 90)
-                restore()
-                return
-            end
-
-            state.startTimer = setTimer(beginWhenAuthoritative, 250, 1)
-            return
-        end
-
-        if not ownershipConfirmedAt then
-            ownershipConfirmedAt = getTickCount()
-            state.startTimer = setTimer(beginWhenAuthoritative, 500, 1)
-            return
-        end
-
-        if getTickCount() - ownershipConfirmedAt < 500 then
-            state.startTimer = setTimer(beginWhenAuthoritative, 100, 1)
-            return
-        end
-
-        state.startTimer = nil
-        setElementFrozen(cargo, false)
-        triggerClientEvent(player, "ropeShowcase:start", resourceRoot, CENTER_X, CENTER_Y, CENTER_Z, SHOW_DIMENSION, cargo)
-    end
-
-    state.startTimer = setTimer(beginWhenAuthoritative, 500, 1)
+    end, 600, 1)
 end
 
 addCommandHandler("ropeshow", function(player, _, action)
@@ -168,13 +112,9 @@ end)
 addEventHandler("onPlayerQuit", root, function()
     if source == state.player then
         clearStartTimer()
-        if isElement(state.cargo) then
-            destroyElement(state.cargo)
-        end
         state.running = false
         state.player = nil
         state.saved = nil
-        state.cargo = nil
     end
 end)
 

--- a/test-resources/rope-showcase/server.lua
+++ b/test-resources/rope-showcase/server.lua
@@ -91,30 +91,50 @@ local function start(player)
     setElementFrozen(cargo, true)
     setObjectDynamicPhysics(cargo, true)
 
+    -- This is a deterministic one-player showcase. Do not wait for the normal
+    -- object-sync election: explicitly nominate the showcase player, then give
+    -- OBJECT_STARTSYNC a short grace period before the rope touches the object.
+    setElementSyncer(cargo, player)
+
     local attempts = 0
+    local ownershipConfirmedAt = false
     local function beginWhenAuthoritative()
         if not state.running or state.player ~= player or state.cargo ~= cargo or not isElement(player) or not isElement(cargo) then
             return
         end
 
-        attempts = attempts + 1
-        if getElementSyncer(cargo) == player then
-            state.startTimer = nil
-            setElementFrozen(cargo, false)
-            triggerClientEvent(player, "ropeShowcase:start", resourceRoot, CENTER_X, CENTER_Y, CENTER_Z, SHOW_DIMENSION, cargo)
+        if getElementSyncer(cargo) ~= player then
+            attempts = attempts + 1
+            setElementSyncer(cargo, player)
+            ownershipConfirmedAt = false
+
+            if attempts >= 24 then
+                outputChatBox("[ROPE SHOWCASE] Could not force cargo sync ownership; showcase aborted.", player, 255, 90, 90)
+                restore()
+                return
+            end
+
+            state.startTimer = setTimer(beginWhenAuthoritative, 250, 1)
             return
         end
 
-        if attempts >= 24 then
-            outputChatBox("[ROPE SHOWCASE] Cargo sync ownership was not assigned; showcase aborted.", player, 255, 90, 90)
-            restore()
+        if not ownershipConfirmedAt then
+            ownershipConfirmedAt = getTickCount()
+            state.startTimer = setTimer(beginWhenAuthoritative, 500, 1)
             return
         end
 
-        state.startTimer = setTimer(beginWhenAuthoritative, 250, 1)
+        if getTickCount() - ownershipConfirmedAt < 500 then
+            state.startTimer = setTimer(beginWhenAuthoritative, 100, 1)
+            return
+        end
+
+        state.startTimer = nil
+        setElementFrozen(cargo, false)
+        triggerClientEvent(player, "ropeShowcase:start", resourceRoot, CENTER_X, CENTER_Y, CENTER_Z, SHOW_DIMENSION, cargo)
     end
 
-    state.startTimer = setTimer(beginWhenAuthoritative, 750, 1)
+    state.startTimer = setTimer(beginWhenAuthoritative, 500, 1)
 end
 
 addCommandHandler("ropeshow", function(player, _, action)

--- a/test-resources/rope-showcase/server.lua
+++ b/test-resources/rope-showcase/server.lua
@@ -1,5 +1,8 @@
 local SHOW_DIMENSION = 64988
-local CENTER_X, CENTER_Y, CENTER_Z = 405.0, 2535.0, 22.0
+local RUNWAY_START_X, RUNWAY_START_Y, RUNWAY_Z = 100.74450, 2501.11401, 16.48438
+local RUNWAY_END_X, RUNWAY_END_Y = 424.00473, 2503.03442
+local CENTER_X = (RUNWAY_START_X + RUNWAY_END_X) * 0.5
+local CENTER_Y = (RUNWAY_START_Y + RUNWAY_END_Y) * 0.5
 
 local state = {
     player = nil,
@@ -25,15 +28,23 @@ local function restore()
     clearStartTimer()
 
     if isElement(player) then
-        triggerClientEvent(player, "ropeShowcase:stop", resourceRoot)
-        if saved then
-            setElementInterior(player, saved.interior)
-            setElementDimension(player, saved.dimension)
-            setElementPosition(player, saved.x, saved.y, saved.z)
-            setElementRotation(player, saved.rx, saved.ry, saved.rz)
-            setElementAlpha(player, saved.alpha)
-            setElementFrozen(player, saved.frozen)
-        end
+        fadeCamera(player, false, 0.2)
+        setTimer(function()
+            if not isElement(player) then
+                return
+            end
+
+            triggerClientEvent(player, "ropeShowcase:stop", resourceRoot)
+            if saved then
+                setElementInterior(player, saved.interior)
+                setElementDimension(player, saved.dimension)
+                setElementPosition(player, saved.x, saved.y, saved.z)
+                setElementRotation(player, saved.rx, saved.ry, saved.rz)
+                setElementAlpha(player, saved.alpha)
+                setElementFrozen(player, saved.frozen)
+            end
+            fadeCamera(player, true, 0.45)
+        end, 220, 1)
     end
 
     state.player = nil
@@ -64,21 +75,20 @@ local function start(player)
     }
     state.running = true
 
+    fadeCamera(player, false, 0.25)
     setElementInterior(player, 0)
     setElementDimension(player, SHOW_DIMENSION)
-    setElementPosition(player, CENTER_X, CENTER_Y - 40.0, 16.8)
+    setElementPosition(player, CENTER_X, CENTER_Y - 55.0, RUNWAY_Z + 1.0)
+    setElementRotation(player, 0, 0, 0)
     setElementAlpha(player, 0)
     setElementFrozen(player, true)
 
-    -- The visual cargo is client-local. The synchronized/object-authority path is
-    -- already covered by rope-test; the showcase must be deterministic and must
-    -- not depend on the server object-sync election.
     state.startTimer = setTimer(function()
         if state.running and state.player == player and isElement(player) then
             state.startTimer = nil
-            triggerClientEvent(player, "ropeShowcase:start", resourceRoot, CENTER_X, CENTER_Y, CENTER_Z, SHOW_DIMENSION)
+            triggerClientEvent(player, "ropeShowcase:start", resourceRoot, CENTER_X, CENTER_Y, RUNWAY_Z, SHOW_DIMENSION)
         end
-    end, 600, 1)
+    end, 350, 1)
 end
 
 addCommandHandler("ropeshow", function(player, _, action)
@@ -100,6 +110,13 @@ addCommandHandler("ropeshow", function(player, _, action)
     end
 
     start(player)
+end)
+
+addEvent("ropeShowcase:ready", true)
+addEventHandler("ropeShowcase:ready", resourceRoot, function()
+    if client and client == state.player and state.running then
+        fadeCamera(client, true, 0.8)
+    end
 end)
 
 addEvent("ropeShowcase:finished", true)

--- a/test-resources/rope-showcase/server.lua
+++ b/test-resources/rope-showcase/server.lua
@@ -1,0 +1,107 @@
+local SHOW_DIMENSION = 64988
+local CENTER_X, CENTER_Y, CENTER_Z = 405.0, 2535.0, 22.0
+
+local state = {
+    player = nil,
+    saved = nil,
+    running = false,
+}
+
+local function restore()
+    if not state.running then
+        return
+    end
+
+    local player, saved = state.player, state.saved
+    state.running = false
+
+    if isElement(player) then
+        triggerClientEvent(player, "ropeShowcase:stop", resourceRoot)
+        if saved then
+            setElementInterior(player, saved.interior)
+            setElementDimension(player, saved.dimension)
+            setElementPosition(player, saved.x, saved.y, saved.z)
+            setElementRotation(player, saved.rx, saved.ry, saved.rz)
+            setElementAlpha(player, saved.alpha)
+            setElementFrozen(player, saved.frozen)
+        end
+    end
+
+    state.player = nil
+    state.saved = nil
+end
+
+local function start(player)
+    if state.running then
+        outputChatBox("[ROPE SHOWCASE] Another showcase is already running.", player, 255, 90, 90)
+        return
+    end
+
+    local x, y, z = getElementPosition(player)
+    local rx, ry, rz = getElementRotation(player)
+
+    state.player = player
+    state.saved = {
+        x = x,
+        y = y,
+        z = z,
+        rx = rx,
+        ry = ry,
+        rz = rz,
+        interior = getElementInterior(player),
+        dimension = getElementDimension(player),
+        alpha = getElementAlpha(player),
+        frozen = isElementFrozen(player),
+    }
+    state.running = true
+
+    setElementInterior(player, 0)
+    setElementDimension(player, SHOW_DIMENSION)
+    setElementPosition(player, CENTER_X, CENTER_Y - 40.0, 16.8)
+    setElementAlpha(player, 0)
+    setElementFrozen(player, true)
+
+    setTimer(function()
+        if state.running and state.player == player and isElement(player) then
+            triggerClientEvent(player, "ropeShowcase:start", resourceRoot, CENTER_X, CENTER_Y, CENTER_Z, SHOW_DIMENSION)
+        end
+    end, 600, 1)
+end
+
+addCommandHandler("ropeshow", function(player, _, action)
+    if not isElement(player) then
+        return
+    end
+
+    action = (action or "start"):lower()
+    if action == "stop" or action == "reset" then
+        if state.player == player then
+            restore()
+        end
+        return
+    end
+
+    if action ~= "start" then
+        outputChatBox("[ROPE SHOWCASE] Usage: /ropeshow [start|stop]", player, 255, 200, 80)
+        return
+    end
+
+    start(player)
+end)
+
+addEvent("ropeShowcase:finished", true)
+addEventHandler("ropeShowcase:finished", resourceRoot, function()
+    if client and client == state.player then
+        restore()
+    end
+end)
+
+addEventHandler("onPlayerQuit", root, function()
+    if source == state.player then
+        state.running = false
+        state.player = nil
+        state.saved = nil
+    end
+end)
+
+addEventHandler("onResourceStop", resourceRoot, restore)

--- a/test-resources/rope-test/README.md
+++ b/test-resources/rope-test/README.md
@@ -1,0 +1,96 @@
+# Managed rope test harness
+
+This resource exercises the managed Rope API independently from a gameplay resource.
+
+## Automated run
+
+Start `rope-test`, join the server, then run:
+
+```text
+/ropetest all
+```
+
+Both sides report explicit results:
+
+```text
+[ROPETEST] PASS basic.create: userdata
+[ROPETEST] PASS client.native.active: true
+[ROPETEST] PASS client.leasing.native-cap: active=8 logical=12
+[ROPETEST] FAIL client.holder.follow: error=...
+```
+
+The automated run covers:
+
+- synchronized `rope` element creation and destruction;
+- type, duration, remaining time, fixed-node, ground, winch-height and velocity state;
+- client reception of authoritative rope custom data;
+- native GTA rope activation and `getRopePositionAt` interpolation;
+- holder + local-offset tracking;
+- object and vehicle carried-element state;
+- client-local rope creation and mutation;
+- server expiry;
+- twelve logical ropes with no more than eight native leases;
+- coexistence with the legacy `createSWATRope` path.
+
+Individual cases:
+
+```text
+/ropetest basic
+/ropetest holder
+/ropetest pickup
+/ropetest leasing
+/ropetest local
+/ropetest legacy
+/ropetest late
+/ropetest status
+/ropetest reset
+```
+
+## Late join
+
+`/ropetest late` creates a synchronized rope for 30 seconds. Join with another client while it is alive and verify that the second client receives the existing `rope` element and a reduced remaining lifetime rather than a restarted timer.
+
+## API shape exercised
+
+```lua
+local rope = createRope(x, y, z, {
+    type = "miniMagnet",
+    holder = vehicle,
+    holderOffset = {0, 0, -1},
+    duration = 10000,
+    fixedNode = 0,
+    sitOnGround = false,
+    winchHeight = 0.5,
+    topVelocity = {0, 0, 0},
+    carriedElement = object,
+    physics = true,
+})
+
+setRopeTopVelocity(rope, Vector3(0.001, 0, 0))
+setRopeWinchHeight(rope, 0.35)
+attachElementToRope(rope, object)
+
+-- Client-only native solver inspection:
+local position, velocity = getRopePositionAt(rope, 0.5)
+local active = isRopeActive(rope)
+```
+
+Synchronized ropes are authoritative on the server. Clients may inspect them but mutation functions return `false`; client-created ropes are locally mutable.
+
+## Manual physics checks
+
+The automated suite intentionally avoids asserting exact physical trajectories because object/vehicle sync ownership can migrate. Run `/ropetest pickup` and visually verify the following on the current sync owner:
+
+- the `miniMagnet` rope obtains a native hook and picks up the scripted object when that client owns object sync;
+- a non-syncing client sees the same logical carried element but does not fight the networked object's transform;
+- changing object/vehicle sync owner transfers physical authority without deleting the `rope` element;
+- `detachElementFromRope` releases the native carried entity on the owning client;
+- destroying or restarting `rope-test` releases managed native leases and leaves no hook/carried object stuck in GTA's rope pool.
+
+For a two-client authority test, keep `/ropetest pickup` active while causing the carried object's sync owner to change, then use `/ropetest status` and the visible object motion to check that only the current sync owner applies rope physics.
+
+## Native-pool behavior
+
+GTA:SA still owns a fixed eight-entry `CRopes` pool. Managed ropes do not patch or steal active stock slots. More than eight logical `rope` elements are allowed; the client leases free native slots to relevant nearby ropes and leaves the others logical-only until a slot becomes available.
+
+`/ropetest leasing` is the regression test for that contract.

--- a/test-resources/rope-test/client.lua
+++ b/test-resources/rope-test/client.lua
@@ -62,7 +62,9 @@ addEventHandler("ropetest:pickupInspect", resourceRoot, function(rope, object, v
     send(serial, "pickup.synced-state", getRopeCarriedElement(rope) == object, tostring(getRopeCarriedElement(rope)))
     setTimer(function()
         if serial ~= activeSerial or not isElement(rope) then return end
-        send(serial, "pickup.native-rope-active", isRopeActive(rope), tostring(isRopeActive(rope)))
+        -- Regression guard for gta_sa.exe 0x557CEA: winch/crane types 1..7
+        -- must never enter native CRope::Update without a physical holder.
+        send(serial, "pickup.unanchored-native-safe", not isRopeActive(rope), tostring(isRopeActive(rope)))
     end, 800, 1)
 end)
 
@@ -102,6 +104,35 @@ addEventHandler("ropetest:local", resourceRoot, function(serial)
     send(serial, "local.offset-set", setRopeHolderOffset(rope, Vector3(0, 0, -0.5)), vectorDetail(getRopeHolderOffset(rope)))
     send(serial, "local.velocity-set", setRopeTopVelocity(rope, Vector3(0.001, 0, 0)), vectorDetail(getRopeTopVelocity(rope)))
 
+    -- Deterministic physical pickup path: both holder and cargo are local, so
+    -- the manager can safely hand their GTA physical pointers to CRope.
+    local anchor = createObject(1337, x + 6, y, z + 5)
+    local cargo = createObject(1337, x + 6, y, z + 1)
+    if isElement(anchor) then
+        setElementAlpha(anchor, 0)
+        setElementCollisionsEnabled(anchor, false)
+        setElementFrozen(anchor, true)
+    end
+    if isElement(cargo) then
+        setElementFrozen(cargo, false)
+    end
+
+    local magnet = false
+    if isElement(anchor) and isElement(cargo) then
+        magnet = createRope(x + 6, y, z + 5, {
+            type = "miniMagnet",
+            holder = anchor,
+            holderOffset = {0, 0, 0},
+            duration = 3500,
+            physics = true,
+        })
+    end
+
+    send(serial, "local.physical-elements", isElement(anchor) and isElement(cargo) and isElement(magnet), tostring(magnet))
+    if isElement(magnet) and isElement(cargo) then
+        send(serial, "local.physical-attach", attachElementToRope(magnet, cargo), tostring(getRopeCarriedElement(magnet)))
+    end
+
     setTimer(function()
         if serial ~= activeSerial or not isElement(rope) then return end
         local active = isRopeActive(rope)
@@ -110,6 +141,17 @@ addEventHandler("ropetest:local", resourceRoot, function(serial)
             local position = getRopePositionAt(rope, 0.25)
             send(serial, "local.sample", position ~= false and position ~= nil, vectorDetail(position))
         end
+
+        local magnetActive = isElement(magnet) and isRopeActive(magnet)
+        send(serial, "local.physical-active", magnetActive == true, tostring(magnetActive))
+        if magnetActive then
+            local position = getRopePositionAt(magnet, 0.5)
+            send(serial, "local.physical-sample", position ~= false and position ~= nil, vectorDetail(position))
+        end
+
+        if isElement(magnet) then destroyElement(magnet) end
+        if isElement(cargo) then destroyElement(cargo) end
+        if isElement(anchor) then destroyElement(anchor) end
         destroyElement(rope)
     end, 650, 1)
 end)

--- a/test-resources/rope-test/client.lua
+++ b/test-resources/rope-test/client.lua
@@ -1,0 +1,131 @@
+local activeSerial = 0
+
+local function send(serial, name, ok, detail)
+    triggerServerEvent("ropetest:clientResult", resourceRoot, serial, name, ok == true, tostring(detail or ""))
+end
+
+local function vectorDetail(value)
+    if not value then return "false" end
+    return ("%.3f %.3f %.3f"):format(value.x or 0, value.y or 0, value.z or 0)
+end
+
+addEvent("ropetest:inspect", true)
+addEventHandler("ropetest:inspect", resourceRoot, function(rope, serial)
+    activeSerial = serial
+    local valid = isElement(rope) and getElementType(rope) == "rope"
+    send(serial, "sync.element", valid, valid and "rope element received" or "missing/invalid rope")
+    if not valid then return end
+
+    send(serial, "sync.type", getRopeType(rope) == "swat", getRopeType(rope))
+    local remaining = getRopeRemainingTime(rope)
+    send(serial, "sync.remaining", type(remaining) == "number" and remaining > 2500 and remaining <= 5000, remaining)
+
+    local velocity = getRopeTopVelocity(rope)
+    send(serial, "sync.velocity", velocity and math.abs((velocity.x or 0) - 0.002) < 0.0005, vectorDetail(velocity))
+
+    setTimer(function()
+        if serial ~= activeSerial or not isElement(rope) then return end
+        local active = isRopeActive(rope)
+        send(serial, "native.active", active, tostring(active))
+        if active then
+            local position, speed = getRopePositionAt(rope, 0.5)
+            send(serial, "native.sample-position", position ~= false and position ~= nil, vectorDetail(position))
+            send(serial, "native.sample-speed", speed ~= false and speed ~= nil, vectorDetail(speed))
+        end
+    end, 500, 1)
+end)
+
+addEvent("ropetest:holderInspect", true)
+addEventHandler("ropetest:holderInspect", resourceRoot, function(rope, holder, serial)
+    if serial ~= activeSerial or not isElement(rope) or not isElement(holder) then return end
+
+    local active = isRopeActive(rope)
+    send(serial, "holder.active", active, tostring(active))
+    if not active then return end
+
+    local top = getRopePositionAt(rope, 0.0)
+    local hx, hy, hz = getElementPosition(holder)
+    local dx = top and (top.x - hx) or 999
+    local dy = top and (top.y - hy) or 999
+    local dz = top and (top.z - (hz + 1.5)) or 999
+    local error = math.sqrt(dx * dx + dy * dy + dz * dz)
+    send(serial, "holder.follow", top and error < 1.25, ("error=%.3f top=%s holder=%.3f %.3f %.3f"):format(error, vectorDetail(top), hx, hy, hz))
+end)
+
+addEvent("ropetest:pickupInspect", true)
+addEventHandler("ropetest:pickupInspect", resourceRoot, function(rope, object, vehicle, serial)
+    if serial ~= activeSerial then return end
+    local valid = isElement(rope) and isElement(object) and isElement(vehicle)
+    send(serial, "pickup.elements", valid, tostring(valid))
+    if not valid then return end
+
+    send(serial, "pickup.synced-state", getRopeCarriedElement(rope) == object, tostring(getRopeCarriedElement(rope)))
+    setTimer(function()
+        if serial ~= activeSerial or not isElement(rope) then return end
+        send(serial, "pickup.native-rope-active", isRopeActive(rope), tostring(isRopeActive(rope)))
+    end, 800, 1)
+end)
+
+addEvent("ropetest:leasingInspect", true)
+addEventHandler("ropetest:leasingInspect", resourceRoot, function(ropes, serial)
+    if serial ~= activeSerial then return end
+    local logical = 0
+    local active = 0
+    for _, rope in ipairs(ropes or {}) do
+        if isElement(rope) and getElementType(rope) == "rope" then
+            logical = logical + 1
+            if isRopeActive(rope) then active = active + 1 end
+        end
+    end
+    send(serial, "leasing.logical-client", logical == 12, ("logical=%d"):format(logical))
+    send(serial, "leasing.native-cap", active > 0 and active <= 8, ("active=%d logical=%d"):format(active, logical))
+end)
+
+addEvent("ropetest:local", true)
+addEventHandler("ropetest:local", resourceRoot, function(serial)
+    activeSerial = serial
+    local x, y, z = getElementPosition(localPlayer)
+    local rope = createRope(x + 2, y, z + 4, {
+        type = "swat",
+        duration = 3500,
+        physics = false,
+        fixedNode = 0,
+        topVelocity = {0, 0.001, 0},
+    })
+
+    local valid = isElement(rope) and getElementType(rope) == "rope"
+    send(serial, "local.create", valid, tostring(rope))
+    if not valid then return end
+
+    send(serial, "local.type-set", setRopeType(rope, "swat") and getRopeType(rope) == "swat", getRopeType(rope))
+    send(serial, "local.physics-set", setRopePhysicsEnabled(rope, false) and not isRopePhysicsEnabled(rope), tostring(isRopePhysicsEnabled(rope)))
+    send(serial, "local.offset-set", setRopeHolderOffset(rope, Vector3(0, 0, -0.5)), vectorDetail(getRopeHolderOffset(rope)))
+    send(serial, "local.velocity-set", setRopeTopVelocity(rope, Vector3(0.001, 0, 0)), vectorDetail(getRopeTopVelocity(rope)))
+
+    setTimer(function()
+        if serial ~= activeSerial or not isElement(rope) then return end
+        local active = isRopeActive(rope)
+        send(serial, "local.active", active, tostring(active))
+        if active then
+            local position = getRopePositionAt(rope, 0.25)
+            send(serial, "local.sample", position ~= false and position ~= nil, vectorDetail(position))
+        end
+        destroyElement(rope)
+    end, 650, 1)
+end)
+
+addEvent("ropetest:legacy", true)
+addEventHandler("ropetest:legacy", resourceRoot, function(serial)
+    activeSerial = serial
+    local x, y, z = getElementPosition(localPlayer)
+    local ok = createSWATRope(x - 2, y, z + 4, 1500)
+    send(serial, "legacy.createSWATRope", ok == true, tostring(ok))
+end)
+
+addEventHandler("onClientResourceStart", resourceRoot, function()
+    outputChatBox("[ROPETEST] /ropetest all | basic | holder | pickup | leasing | local | legacy | late | status | reset", 170, 220, 255)
+end)
+
+addEventHandler("onClientResourceStop", resourceRoot, function()
+    activeSerial = activeSerial + 1
+end)

--- a/test-resources/rope-test/meta.xml
+++ b/test-resources/rope-test/meta.xml
@@ -1,0 +1,5 @@
+<meta>
+    <info author="MTA Neon" name="Managed rope test harness" type="script" version="1.0" />
+    <script src="server.lua" type="server" />
+    <script src="client.lua" type="client" cache="false" />
+</meta>

--- a/test-resources/rope-test/server.lua
+++ b/test-resources/rope-test/server.lua
@@ -1,0 +1,255 @@
+local tracked = {}
+local runSerial = 0
+local runPlayer = false
+
+local function emit(message, debugLevel, r, g, b)
+    outputDebugString(message, debugLevel or 3)
+    if isElement(runPlayer) and getElementType(runPlayer) == "player" then
+        outputChatBox(message, runPlayer, r or 255, g or 255, b or 255)
+    end
+end
+
+local function log(kind, name, detail)
+    local suffix = detail and (": " .. tostring(detail)) or ""
+    local message = ("[ROPETEST] %s %s%s"):format(kind, name, suffix)
+    if kind == "FAIL" then
+        emit(message, 1, 255, 80, 80)
+    else
+        emit(message, 3, 100, 255, 100)
+    end
+end
+
+local function pass(name, detail) log("PASS", name, detail) end
+local function fail(name, detail) log("FAIL", name, detail) end
+local function check(name, condition, detail)
+    if condition then pass(name, detail) else fail(name, detail) end
+    return condition
+end
+
+local function track(element)
+    if isElement(element) then tracked[element] = true end
+    return element
+end
+
+local function reset()
+    for element in pairs(tracked) do
+        if isElement(element) then destroyElement(element) end
+    end
+    tracked = {}
+end
+
+local function spawnPosition(player, forward, side)
+    local x, y, z = getElementPosition(player)
+    return x + (forward or 4), y + (side or 0), z + 3
+end
+
+local function countRopes()
+    local count = 0
+    for _, rope in ipairs(getElementsByType("rope")) do
+        if isElement(rope) then count = count + 1 end
+    end
+    return count
+end
+
+local function runBasic(player, serial)
+    local x, y, z = spawnPosition(player, 4)
+    local rope = track(createRope(x, y, z, {
+        type = "swat",
+        duration = 5000,
+        physics = false,
+        fixedNode = 0,
+        sitOnGround = false,
+        winchHeight = 0.5,
+        topVelocity = {0.001, 0, 0},
+    }))
+
+    check("basic.create", isElement(rope), tostring(rope))
+    if not isElement(rope) then return false end
+
+    check("basic.element-type", getElementType(rope) == "rope", getElementType(rope))
+    check("basic.rope-type", getRopeType(rope) == "swat", tostring(getRopeType(rope)))
+    check("basic.duration", math.abs((getRopeDuration(rope) or -1) - 5000) < 1, getRopeDuration(rope))
+    check("basic.remaining", (getRopeRemainingTime(rope) or -1) > 4500, getRopeRemainingTime(rope))
+    check("basic.physics", isRopePhysicsEnabled(rope) == false, tostring(isRopePhysicsEnabled(rope)))
+
+    check("basic.type-set", setRopeType(rope, "swat") and getRopeType(rope) == "swat", getRopeType(rope))
+    check("basic.winch-set", setRopeWinchHeight(rope, 0.65) and math.abs((getRopeWinchHeight(rope) or 0) - 0.65) < 0.01, getRopeWinchHeight(rope))
+    check("basic.fixed-set", setRopeFixedNode(rope, 2) and getRopeFixedNode(rope) == 2, getRopeFixedNode(rope))
+    check("basic.ground-set", setRopeOnGround(rope, true) and isRopeOnGround(rope), tostring(isRopeOnGround(rope)))
+    check("basic.velocity-set", setRopeTopVelocity(rope, Vector3(0.002, 0, 0)), "setter returned true")
+    check("basic.offset-set", setRopeHolderOffset(rope, Vector3(0, 0, -1)), "setter returned true")
+
+    triggerClientEvent(player, "ropetest:inspect", resourceRoot, rope, serial)
+    return true
+end
+
+local function runExpiry(player, serial)
+    local x, y, z = spawnPosition(player, 6)
+    local rope = track(createRope(x, y, z, {type = "swat", duration = 850, physics = false}))
+    check("expiry.created", isElement(rope))
+    setTimer(function()
+        if serial ~= runSerial then return end
+        check("expiry.destroyed", not isElement(rope), isElement(rope) and "still alive" or "expired")
+        tracked[rope] = nil
+    end, 1450, 1)
+end
+
+local function runHolder(player, serial)
+    local x, y, z = spawnPosition(player, 9)
+    local holder = track(createObject(1337, x, y, z - 2))
+    if not isElement(holder) then
+        fail("holder.object", "createObject failed")
+        return
+    end
+    setElementDimension(holder, getElementDimension(player))
+    setElementInterior(holder, getElementInterior(player))
+
+    local rope = track(createRope(x, y, z, {
+        type = "swat",
+        holder = holder,
+        holderOffset = {0, 0, 1.5},
+        duration = 8000,
+        physics = false,
+    }))
+    check("holder.rope", isElement(rope))
+    if not isElement(rope) then return end
+
+    setElementPosition(holder, x + 2, y + 1, z - 2)
+    setTimer(function()
+        if serial ~= runSerial or not isElement(rope) or not isElement(holder) then return end
+        triggerClientEvent(player, "ropetest:holderInspect", resourceRoot, rope, holder, serial)
+    end, 700, 1)
+end
+
+local function runPickupState(player, serial)
+    local x, y, z = spawnPosition(player, 12)
+    local carriedObject = track(createObject(1337, x, y, z - 4))
+    local carrierVehicle = track(createVehicle(411, x + 3, y, z - 4))
+    local rope = track(createRope(x, y, z, {
+        type = "miniMagnet",
+        duration = 10000,
+        physics = true,
+        carriedElement = carriedObject,
+    }))
+
+    check("pickup.object-created", isElement(carriedObject))
+    check("pickup.vehicle-created", isElement(carrierVehicle))
+    check("pickup.rope-created", isElement(rope))
+    if not isElement(rope) or not isElement(carriedObject) then return end
+
+    check("pickup.object-state", getRopeCarriedElement(rope) == carriedObject, tostring(getRopeCarriedElement(rope)))
+    check("pickup.detach", detachElementFromRope(rope) and getRopeCarriedElement(rope) == false, tostring(getRopeCarriedElement(rope)))
+    check("pickup.vehicle-state", isElement(carrierVehicle) and attachElementToRope(rope, carrierVehicle) and getRopeCarriedElement(rope) == carrierVehicle,
+        tostring(getRopeCarriedElement(rope)))
+    check("pickup.vehicle-detach", detachElementFromRope(rope) and getRopeCarriedElement(rope) == false, tostring(getRopeCarriedElement(rope)))
+
+    -- Reattach the object for the client authority/native pickup observation.
+    attachElementToRope(rope, carriedObject)
+    triggerClientEvent(player, "ropetest:pickupInspect", resourceRoot, rope, carriedObject, carrierVehicle, serial)
+end
+
+local function runLeasing(player, serial)
+    local x, y, z = spawnPosition(player, 18)
+    local ropes = {}
+    for i = 1, 12 do
+        local rope = track(createRope(x + (i - 1) * 0.6, y, z, {
+            type = "swat",
+            duration = 7000,
+            physics = false,
+        }))
+        if isElement(rope) then ropes[#ropes + 1] = rope end
+    end
+    check("leasing.logical-count", #ropes == 12, ("created=%d"):format(#ropes))
+    setTimer(function()
+        if serial ~= runSerial then return end
+        triggerClientEvent(player, "ropetest:leasingInspect", resourceRoot, ropes, serial)
+    end, 900, 1)
+end
+
+local function runLocal(player, serial)
+    triggerClientEvent(player, "ropetest:local", resourceRoot, serial)
+end
+
+local function runLegacy(player, serial)
+    triggerClientEvent(player, "ropetest:legacy", resourceRoot, serial)
+end
+
+local function runAll(player)
+    runSerial = runSerial + 1
+    local serial = runSerial
+    reset()
+    runPlayer = player
+    emit(("[ROPETEST] RUN serial=%d player=%s"):format(serial, getPlayerName(player)), 3, 255, 200, 80)
+
+    if not runBasic(player, serial) then
+        fail("run", "basic creation failed; dependent tests skipped")
+        return
+    end
+    runExpiry(player, serial)
+    runHolder(player, serial)
+    runPickupState(player, serial)
+    runLeasing(player, serial)
+    runLocal(player, serial)
+    runLegacy(player, serial)
+
+    setTimer(function()
+        if serial == runSerial then
+            emit(("[ROPETEST] DONE serial=%d -- inspect PASS/FAIL lines above"):format(serial), 3, 255, 200, 80)
+        end
+    end, 4500, 1)
+end
+
+addEvent("ropetest:clientResult", true)
+addEventHandler("ropetest:clientResult", resourceRoot, function(serial, name, ok, detail)
+    if not client or serial ~= runSerial then return end
+    check("client." .. tostring(name), ok == true, detail)
+end)
+
+addCommandHandler("ropetest", function(player, _, caseName)
+    if not isElement(player) or getElementType(player) ~= "player" then return end
+    runPlayer = player
+    caseName = caseName or "all"
+
+    if caseName == "all" then
+        runAll(player)
+    elseif caseName == "basic" then
+        runSerial = runSerial + 1; reset(); runBasic(player, runSerial)
+    elseif caseName == "holder" then
+        runSerial = runSerial + 1; reset(); runHolder(player, runSerial)
+    elseif caseName == "pickup" then
+        runSerial = runSerial + 1; reset(); runPickupState(player, runSerial)
+    elseif caseName == "leasing" then
+        runSerial = runSerial + 1; reset(); runLeasing(player, runSerial)
+    elseif caseName == "local" then
+        runSerial = runSerial + 1; reset(); runLocal(player, runSerial)
+    elseif caseName == "legacy" then
+        runSerial = runSerial + 1; reset(); runLegacy(player, runSerial)
+    elseif caseName == "late" then
+        runSerial = runSerial + 1; reset()
+        local x, y, z = spawnPosition(player, 6)
+        local rope = track(createRope(x, y, z, {type = "swat", duration = 30000, physics = false, winchHeight = 0.75}))
+        if isElement(rope) then
+            pass("late.setup", ("remaining=%.0f"):format(getRopeRemainingTime(rope) or -1))
+            outputChatBox("[ROPETEST] 30s rope active: join a second client and inspect remaining time / visibility.", player, 255, 200, 80)
+        else
+            fail("late.setup", "createRope returned false")
+        end
+    elseif caseName == "status" then
+        outputChatBox(("[ROPETEST] tracked=%d worldRopes=%d serial=%d"):format(
+            (function() local n = 0 for element in pairs(tracked) do if isElement(element) then n = n + 1 end end return n end)(),
+            countRopes(), runSerial), player, 255, 200, 80)
+    elseif caseName == "reset" then
+        runSerial = runSerial + 1; reset(); pass("reset")
+    else
+        outputChatBox("[ROPETEST] cases: all, basic, holder, pickup, leasing, local, legacy, late, status, reset", player, 255, 200, 80)
+    end
+end)
+
+addEventHandler("onPlayerQuit", root, function()
+    if source == runPlayer then runPlayer = false end
+end)
+
+addEventHandler("onResourceStop", resourceRoot, function()
+    reset()
+    runPlayer = false
+end)


### PR DESCRIPTION
## Summary

Adds a managed, synchronized Rope API backed by GTA:SA's native `CRopes`/`CRope` subsystem.

### Native layer
- Corrects the 0x328 rope layout naming and adds critical `offsetof` checks.
- Wraps `RegisterRope`, `FindRope`, `FindCoorsAlongRope`, `SetSpeedOfTopNode`, remove, pickup/release, node inspection, winch height and rope length.
- Keeps `createSWATRope` compatibility intact.
- Disables GTA's autonomous winch pickup for wrapper-created managed ropes so carried entities are explicit/script-owned.
- Safety guard: native winch/crane types 1..7 are never leased unless an authoritative physical holder is available. `CRope::Update` dereferences `m_pRopeHolder`; registering those types with a null holder can crash at the stock GTA rope update path (observed at `0x557CEA`). `swat` remains the free world-anchored native type.
- SWAT ropes are also prevented from entering the native carried-object path because they do not create a hook object.

### Managed runtime
- Adds synchronized server-owned `rope` dummy elements plus client-local ropes.
- Seeds all synchronized state before `EntityAdd` for deterministic late join.
- Supports duration/remaining lifetime, type, holder + local offset, top velocity, fixed node, ground behavior, winch height, optional length override, carried element and physics policy.
- Adds a client `CClientRopeManager` that leases only free entries from GTA's fixed eight-rope pool.
- Allows >8 logical ropes while keeping <=8 native leases.
- Never evicts stock GTA ropes.
- Prioritizes sync-owner ropes carrying physical entities; when necessary these can evict the farthest non-authoritative managed visual lease.
- Physical holder/carried pointers are only handed to GTA on the client currently owning the relevant object/vehicle sync, avoiding transform fights on remote clients.

### Lua API
Server + local-client mutation / synchronized-client inspection:
- `createRope`
- type, duration/remaining, holder/offset, top velocity
- winch height, optional rope length, fixed node, sit-on-ground
- physics enabled state
- `attachElementToRope` / `detachElementFromRope`
- carried element getter

Client native-solver inspection:
- `isRopeActive`
- `getRopePositionAt`

### Test harness
Adds `test-resources/rope-test` with explicit `[ROPETEST] PASS/FAIL` output.

`/ropetest all` covers synchronized lifecycle/state, native activation/interpolation, expiry, holder tracking, object/vehicle carried state, client-local ropes, 12 logical ropes with max 8 native leases, legacy `createSWATRope` coexistence, and the missing-holder crash regression. It now explicitly verifies that an unanchored `miniMagnet` remains logical but never becomes native-active, plus a deterministic local `miniMagnet` pickup with a real local holder.

The original full harness run was reported all-PASS before the missing-holder crash was found; rerun is required after rebuilding this safety fix.

### Cinematic showcase
Adds `test-resources/rope-showcase` (`/ropeshow`). The ~36s visual demo now uses the same clear Las Venturas runway coordinates as `2dfx-showcase` (in its own dimension) and separates the three native types into obvious left/center/right demonstrations with world-space labels and dedicated camera close-ups:
- left: `wreckingBall` with its native weighted ball hook, shortened to stay visibly above the runway and swung by its holder;
- center: `miniMagnet` hoisting/translating a crate, then releasing it in the final wide shot;
- right: `harness` carrying and lifting a local Bobcat vehicle.

All three use invisible client-local physical holders, and the cinematic waits until all three native rope leases are active before fading in. The synchronized multiplayer authority path remains covered by `rope-test`.

## Deliberate scope

This PR does **not** patch GTA's native eight-entry rope pool. The managed layer virtualizes/leases those entries instead. GTA's existing camera-distance solver guard is also left untouched until there is a runtime-verified instruction-site patch; normal streamed/sync-owner rope use remains within the native solver's intended range.